### PR TITLE
Fix two memory leaks

### DIFF
--- a/src/news.c
+++ b/src/news.c
@@ -413,7 +413,7 @@ const news_t *news_generate( int *ngen, int n )
 #endif /* DEBUGGING */
 
    /* Save news found. */
-   news_nbuf   = i;
+   news_nbuf   = n+1;
    if (ngen != NULL)
       (*ngen)  = news_nbuf;
 

--- a/src/space.c
+++ b/src/space.c
@@ -662,10 +662,15 @@ int space_sysReachable( StarSystem *sys )
 int space_sysReallyReachable( char* sysname )
 {
    int njumps;
+   StarSystem** path;
 
-   if (strcmp(sysname,cur_system->name)==0 || map_getJumpPath( &njumps,
-         cur_system->name, sysname, 1, NULL ) != NULL)
+   if (strcmp(sysname,cur_system->name)==0)
       return 1;
+   path = map_getJumpPath( &njumps, cur_system->name, sysname, 1, NULL );
+   if (path != NULL) {
+      free(path);
+      return 1;
+   }
    return 0;
 }
 


### PR DESCRIPTION
Fix two memory leaks, one failing to free a returned array in space.c, one failing to free the last news item line in news.c
