### PR TITLE
Add "Play All" option to tutorial menu.

### DIFF
--- a/dat/events/tutorial/tutorial-aoutfits.lua
+++ b/dat/events/tutorial/tutorial-aoutfits.lua
@@ -81,6 +81,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: Disabling")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-basic.lua
+++ b/dat/events/tutorial/tutorial-basic.lua
@@ -146,6 +146,7 @@ end
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
     naev.keyEnableAll()
+    var.push("tut_next", "Tutorial: Exploration and Discovery")
     naev.eventStart("Tutorial")
     evt.finish(true)
 end

--- a/dat/events/tutorial/tutorial-combat1.lua
+++ b/dat/events/tutorial/tutorial-combat1.lua
@@ -268,6 +268,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: Missile Combat")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-combat2.lua
+++ b/dat/events/tutorial/tutorial-combat2.lua
@@ -210,6 +210,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("var_next", "Tutorial: Heat")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-comms.lua
+++ b/dat/events/tutorial/tutorial-comms.lua
@@ -86,6 +86,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: Basic Combat")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-disabling.lua
+++ b/dat/events/tutorial/tutorial-disabling.lua
@@ -130,6 +130,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: The Planetary Screen")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-discovery.lua
+++ b/dat/events/tutorial/tutorial-discovery.lua
@@ -94,6 +94,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: Interstellar Flight")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-heat.lua
+++ b/dat/events/tutorial/tutorial-heat.lua
@@ -139,6 +139,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: Activated Outfits")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-interstellar.lua
+++ b/dat/events/tutorial/tutorial-interstellar.lua
@@ -108,6 +108,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     if not (omsg == nil) then player.omsgRm(omsg) end
+    var.push("tut_next", "Tutorial: Comms") 
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial-planet.lua
+++ b/dat/events/tutorial/tutorial-planet.lua
@@ -113,6 +113,7 @@ end
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
     naev.keyEnableAll()
+    var.push("tut_next", "Tutorial: Missions and Events")
     naev.eventStart("Tutorial")
     evt.finish(true)
 end

--- a/dat/events/tutorial/tutorial-template.lua
+++ b/dat/events/tutorial/tutorial-template.lua
@@ -1,6 +1,6 @@
 -- Template for tutorial modules.
 -- Each module should start by setting up the tutorial environment and enforcing rules.
--- Each module should clean up and return to the main tutorial menu when ending or aborting.
+-- Each module should clean up, set mission variable "var_next" to next tutorial in sequence, and return to the main tutorial menu when ending or aborting.
 
 include("dat/events/tutorial/tutorial-common.lua")
 
@@ -20,6 +20,7 @@ end
 
 -- Cleanup function. Should be the exit point for the module in all cases.
 function cleanup()
+    var.push("tut_next", "Next Tutorial")
     naev.keyEnableAll()
     naev.eventStart("Tutorial")
     evt.finish(true)

--- a/dat/events/tutorial/tutorial.lua
+++ b/dat/events/tutorial/tutorial.lua
@@ -7,6 +7,8 @@ if lang == "es" then
 else -- default english
     menutitle = "Tutorial Menu"
     menutext = "Welcome to the Naev tutorial menu. Please select a tutorial module from the list below:"
+    
+    menuall = "Play All"
 
     menubasic = "Tutorial: Basic Operation"
     menudiscover = "Tutorial: Exploration and Discovery"
@@ -45,9 +47,19 @@ function create()
     system.get("Iroquois"):setKnown(false, true)
     system.get("Navajo"):setKnown(false, true)
     system.get("Sioux"):setKnown(false, true)
+    
+    if var.peek("tut_all") then
+        local nm = var.peek("tut_next")
+        var.pop("tut_next")
+        if nm == nil then
+            var.pop("tut_all")
+        else
+            startModule(nm)
+        end
+    end
 
     -- Create menu.
-    _, selection = tk.choice(menutitle, menutext, menubasic, menudiscover, menuinterstellar, menucomms, menubasiccombat, menumisscombat, menuheat, menuaoutfits, menudisable, menuplanet, menumissions, menux)
+    _, selection = tk.choice(menutitle, menutext, menuall, menubasic, menudiscover, menuinterstellar, menucomms, menubasiccombat, menumisscombat, menuheat, menuaoutfits, menudisable, menuplanet, menumissions, menux)
     
     startModule(selection)
 end
@@ -56,6 +68,9 @@ end
 function startModule(module)
     if selection == menux then -- Quit to main menu
         tut.main_menu()
+    elseif selection == menuall then
+        var.push("tut_all", true)
+        module = menubasic
     end
     player.cinematics(false)
     naev.eventStart(module)


### PR DESCRIPTION
When "Play All" is selected, var "tut_all" is set true. If "tut_all" is
true and "tut_next" is not nil, the tutorial menu will pop "tut_all",
then start the event named by "tut_next". If "tut_next" is nil,
"tut_all" is cleared.

Each tutorial sets var "tut_next" to the next tutorial in sequence
during cleanup.
