### PR TITLE
fix format failure in drunkard mission

### DIFF
--- a/dat/missions/neutral/drunkard.lua
+++ b/dat/missions/neutral/drunkard.lua
@@ -164,7 +164,7 @@ end
 
 function closehail()
    bonus = 0
-   player.pay( numstring(payment) )
+   player.pay( payment )
    tk.msg( title[8], text[8]:format( payment) )
    willie:setVisplayer(false)
    willie:hyperspace()


### PR DESCRIPTION
The drunkard mission fails at my place with
Warning: [misn_runFunc] Mission 'Drunkard' -> 'closehail': [string "dat/missions/neutral/drunkard.lua"]:167: bad argument #1 to 'pay' (number expected, got string)
stack traceback:
    [C]: in function 'pay'
    [string "dat/missions/neutral/drunkard.lua"]:167: in function <[string "dat/missions/neutral/drunkard.lua"]:165>
Warning: [hook_runMisn] Hook [timer] '57' -> 'closehail' failed

With this patch I was able to finish it - is the fix correct?

Signed-off-by: Nicolas Kaiser nikai@nikai.net
