### PR TITLE
Fixed headers that misspelled their include guards with two underscores.

### DIFF
--- a/src/debris.h
+++ b/src/debris.h
@@ -5,7 +5,7 @@
 
 
 #ifndef DEBRIS_H
-#  define DEBRIS__H
+#  define DEBRIS_H
 
 
 #include "pilot.h"

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -5,7 +5,7 @@
 
 
 #ifndef EXPLOSION_H
-#  define EXPLOSION__H
+#  define EXPLOSION_H
 
 
 #include "outfit.h"

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -5,7 +5,7 @@
 
 
 #ifndef WEAPON_H
-#  define WEAPON__H
+#  define WEAPON_H
 
 
 #include "outfit.h"


### PR DESCRIPTION
Three of the C headers had include guards that looked for a *_H symbol, but then defined a *__H symbol (note double underscore). I'm nobody's C expert, but I'm pretty sure that it's wrong. This commit fixes it.
