### PR TITLE
Fixed typo in shadowvigil

### DIFF
--- a/dat/missions/shadow/shadowvigil.lua
+++ b/dat/missions/shadow/shadowvigil.lua
@@ -100,7 +100,7 @@ function create()
     misssys = {system.get("Qex"), system.get("Borla"), system.get("Doranthex")} -- Escort meeting point, protegee meeting point, final destination.
     misssys["__save"] = true
     
-    if not misn.claim(missys) then
+    if not misn.claim(misssys) then
         abort()
     end
     


### PR DESCRIPTION
I fixed a typo that was causing a warning on line 103, but it now causes a SIGSEGV. http://pastebin.com/L7xwKJbw I don't know how to fix that.
