### PR TITLE
Make Dvaered warlord-killing mission script more modular.

### DIFF
--- a/dat/missions/dvaered/dv_diversion.lua
+++ b/dat/missions/dvaered/dv_diversion.lua
@@ -9,6 +9,10 @@ include("scripts/fleethelper.lua")
 lang = naev.lang()
 if lang == "es" then
 else -- default english
+    destsysname = "Torg"
+    destplanetname = "Jorcan"
+    destjumpname = "Doranthex"
+
     title = {}
     text = {}
     failtitle = {}
@@ -25,7 +29,7 @@ else -- default english
     
     title[2] = "A small distraction"
     text[2] = [[    "My General has just retired from the High Command and is now looking to become the Warlord of a planetary system. Unfortunately, our loyal forces do not seem sufficient enough to take on any existing planetary defense forces head on.  
-    "However, it looks like there may be an opportunity for us in %s. Warlord Khan of Jorcan has been building his newest flagship, the Hawk, and will be onboard the Hawk as it tests its hyperspace capabilities. Since its engines and weapons have not been fully installed yet, it will be substantially slower than normal and unable to defend itself.  
+    "However, it looks like there may be an opportunity for us in %s. Warlord Khan of %s has been building his newest flagship, the Hawk, and will be onboard the Hawk as it tests its hyperspace capabilities. Since its engines and weapons have not been fully installed yet, it will be substantially slower than normal and unable to defend itself.  
     "To protect himself and the Hawk, Khan will have deployed a substantial escort fighter fleet to defend against any surprise attack."]]
     text[3] = [[    "That is where you come in. You will jump into %s and find the Hawk and its escorts. Before the Hawk is able to reach hyperspace, you will fire on it, and cause the fighters to engage with you. At this point, you should run away from the Hawk and the jump point, so that the fighters will give chase. Then we will jump into the system and destroy the Hawk before the fighters can return."]]
     text[4] = [[    "We will jump in approximately 8000 STU after you jump into %s, so the fighters must be far enough away by then not to come back and attack us."]]
@@ -40,7 +44,7 @@ else -- default english
     failtext[2] = "The Hawk jumped out of the system. You have failed your mission."
 
     failtitle[3] = "The Hawk got away!"
-    failtext[3] = "The Hawk landed back on Jorcan. You have failed your mission."
+    failtext[3] = "The Hawk landed back on %s. You have failed your mission."
     failtitle[4] = "The Hawk is safe."
     failtext[4] = "The Hawk was able to fend off the attackers and destroy their flagship. You have failed your mission."
 
@@ -54,7 +58,7 @@ else -- default english
     osd_desc[2] = "Fire on the Hawk and flee from the fighter escorts until the Dvaered fleet jumps in and destroys the Hawk"  
     misn_desc = "You have been recruited to distract the Dvaered fighter escorts and lead them away from the jump gate and the capital ship Hawk. The Dvaered task force will jump in and attempt to destroy the Hawk before the escort ships can return. The mission will fail if the Hawk survives or the Dvaered task force is eliminated."
 
-    chatter[0] = "All right men, this will be Hawk's maiden jump. Continue on course to the Doranthex jump gate."
+    chatter[0] = "All right men, this will be Hawk's maiden jump. Continue on course to the %s jump gate."
     chatter[1] = "How dare he attack me! Get him!"
     chatter[2] = "You heard Warlord Khan, blow him to pieces!"
     chatter[3] = "He's attacking us, blow him to pieces!"
@@ -62,16 +66,16 @@ else -- default english
     chatter[5] = "Khan is dead! Who will be our warlord now?"
     chatter[6] = "Obviously the one who killed him, idiot!"
     chatter[7] = "I will never serve a different warlord than Khan! Die, you traitors!"
-    chatter[8] = "Jorcan will be ours! Khan, prepare to die!"
+    chatter[8] = "%s will be ours! Khan, prepare to die!"
     chatter[9] = "All units, defend Hawk, we are under attack!"
     chatter[10] = "All units, defend Hawk, we are under attack!"
     chatter[11] = "Return to Hawk, Khan is in danger!"
     chatter[12] = "Pathetic, can't even take down an unarmed ship."
-    chatter[13] = "I declare myself the Warlord of Jorcan!"
+    chatter[13] = "I declare myself the Warlord of %s!"
 end
 
 function create()
-    missys = {system.get("Torg")}
+    missys = {system.get(destsysname)}
     if not misn.claim(missys) then
         abort()
     end
@@ -82,9 +86,7 @@ end
 
 function accept()
     if tk.yesno(title[1], text[1]) then
-        destsysname = "Torg"
-        destplanetname = "Jorcan"
-        tk.msg(title[2], string.format(text[2], destsysname))
+        tk.msg(title[2], string.format(text[2], destsysname, destplanetname))
         tk.msg(title[2], string.format(text[3], destsysname))
         tk.msg(title[2], string.format(text[4], destsysname))
 
@@ -117,7 +119,7 @@ function enter()
         pilot.clear()
         misn.osdActive(2)
         missionstarted = true
-        j = jump.get("Torg","Doranthex")
+        j = jump.get(destsysname, destjumpname)
         v = j:pos()
         hawk = pilot.add("Dvaered Goddard", "dvaered_norun", v-vec2.new(1500,8000))[1]
         hawk:rename("Hawk")
@@ -125,8 +127,8 @@ function enter()
         hawk:setVisible(true)
         pilot.cargoAdd(hawk, "Food", 500)
         hawk:control()
-        hawk:hyperspace(Doranthex)
-        hawk:broadcast(chatter[0])
+        hawk:hyperspace(destjumpname)
+        hawk:broadcast(string.format(chatter[0], destjumpname))
         fleetdv = pilot.add("Dvaered Home Guard", "dvaered_norun", hawk:pos()-vec2.new(1000,1500))
         for i, j in ipairs(fleetdv) do
             j:changeAI("dvaered_norun")
@@ -173,7 +175,7 @@ function hawk_attacked () -- chased
     else
         hawk:broadcast(chatter[1])
         hawk:control()
-        hawk:hyperspace(Doranthex)
+        hawk:hyperspace(destjumpname)
         fleetdv[1]:broadcast(chatter[2])
     end
     for i, j in ipairs(fleetdv) do
@@ -190,7 +192,7 @@ function fleetdv_attacked () -- chased
     if jump_fleet_entered then
     else
         hawk:control()
-        hawk:hyperspace(Doranthex)
+        hawk:hyperspace(destjumpname)
         fleetdv[1]:broadcast(chatter[3])
     end
     for i, j in ipairs(fleetdv) do
@@ -228,15 +230,15 @@ function hawk_dead () -- mission accomplished
     hook.timer(10000, "complete")
     for i, j in ipairs(jump_fleet) do
         if j:exists() then
-            j:land(planet.get("Jorcan"))
+            j:land(planet.get(destplanetname))
 	end    
     end
 end
 
 function spawn_fleet() -- spawn warlord killing fleet
     jump_fleet_entered = true
-    jump_fleet = pilot.add("Dvaered Med Force", "dvaered_norun", system.get("Doranthex"))
-    jump_fleet[6]:broadcast(chatter[8])
+    jump_fleet = pilot.add("Dvaered Med Force", "dvaered_norun", system.get(destjumpname))
+    jump_fleet[6]:broadcast(string.format(chatter[8], destplanetname))
     for i, j in ipairs(jump_fleet) do
         j:changeAI("dvaered_norun")
         j:setFaction("FLF")
@@ -250,7 +252,7 @@ function spawn_fleet() -- spawn warlord killing fleet
     hawk:broadcast(chatter[9])
     fleetdv[1]:broadcast(chatter[10])
     hawk:control()
-    hawk:land(planet.get("Jorcan"))
+    hawk:land(planet.get(destplanetname))
     for i, j in ipairs(fleetdv) do
         j:changeAI("dvaered_norun")
         j:control(false)
@@ -263,7 +265,7 @@ function jump_fleet_cap_dead () -- mission failed
     hawk:setNoDeath()
     tk.msg(failtitle[4], failtext[4])
     faction.get("Dvaered"):modPlayerSingle(-5)
-    hawk:land(planet.get("Jorcan"))
+    hawk:land(planet.get(destplanetname))
     for i, j in ipairs(fleetdv) do
         j:control()
         j:follow(hawk)
@@ -281,7 +283,7 @@ function complete()
     tk.msg(passtitle[1], passtext[1])
     camera.set(player.pilot(), true)
     player.pay(80000)
-    jump_fleet[6]:broadcast(chatter[13])
+    jump_fleet[6]:broadcast(string.format(chatter[13], destplanetname))
     misn.finish(true)
 end
 


### PR DESCRIPTION
I've edited the dv_diversion.lua mission script to use string substitution for system and planet names -- as is common in other files -- rather than repeating them over and over.

This commit is my first attempt at really digging into the Lua (rather than just editing strings). Lua's a fairly new language to me, but it's all in working order as best I can tell.
