### PR TITLE
Targeting Upgrade

### DIFF
--- a/dat/outfit.xml
+++ b/dat/outfit.xml
@@ -1774,7 +1774,7 @@
  <outfit name="Unicorp Caesar IV Launcher">
   <general>
    <slot>weapon</slot>
-   <size>medium</size>
+   <size>heavy</size>
    <license>Heavy Weapon License</license>
    <mass>30</mass>
    <price>120000</price>
@@ -1821,7 +1821,7 @@
  <outfit name="TeraCom Imperator Launcher">
   <general>
    <slot>weapon</slot>
-   <size>medium</size>
+   <size>heavy</size>
    <license>Heavy Weapon License</license>
    <mass>40</mass>
    <price>220000</price>

--- a/dat/outfit.xml
+++ b/dat/outfit.xml
@@ -2434,7 +2434,6 @@
    <gfx_store>accuracy_turret</gfx_store>
   </general>
   <specific type="modification">
-   <tur_heat>-25</tur_heat>
    <tur_firerate>-10</tur_firerate>
   </specific>
  </outfit>

--- a/src/ai.c
+++ b/src/ai.c
@@ -2178,6 +2178,8 @@ static int aiL_aim( lua_State *L )
                                       p->solid->vel.x-cur_pilot->solid->vel.x, p->solid->vel.y-cur_pilot->solid->vel.y,
                                       speed
                                  );
+   /* On fail maintain current direction */
+   if (angle==1000.) angle=cur_pilot->solid->dir;
 
    /* Calculate what we need to turn */
    mod = 10.;

--- a/src/ai.c
+++ b/src/ai.c
@@ -2181,7 +2181,7 @@ static int aiL_aim( lua_State *L )
 
    /* Calculate what we need to turn */
    mod = 10.;
-   diff = angle_diff(cur_pilot->solid->dir, VANGLE(tv));
+   diff = angle_diff(cur_pilot->solid->dir, angle);
    pilot_turn = mod * diff;
 
    /* Return distance to target (in grad) */

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -621,12 +621,13 @@ double outfit_cpu( const Outfit* o )
  * @brief Gets the outfit's range.
  *    @param o Outfit to get information from.
  */
+//dose not take into account radial speed so is very inaccurate
 double outfit_range( const Outfit* o )
 {
    Outfit *amm;
    if (outfit_isBolt(o)) return o->u.blt.falloff + (o->u.blt.range - o->u.blt.falloff)/2.;
    else if (outfit_isBeam(o)) return o->u.bem.range;
-   else if (outfit_isAmmo(o)) return 0.8*o->u.amm.speed*o->u.amm.duration;
+   else if (outfit_isAmmo(o)) return /*0.8**/o->u.amm.speed*o->u.amm.duration;
    else if (outfit_isLauncher(o)) {
       amm = outfit_ammo(o);
       if (amm != NULL)
@@ -644,6 +645,7 @@ double outfit_range( const Outfit* o )
 double outfit_speed( const Outfit* o )
 {
    if (outfit_isBolt(o)) return o->u.blt.speed;
+   else if (outfit_isLauncher(o) && (o->u.lau.ammo!=0)) return o->u.lau.ammo->u.amm.speed;
    else if (outfit_isAmmo(o)) return o->u.amm.speed;
    return -1.;
 }

--- a/src/physics.c
+++ b/src/physics.c
@@ -301,8 +301,10 @@ static void solid_update_euler (Solid *obj, const double dt)
    
    /*Calc average velocity*/
    double avg_mod = AVERAGE_VELOCITY_MOD*dt;//the avg_mod must never be greater than 1.0
-   //this clamping will cause an inacuracy if the frame rate spikes above AVERAGE_VELOCITY_TIME
-   //this will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems
+   /*
+     This clamping will cause an inaccuracy if the frame length spikes above AVERAGE_VELOCITY_TIME.
+     This will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems.
+   */
    if (avg_mod>1.0) avg_mod=1.0;
    obj->avg_vel.x *= (1.0-avg_mod);
    obj->avg_vel.x += (obj->vel.x*avg_mod);
@@ -420,8 +422,10 @@ static void solid_update_rk4 (Solid *obj, const double dt)
    
    /*Calc average velocity*/
    double avg_mod = AVERAGE_VELOCITY_MOD*dt;//the avg_mod must never be greater than 1.0
-   //this clamping will cause an inacuracy if the frame rate spikes above AVERAGE_VELOCITY_TIME
-   //this will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems
+   /*
+     This clamping will cause an inaccuracy if the frame length spikes above AVERAGE_VELOCITY_TIME.
+     This will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems.
+   */
    if (avg_mod>1.0) avg_mod=1.0;
    obj->avg_vel.x *= (1.0-avg_mod);
    obj->avg_vel.x += (obj->vel.x*avg_mod);

--- a/src/physics.c
+++ b/src/physics.c
@@ -298,19 +298,6 @@ static void solid_update_euler (Solid *obj, const double dt)
    /* Update position and velocity. */
    vect_cset( &obj->vel, vx, vy );
    vect_cset( &obj->pos, px, py );
-   
-   /*Calc average velocity*/
-   double avg_mod = AVERAGE_VELOCITY_MOD*dt;//the avg_mod must never be greater than 1.0
-   /*
-     This clamping will cause an inaccuracy if the frame length spikes above AVERAGE_VELOCITY_TIME.
-     This will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems.
-   */
-   if (avg_mod>1.0) avg_mod=1.0;
-   obj->avg_vel.x *= (1.0-avg_mod);
-   obj->avg_vel.x += (obj->vel.x*avg_mod);
-   obj->avg_vel.y *= (1.0-avg_mod);
-   obj->avg_vel.y += (obj->vel.y*avg_mod);
-   vect_cset(&obj->avg_vel,obj->avg_vel.x,obj->avg_vel.y);
 }
 
 
@@ -419,19 +406,6 @@ static void solid_update_rk4 (Solid *obj, const double dt)
       obj->dir -= 2.*M_PI;
    else if (obj->dir < 0.)
       obj->dir += 2.*M_PI;
-   
-   /*Calc average velocity*/
-   double avg_mod = AVERAGE_VELOCITY_MOD*dt;//the avg_mod must never be greater than 1.0
-   /*
-     This clamping will cause an inaccuracy if the frame length spikes above AVERAGE_VELOCITY_TIME.
-     This will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems.
-   */
-   if (avg_mod>1.0) avg_mod=1.0;
-   obj->avg_vel.x *= (1.0-avg_mod);
-   obj->avg_vel.x += (obj->vel.x*avg_mod);
-   obj->avg_vel.y *= (1.0-avg_mod);
-   obj->avg_vel.y += (obj->vel.y*avg_mod);
-   vect_cset(&obj->avg_vel,obj->avg_vel.x,obj->avg_vel.y);
 }
 
 
@@ -475,12 +449,10 @@ void solid_init( Solid* dest, const double mass, const double dir,
    if (vel == NULL)
    {
       vectnull( &dest->vel );
-      vectnull( &dest->avg_vel );
    }
    else
    {
       vectcpy( &dest->vel, vel );
-      vectcpy( &dest->avg_vel, vel );
    }
 
    /* Set position. */

--- a/src/physics.c
+++ b/src/physics.c
@@ -298,6 +298,17 @@ static void solid_update_euler (Solid *obj, const double dt)
    /* Update position and velocity. */
    vect_cset( &obj->vel, vx, vy );
    vect_cset( &obj->pos, px, py );
+   
+   /*Calc average velocity*/
+   double avg_mod = AVERAGE_VELOCITY_MOD*dt;//the avg_mod must never be greater than 1.0
+   //this clamping will cause an inacuracy if the frame rate spikes above AVERAGE_VELOCITY_TIME
+   //this will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems
+   if (avg_mod>1.0) avg_mod=1.0;
+   obj->avg_vel.x *= (1.0-avg_mod);
+   obj->avg_vel.x += (obj->vel.x*avg_mod);
+   obj->avg_vel.y *= (1.0-avg_mod);
+   obj->avg_vel.y += (obj->vel.y*avg_mod);
+   vect_cset(&obj->avg_vel,obj->avg_vel.x,obj->avg_vel.y);
 }
 
 
@@ -406,6 +417,17 @@ static void solid_update_rk4 (Solid *obj, const double dt)
       obj->dir -= 2.*M_PI;
    else if (obj->dir < 0.)
       obj->dir += 2.*M_PI;
+   
+   /*Calc average velocity*/
+   double avg_mod = AVERAGE_VELOCITY_MOD*dt;//the avg_mod must never be greater than 1.0
+   //this clamping will cause an inacuracy if the frame rate spikes above AVERAGE_VELOCITY_TIME
+   //this will only cause lag of AVERAGE_VELOCITY_TIME as where not clamping could cause huge problems
+   if (avg_mod>1.0) avg_mod=1.0;
+   obj->avg_vel.x *= (1.0-avg_mod);
+   obj->avg_vel.x += (obj->vel.x*avg_mod);
+   obj->avg_vel.y *= (1.0-avg_mod);
+   obj->avg_vel.y += (obj->vel.y*avg_mod);
+   vect_cset(&obj->avg_vel,obj->avg_vel.x,obj->avg_vel.y);
 }
 
 
@@ -447,9 +469,15 @@ void solid_init( Solid* dest, const double mass, const double dir,
 
    /* Set velocity. */
    if (vel == NULL)
+   {
       vectnull( &dest->vel );
+      vectnull( &dest->avg_vel );
+   }
    else
+   {
       vectcpy( &dest->vel, vel );
+      vectcpy( &dest->avg_vel, vel );
+   }
 
    /* Set position. */
    if (pos == NULL)

--- a/src/physics.h
+++ b/src/physics.h
@@ -68,15 +68,11 @@ void vect_uv_decomp(Vector2d* u, Vector2d* v, Vector2d* reference);
 /**
  * @brief Represents a solid in the game.
  */
-/* /I would prefer these to be static members of Solid and set in .c but im moor c++ than c and arnt sure if/how you would do it */
-#define AVERAGE_VELOCITY_MOD 8.0
-#define AVERAGE_VELOCITY_TIME 0.12
 typedef struct Solid_ {
    double mass; /**< Solid's mass. */
    double dir; /**< Direction solid is facing in rad. */
    double dir_vel; /**< Velocity at which solid is rotating in rad/s. */
    Vector2d vel; /**< Velocity of the solid. */
-   Vector2d avg_vel;/**< Uses AVERAGE_VELOCITY_MOD to compute an the average velocity at AVERAGE_VELOCITY_TIME seconds ago. Computed in update function*/
    Vector2d pos; /**< Position of the solid. */
    double thrust; /**< Relative X force, basically simplified for our thrust model. */
    double speed_max; /**< Maximum speed. */

--- a/src/physics.h
+++ b/src/physics.h
@@ -68,15 +68,15 @@ void vect_uv_decomp(Vector2d* u, Vector2d* v, Vector2d* reference);
 /**
  * @brief Represents a solid in the game.
  */
- //I would prefer thease to be static members of Solid and set in .c but im moor c++ than c and arnt sure if/how you would do it
+/* /I would prefer these to be static members of Solid and set in .c but im moor c++ than c and arnt sure if/how you would do it */
 #define AVERAGE_VELOCITY_MOD 8.0
-#define AVERAGE_VELOCITY_TIME 1.12
+#define AVERAGE_VELOCITY_TIME 0.12
 typedef struct Solid_ {
    double mass; /**< Solid's mass. */
    double dir; /**< Direction solid is facing in rad. */
    double dir_vel; /**< Velocity at which solid is rotating in rad/s. */
    Vector2d vel; /**< Velocity of the solid. */
-   Vector2d avg_vel;//*< Uses AVERAGE_VELOCITY_MOD to compute an the average velocity at AVERAGE_VELOCITY_TIME seconds ago. Computed in update function
+   Vector2d avg_vel;/**< Uses AVERAGE_VELOCITY_MOD to compute an the average velocity at AVERAGE_VELOCITY_TIME seconds ago. Computed in update function*/
    Vector2d pos; /**< Position of the solid. */
    double thrust; /**< Relative X force, basically simplified for our thrust model. */
    double speed_max; /**< Maximum speed. */

--- a/src/physics.h
+++ b/src/physics.h
@@ -68,11 +68,15 @@ void vect_uv_decomp(Vector2d* u, Vector2d* v, Vector2d* reference);
 /**
  * @brief Represents a solid in the game.
  */
+ //I would prefer thease to be static members of Solid and set in .c but im moor c++ than c and arnt sure if/how you would do it
+#define AVERAGE_VELOCITY_MOD 8.0
+#define AVERAGE_VELOCITY_TIME 1.12
 typedef struct Solid_ {
    double mass; /**< Solid's mass. */
    double dir; /**< Direction solid is facing in rad. */
    double dir_vel; /**< Velocity at which solid is rotating in rad/s. */
    Vector2d vel; /**< Velocity of the solid. */
+   Vector2d avg_vel;//*< Uses AVERAGE_VELOCITY_MOD to compute an the average velocity at AVERAGE_VELOCITY_TIME seconds ago. Computed in update function
    Vector2d pos; /**< Position of the solid. */
    double thrust; /**< Relative X force, basically simplified for our thrust model. */
    double speed_max; /**< Maximum speed. */

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -973,7 +973,7 @@ static int pilot_shootWeapon( Pilot* p, PilotOutfitSlot* w )
       energy      = outfit_energy(w->u.ammo.outfit)*energy_mod;
       p->energy  -= energy;
       pilot_heatAddSlot( p, w );
-      weapon_add( w->u.ammo.outfit, w->heat_T, p->solid->dir,
+      weapon_add( w->outfit, w->heat_T, p->solid->dir,
             &vp, &p->solid->vel, p, p->target );
 
       w->u.ammo.quantity -= 1; /* we just shot it */

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1318,16 +1318,23 @@ static void weapon_createAmmo( Weapon *w, const Outfit* outfit, double T,
    double mass, rdir;
    Pilot *pilot_target;
    glTexture *gfx;
+   /* Dont use shooter velocity to aim lunchers as drag will limit ammo speed */
+   Vector2d aim_vel;
+   aim_vel.x=0.;
+   aim_vel.y=0.;
+   aim_vel.mod=0.;
+   aim_vel.angle=0.;
+   
 
    pilot_target = NULL;
-   if (w->outfit->type == OUTFIT_TYPE_TURRET_AMMO) {
+   if (outfit_isTurret(outfit)) {
       pilot_target = pilot_get(w->target);
-      rdir = weapon_aimTurret( w, outfit, parent, pilot_target, pos, vel, dir, M_PI );
+      rdir = weapon_aimTurret( w, outfit, parent, pilot_target, pos, &aim_vel, dir, M_PI );
    }
    else {
       if (outfit->u.lau.arc>0.0) {
         pilot_target = pilot_get(w->target);
-        rdir = weapon_aimTurret( w, outfit, parent, pilot_target, pos, vel, dir, outfit->u.lau.arc );
+        rdir = weapon_aimTurret( w, outfit, parent, pilot_target, pos, &aim_vel, dir, outfit->u.lau.arc );
       }
       else
          rdir        = dir;

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -146,10 +146,6 @@ void weapon_minimap( const double res, const double w,
 static void weapon_setThrust( Weapon *w, double thrust );
 static void weapon_setTurn( Weapon *w, double turn );
 
-// math
-static void RotateToNormal ( double* x_, double* y_, double nx_,double ny_ );
-
-
 /**
  * @brief Draws the minimap weapons (used in player.c).
  *
@@ -334,40 +330,44 @@ static void think_seeker( Weapon* w, const double dt )
       case WEAPON_STATUS_UNJAMMED: /* Work as expected */
 
          /* Smart seekers take into account ship velocity. */
-         if (w->outfit->u.amm.ai == 2)
-         {
-            //this gives the the desired direction of travel but not the angle to achieve it
+         if (w->outfit->u.amm.ai == 2) {
+            /* This gives the the desired direction of travel but not the angle to achieve it */
             a=LinearTrajectoryAngle(
                                        w->solid->pos.x-p->solid->pos.x, w->solid->pos.y-p->solid->pos.y,
                                        p->solid->vel.x/*-w->solid->vel.x*/, p->solid->vel.y/*-w->solid->vel.y*/,//dont remove weapons current velocity as thats what were trying to calc
                                        w->outfit->u.amm.speed
                                     );
-            if (a==1000.0)
-            {
-               //fallback on stupid tracking if LinearTrajectoryAngle Fails
-               //even if the targets out running us we should still
-               //track it as it may change direction
+            if (a==1000.0) {
+               /*
+                  Fallback on stupid tracking if LinearTrajectoryAngle Fails.
+                  Even if the targets out running us we should still
+                  track it as it may change direction.
+               */
                diff = angle_diff(w->solid->dir, /* Get angle to target pos */
                                  vect_angle(&w->solid->pos, &p->solid->pos));
             }
-            else
-            {
+            else {
                diff = angle_diff(w->solid->dir, a );
             }
+            /*
+              If we double the diff we should cancel out our current velocity faster.
+              The quickest way to do this would be to aim 90 degrease from our velocity's angle
+              but that would lead to over turning (zig zagging) so this is probably better
+              This should make even the worst version of smart better than stupid seekers
+            */
             diff*=2.0;
-            //If we double the diff we should cancel out our current velocity faster.
-            //The quickest way to do this would be to aim 90 degrease from our velocity's angle
-            //but that would lead to over turning (zig zagging) so this is probably better
-            //This should make even the worst version of smart better than stupid seekers
          }
          /* Other seekers are stupid. */
-         else
-         {
+         else {
             diff = angle_diff(w->solid->dir, /* Get angle to target pos */
                               vect_angle(&w->solid->pos, &p->solid->pos));
          }
 
-         /* Set turn. */
+         /*
+            Set turn.
+            Even a slow turning smart seeker can kill a target if it knows
+            where that target will be in the future ! 
+         */
          turn_max = w->outfit->u.amm.turn * (1. - w->jam_power);
          weapon_setTurn( w, CLAMP( -turn_max, turn_max,
                   10 * diff * w->outfit->u.amm.turn ));
@@ -382,7 +382,12 @@ static void think_seeker( Weapon* w, const double dt )
          break;
    }
 
-   /* Limit speed here */
+   /*
+      Limit speed here 
+      Should this not be done in solid Update ?
+      The drag factor added hear puts a big downer on firing from fast ships !
+      w->solid->speed_max should be set hear to apply jam_power
+   */
    vel  = MIN(w->outfit->u.amm.speed, VMOD(w->solid->vel) + w->outfit->u.amm.thrust*dt);
    vel *= (1. - w->jam_power);
    vect_pset( &w->solid->vel, vel, w->solid->dir );
@@ -1319,10 +1324,8 @@ static void weapon_createAmmo( Weapon *w, const Outfit* outfit, double T,
       pilot_target = pilot_get(w->target);
       rdir = weapon_aimTurret( w, outfit, parent, pilot_target, pos, vel, dir, M_PI );
    }
-   else
-   {
-      if (outfit->u.lau.arc>0.0)
-      {
+   else {
+      if (outfit->u.lau.arc>0.0) {
         pilot_target = pilot_get(w->target);
         rdir = weapon_aimTurret( w, outfit, parent, pilot_target, pos, vel, dir, outfit->u.lau.arc );
       }
@@ -1853,142 +1856,177 @@ static void weapon_explodeLayer( WeaponLayer layer,
    }
 }
 
-//this is just a hacked up matrix
-//there should be at least some 3X3 matrix utility in physics which is where this should be
-//if normal has a distence > 1 then scaling will take effect
-static void RotateToNormal ( double* x_, double* y_, double nx_,double ny_ )
+/**
+ * @brief rotates a point so that its x travles along the line provided by a normal
+ * 
+ * this is just a hacked up matrix
+ * there should be at least some 3X3 matrix utility in physics which is where this should be
+ * if normal has a distance > 1 then scaling will take effect
+ * 
+ * :( i now wish to use this outside weapon.c so its gone public  
+ */ 
+void RotateToNormal ( double* x_, double* y_, double nx_,double ny_ )
 {
-	double x = (  nx_ * *x_) + (ny_* *y_);
-	double y = ((-ny_)* *x_) + (nx_* *y_);
-  *x_ = x;
-	*y_ = y;
+   /* store the x until we are done with the orignal */
+   double x = (  nx_ * *x_) + (ny_* *y_);
+   *y_      = ((-ny_)* *x_) + (nx_* *y_);
+   *x_ = x;
 }
 
-//LinearTrajectoryAngle
-//
-// x_,y_ is the position relative to the source (source - target)
-// vx_,vy_ is the velocity relative to the target (target - source)
-// speed_ is the speed of the projectile you want the angle for
-//
-//returns 1000.0 on fail (pos has no distance, speed_<=0 or target outruns projectile).
-//as good as any other. good results should range from -PI to +PI
+/**
+ * 
+ * @brief Attemps to calculate the angle needed to hit a target using a linear trajectorys
+ * 
+ *    @param  x_,y_  is the position relative to the source (source - target)
+ *    @param  vx_,vy_  is the velocity relative to the target (target - source)
+ *    @param speed_   is the speed of the projectile you want the angle for
+ *    
+ *    @return valid range from -PI to +PI or 1000. on fail
+ *    May fial if position's distance <= 0, speed_ <= 0 or if target outruns the projectile
+ */ 
 double LinearTrajectoryAngle ( double x_,double y_, double vx_,double vy_, double speed_ )
 {
-  if (speed_<=0.0) return 1000.0;
-  
-  // vars needed for targeting calculation
-  double dis = sqrt((x_*x_) + (y_*y_));
-  if (dis<=0.0) return 1000.0;//ships in same position. cant miss. avoid throw from division by 0
-  
-  //Calc Normal
-  double nx = x_/dis;
-  double ny = y_/dis;
-  
-  //Rotate the velocity into relative_space making x=radial_speed and y=perpendicular_speed
-  RotateToNormal( &vx_,&vy_, nx,ny );
-  
-  //compute new value for vx to find projectiles velocity vector.
-  //We dont care about knowing collision time or position all we need is a vector to that point
-  //squaring numbers will force positive values and calculate + radial_speed thus finding the
-  //nearest collision point. A negative value for vx could result in a 2nd point at a later time (:~ i think).
-  double new_radial = sqrt( (speed_*speed_) - (vy_*vy_) );
-  
-  //if the perpendicular_speed is greater then the projectile speed a collision is not posable
-  if (fabs(vy_)>speed_) return 1000.0;
-  //if they are = then it depends on the relative radial to do all the work.
-  //The relative radial should be checked against new_radial.
-  //If the relative is negative after adding the new_radial then they still wont collide
-  if ((vx_+new_radial)<=0.0) return 1000.0;
-  
-  //Rotate new velocity back to game_space using the reverse normal
-  RotateToNormal( &new_radial,&vy_, -nx,-ny );
-  
-  //Return the angle of the velocity
-  return ANGLE(new_radial, -vy_);//not sure whats up with the negative y value
+   if (speed_<=0.0) return 1000.0;
+   
+   /* vars needed for targeting calculation*/
+   double dis = sqrt((x_*x_) + (y_*y_));
+   if (dis<=0.0) return 1000.0; /* ships in same position. cant miss. avoid throw from division by 0 */
+   
+   /* Calc Normal */
+   double nx = x_/dis;
+   double ny = y_/dis;
+   
+   /* Rotate the velocity into relative_space making x=radial_speed and y=perpendicular_speed */
+   RotateToNormal( &vx_,&vy_, nx,ny );
+   
+   /*
+     Compute the new value for vx to find projectiles velocity vector.
+     We dont care about knowing collision time or position. All we need is a vector to that point.
+     Squaring numbers will force positive values and thus calculate a + radial_speed finding the
+     nearest collision point. A negative value for vx could result in a 2nd point at a later time.
+     This 2nd point has a lot less chance than the 1st point as it needs the targets radial to
+     still be > 0 after removing the projectiles radial. 2 points gives a chance of TimeOnTarget.
+   */
+   double new_radial = sqrt( (speed_*speed_) - (vy_*vy_) );
+   
+   /* If the perpendicular_speed is greater then the projectiles speed a collision is not posable */
+   if (fabs(vy_)>speed_) return 1000.0;
+   
+   /*
+     If they are = then it depends on the relative radial to do all the work.
+     The relative radial should be checked against new_radial.
+     If the relative is negative after adding the new_radial then they still wont collide
+   */
+   if ((vx_+new_radial)<=0.0) return 1000.0;
+   
+   /* Rotate new velocity back to game_space using the reverse normal */
+   RotateToNormal( &new_radial,&vy_, -nx,-ny );
+   
+   /* Return the angle of the velocity */
+   return ANGLE(new_radial, -vy_);/* not sure whats up with the negative y value */
 }
 
-//AngularTrajectoryAngle
-//
-// calculates the angle that a projectile of speed fired from source at target must take
-// Uses angular tracking to attempt orbital path prediction
-//
-// Reverts to LinearTrajectoryAngle in cases of straight lines
-//
-// returns 1000.0 on fail
+/**
+ *
+ * @brief Calculates the angle that a projectile should take using angular trajectory
+ *
+ *   @param position of the source
+ *   @param velocity of the source
+ *   @param the target solid (uses pos,vel,avg_vel)
+ *   
+ *   @return valid range from -PI to +PI or 1000. on fail
+ *   Will revert to LinearTrajectoryAngle on very small angles
+ *   Can also fail if the target turns more than a half circle in the time it takes for the projectile to reach it
+ */
 double AngularTrajectoryAngle ( const Vector2d* pos_, const Vector2d* vel_, const Solid* target_, double speed_ )
 {
    Vector2d velocity_normal,circle_normal,circle_center,t_circle_normal;
    
-   
-   //velocity_normal is the normal of the difference between the targets 2 velocity so can describe a circle
+   /* velocity_normal is the normal of the difference between the targets 2 velocity's so can describe a circle */
    vect_pset(
                &velocity_normal, 1.,
                angle_diff(target_->avg_vel.angle,target_->vel.angle) / AVERAGE_VELOCITY_TIME
             );
    
-   if (fabs(velocity_normal.angle)<=0.0174532925199433)//0.0174532925199433=1 degrees  0.0872664625997165=5 and 0.1745329251994329=10
-   //division by 0 prevention. an angle of 0 results in a straight line
-   {
+   /*
+      Division by 0 prevention. an angle of 0 results in a straight line.
+      Should use a cutoff angle
+      0.0174532925199433=1 degrees  0.0872664625997165=5 and 0.1745329251994329=10
+   */
+   if (fabs(velocity_normal.angle)<=0.0174532925199433) {
       return LinearTrajectoryAngle(
                VX(*pos_)-VX(target_->pos), VY(*pos_)-VY(target_->pos),
                VX(target_->vel)-VX(*vel_), VY(target_->vel)-VY(*vel_),
                speed_
                                     );
    }
-   else
-   {
+   else {
       const int loops = 15;
       int l;
       double ang_1,ang_2,ang_3;//angles
       double revolution_time,circle_radius;
-      double time,distence;
+      double time,distance;
       double x,y;
       
       revolution_time = fabs((M_PI*2.0)/velocity_normal.angle);
-      //targets speed * time_to_compleat_circle = circle_length then convert to radius
+      /* targets speed * time_to_compleat_circle = circle_length then convert to radius */
       circle_radius = (target_->vel.mod*revolution_time) / (M_PI*2.);
       
-      //Calc the normal from the circle center to the targets pos
-      //The circle_normal.angle is the angle at time=0 (start_angle)
-      //NOTE: + angles are anticlockwise ! Why ??? My poor poor brain
-      if (velocity_normal.angle>0.)//turn the opposit way to velocity_normal to point out from center
+      /*
+         Calc the normal from the circle center to the targets position
+         The circle_normal.angle is the angle at time=0 (start_angle)
+         NOTE: + angles are anticlockwise ! Why ??? My poor poor brain
+      */
+      if (velocity_normal.angle>0.) /* turn the opposit way to velocity_normal to point out from center */
          circle_normal.angle = (target_->vel.angle-(M_PI*0.5));
       else
          circle_normal.angle = (target_->vel.angle+(M_PI*0.5));
       vect_pset(&circle_normal,1.,circle_normal.angle);
       
-      //calc the circles center
+      /* Calculate the circles center.
+         Do we need a vect_set hear ? or is it just a waste of an atan2 and sqrt*/
       vect_cset (
-                  &circle_center,//circle_normal is from circle_center so must be - from position
+                  &circle_center,/* circle_normal is from circle_center so must be removed from the target */
                   target_->pos.x - (circle_normal.x*circle_radius),
                   target_->pos.y - (circle_normal.y*circle_radius)
                 );
       
-      ang_1=circle_normal.angle;//start angle is at a time 0 and thus a certain undershoot
-      ang_2=ang_1-(M_PI*1.);// a guess at an overshoot. if its not 1/2 a circle would probably be a miss anyway
+      /* The start angle is at a time 0 and thus a certain undershoot */
+      ang_1=circle_normal.angle;
+      /*
+         A guess at an overshoot.
+         If its not 1/2 a circle would probably be a miss anyway
+         Should do a check to see if its an overshoot and return an error before the loop.
+      */
+      ang_2=ang_1-(M_PI*1.);
       if (velocity_normal.angle>0.) ang_2 = ang_1+(M_PI*1.);
       
-      for ( l=0; l<loops; l++)
-      {
-         //find the half way position
+      for ( l=0; l<loops; l++) {
+         /* Find the half way position */
          ang_3 =(ang_1+ang_2)/2.;
          time = fabs((ang_3-circle_normal.angle)/velocity_normal.angle);
          vect_pset(&t_circle_normal,1,ang_3);
          
-         //find the relative position at a given time
+         /* Find the relative position at the given time */
          x = (circle_center.x+(t_circle_normal.x*circle_radius)) - (pos_->x+(vel_->x*time));
          y = (circle_center.y+(t_circle_normal.y*circle_radius)) - (pos_->y+(vel_->y*time));
          
-         //The distance of the relative position - (projectile_speed*time) will give
-         // the smallest posable distance to target
-         // values < 0 indicate overshoot > 0 undershoot and 0 == a dead hit. hugh dead, get it ?
-         distence = sqrt((x*x)+(y*y)) - (speed_*time);
-         if (distence>0.0) ang_1=ang_3; else ang_2=ang_3;
-         if (distence==0.0) l=loops;
+         /*
+            The distance of the relative position - (projectile_speed*time) will
+            give the smallest posable distance to target.
+            Negative values indicate an overshoot. Positive an undershoot and
+            0 == a dead hit. hugh dead, get it ?
+         */
+         distance = sqrt((x*x)+(y*y)) - (speed_*time);
+         if (distance>0.0) ang_1=ang_3; else ang_2=ang_3;
+         if (distance==0.0) l=loops;
       }
-      //do accuracy check as a can we hit guide
-      //25 seams like a long way out :? whats the size of the biggest ship ?
-      if (fabs(distence)>25.0) return 1000.;
+      /*
+         do accuracy check as a can we hit guide
+         25 seams like a long way out :? whats the size of the biggest ship ?
+         This should be replaced with an overshoot check of ang_2 pre loop
+      */
+      if (fabs(distance)>25.0) return 1000.;
       
       return ANGLE(x,y);
    }

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1162,9 +1162,12 @@ static double weapon_aimTurret( Weapon *w, const Outfit *outfit, const Pilot *pa
       int a;
       for (a=0; a<parent->outfit_nstructure; a++)
       {
-         if ( outfit_compareTech(parent->outfit_structure[a].outfit, outfit_get("Targeting Array")) )
+         if (parent->outfit_structure[a].outfit!=0)
          {
-            has_targeting_upgrade=1;
+            if ( strcmp (parent->outfit_structure[a].outfit->name,"Targeting Array" ) == 0 )
+            {
+               has_targeting_upgrade=1;
+            }
          }
       }
    }
@@ -1943,16 +1946,16 @@ double AngularTrajectoryAngle ( const Vector2d* pos_, const Vector2d* vel_, cons
       
       revolution_time = fabs((M_PI*2.0)/velocity_normal.angle);
       //targets speed * time_to_compleat_circle = circle_length then convert to radius
-      circle_radius = (target_->vel.mod*revolution_time) / (M_PI*2.0d);
+      circle_radius = (target_->vel.mod*revolution_time) / (M_PI*2.);
       
       //Calc the normal from the circle center to the targets pos
       //The circle_normal.angle is the angle at time=0 (start_angle)
       //NOTE: + angles are anticlockwise ! Why ??? My poor poor brain
-      if (velocity_normal.angle>0.0)//turn the opposit way to velocity_normal to point out from center
+      if (velocity_normal.angle>0.)//turn the opposit way to velocity_normal to point out from center
          circle_normal.angle = (target_->vel.angle-(M_PI*0.5));
       else
          circle_normal.angle = (target_->vel.angle+(M_PI*0.5));
-      vect_pset(&circle_normal,1.0,circle_normal.angle);
+      vect_pset(&circle_normal,1.,circle_normal.angle);
       
       //calc the circles center
       vect_cset (
@@ -1963,12 +1966,12 @@ double AngularTrajectoryAngle ( const Vector2d* pos_, const Vector2d* vel_, cons
       
       ang_1=circle_normal.angle;//start angle is at a time 0 and thus a certain undershoot
       ang_2=ang_1-(M_PI*1.);// a guess at an overshoot. if its not 1/2 a circle would probably be a miss anyway
-      if (velocity_normal.angle>0.0d) ang_2 = ang_1+(M_PI*1.);
+      if (velocity_normal.angle>0.) ang_2 = ang_1+(M_PI*1.);
       
       for ( l=0; l<loops; l++)
       {
          //find the half way position
-         ang_3 =(ang_1+ang_2)/2.0;
+         ang_3 =(ang_1+ang_2)/2.;
          time = fabs((ang_3-circle_normal.angle)/velocity_normal.angle);
          vect_pset(&t_circle_normal,1,ang_3);
          

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1160,9 +1160,9 @@ static double weapon_aimTurret( Weapon *w, const Outfit *outfit, const Pilot *pa
    //scan outfits for targeting upgrade
    {
       int a;
-      for (a=0; a<parent->outfit_nutility; a++)
+      for (a=0; a<parent->outfit_nstructure; a++)
       {
-         if ( outfit_compareTech(parent->outfit_utility[a].outfit, outfit_get("Targeting Array")) )
+         if ( outfit_compareTech(parent->outfit_structure[a].outfit, outfit_get("Targeting Array")) )
          {
             has_targeting_upgrade=1;
          }

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -70,9 +70,10 @@ void weapon_exit (void);
 // returns -PI to +PI or 1000. on fail
 double LinearTrajectoryAngle ( double x_,double y_, double vx_,double vy_, double speed_ );
 //AngularTrajectoryAngle
-//uses the velocity diffrence in the targets solid to calc a circular path and return a collision angle for it at speed
-//Probably should be static but may be wanted by the AI for aimming
-double AngularTrajectoryAngle ( Solid* source_, Solid* target_, double speed_ );
+//uses the velocity difference in the targets solid to calc a circular path and return a collision angle for it at the given speed
+//Probably should be static but may be wanted by the AI for aiming
+//could still be improved a lot
+double AngularTrajectoryAngle ( const Vector2d* pos_, const Vector2d* vel_, const Solid* target_, double speed_ );
 
 #endif /* WEAPON_H */
 

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -60,19 +60,11 @@ void weapons_render( const WeaponLayer layer, const double dt );
 void weapon_clear (void);
 void weapon_exit (void);
 
-// Targeting
-
-// LinearTrajectoryAngle finds the angle to hit a target using a relative position, velocity and projectile speed_
-//
-// x,y = relative position (source-target)
-// vx,vy = relative velocity (target-source)
-// speed_ to find angle for
-// returns -PI to +PI or 1000. on fail
+/*
+ * Targeting
+ */
+void RotateToNormal ( double* x_, double* y_, double nx_,double ny_ );
 double LinearTrajectoryAngle ( double x_,double y_, double vx_,double vy_, double speed_ );
-//AngularTrajectoryAngle
-//uses the velocity difference in the targets solid to calc a circular path and return a collision angle for it at the given speed
-//Probably should be static but may be wanted by the AI for aiming
-//could still be improved a lot
 double AngularTrajectoryAngle ( const Vector2d* pos_, const Vector2d* vel_, const Solid* target_, double speed_ );
 
 #endif /* WEAPON_H */

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -65,7 +65,6 @@ void weapon_exit (void);
  */
 void RotateToNormal ( double* x_, double* y_, double nx_,double ny_ );
 double LinearTrajectoryAngle ( double x_,double y_, double vx_,double vy_, double speed_ );
-double AngularTrajectoryAngle ( const Vector2d* pos_, const Vector2d* vel_, const Solid* target_, double speed_ );
 
 #endif /* WEAPON_H */
 

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -60,6 +60,12 @@ void weapons_render( const WeaponLayer layer, const double dt );
 void weapon_clear (void);
 void weapon_exit (void);
 
+// Targeting
+// x,y = relative position (source-target)
+// vx,vy = relative velocity (target-source)
+// speed_ to find angle for
+// valid returns -PI to +PI 1000.
+double LinearTrajectoryAngle ( double x_,double y_, double vx_,double vy_, double speed_ );
 
 #endif /* WEAPON_H */
 

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -61,11 +61,18 @@ void weapon_clear (void);
 void weapon_exit (void);
 
 // Targeting
+
+// LinearTrajectoryAngle finds the angle to hit a target using a relative position, velocity and projectile speed_
+//
 // x,y = relative position (source-target)
 // vx,vy = relative velocity (target-source)
 // speed_ to find angle for
-// valid returns -PI to +PI 1000.
+// returns -PI to +PI or 1000. on fail
 double LinearTrajectoryAngle ( double x_,double y_, double vx_,double vy_, double speed_ );
+//AngularTrajectoryAngle
+//uses the velocity diffrence in the targets solid to calc a circular path and return a collision angle for it at speed
+//Probably should be static but may be wanted by the AI for aimming
+double AngularTrajectoryAngle ( Solid* source_, Solid* target_, double speed_ );
 
 #endif /* WEAPON_H */
 


### PR DESCRIPTION
Defines an accurate linear targeting function and then implements it in multiple places.
aim_turret,seeker_think& ai_aim
If it ever needs updating again it will save lots of effort tracking down the code locations.
The function can also be used to find ship to ship intercept angles but for the moment is only used with weapons.

Fixed loads of launcher related problems.
The turret_ammo type is now pointless as all checks are done on the spawning outfit.
launchers could use a swivel setting but for the moment i use arc.
I done this due to none lockon rockets needing some help in there aiming.

Implemented an angular targeting system and linked it to the targeting array upgrade.
Although this is far from perfect it dose provide a starting place to increase from.
Iv got thoughts on a nerb tracking that would make this look poo.
