### PR TITLE
Added option to pause game upon taking damage instead of aborting autonav

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -183,6 +183,7 @@ void conf_setGameplayDefaults (void)
    conf.save_compress         = SAVE_COMPRESSION_DEFAULT;
    conf.mouse_thrust          = MOUSE_THRUST_DEFAULT;
    conf.autonav_abort         = AUTONAV_ABORT_DEFAULT;
+   conf.autonav_pause         = AUTONAV_PAUSE_DEFAULT;
    conf.zoom_manual           = MANUAL_ZOOM_DEFAULT;
 }
 
@@ -400,6 +401,7 @@ int conf_loadConfig ( const char* file )
       conf_loadInt("afterburn_sensitivity",conf.afterburn_sens);
       conf_loadInt("mouse_thrust",conf.mouse_thrust);
       conf_loadFloat("autonav_abort",conf.autonav_abort);
+      conf_loadBool("autonav_pause",conf.autonav_pause);
       conf_loadBool("devmode",conf.devmode);
       conf_loadBool("conf_nosave",conf.nosave);
 
@@ -1031,6 +1033,10 @@ int conf_saveConfig ( const char* file )
 
    conf_saveComment("Condition under which the autonav aborts.");
    conf_saveFloat("autonav_abort",conf.autonav_abort);
+   conf_saveEmptyLine();
+
+   conf_saveComment("If set, the game will pause when damage is received, instead of aborting the autonav.");
+   conf_saveBool("autonav_pause",conf.autonav_pause);
    conf_saveEmptyLine();
 
    conf_saveComment("Enables developer mode (universe editor and teh likes)");

--- a/src/conf.h
+++ b/src/conf.h
@@ -17,6 +17,7 @@
 #define SAVE_COMPRESSION_DEFAULT             1     /**< Whether or not saved games should be compressed. */
 #define MOUSE_THRUST_DEFAULT                 1     /**< Whether or not to use mouse thrust controls. */
 #define AUTONAV_ABORT_DEFAULT                1.    /**< Shield level (0-1) to abort autonav at. 1 means at missile lock, 0 means at armour damage. */
+#define AUTONAV_PAUSE_DEFAULT                0
 #define MANUAL_ZOOM_DEFAULT                  0     /**< Whether or not to enable manual zoom controls. */
 #define INPUT_MESSAGES_DEFAULT               5     /**< Amount of messages to display. */
 /* Video options */
@@ -127,6 +128,7 @@ typedef struct PlayerConf_s {
    unsigned int afterburn_sens; /**< Afterburn sensibility. */
    int mouse_thrust; /**< Whether mouse flying controls thrust. */
    double autonav_abort; /**< Condition for aborting autonav. */
+   int autonav_pause;/**< Pauses game instead of aborting autonav. */
    int nosave; /**< Disables conf saving. */
    int devmode; /**< Developer mode. */
    int devcsv; /**< Output CSV data. */

--- a/src/options.c
+++ b/src/options.c
@@ -109,7 +109,7 @@ void opt_menu (void)
 
    /* Dimensions. */
    w = 600;
-   h = 500;
+   h = 525;
 
    /* Create window and tabs. */
    opt_wid = window_create( "Options", -1, -1, w, h );
@@ -271,6 +271,11 @@ static void opt_gameplay( unsigned int wid )
    window_addText( wid, x+20, y, cw, 20, 0, "txtSettings",
          NULL, &cDConsole, "Settings" );
    y -= 25;
+
+   window_addCheckbox( wid, x, y, cw, 20,
+         "chkAutonavPause", "Pause instead of aborting Autonav", NULL, conf.autonav_pause );
+   y -= 25;
+
    window_addCheckbox( wid, x, y, cw, 20,
          "chkZoomManual", "Enable manual zoom control", NULL, conf.zoom_manual );
    y -= 25;
@@ -320,6 +325,7 @@ static void opt_gameplaySave( unsigned int wid, char *str )
    conf.zoom_manual = window_checkboxState( wid, "chkZoomManual" );
    conf.mouse_thrust = window_checkboxState(wid, "chkMouseThrust" );
    conf.save_compress = window_checkboxState( wid, "chkCompress" );
+   conf.autonav_pause = window_checkboxState( wid, "chkAutonavPause" );
    
    /* Faders. */
    conf.autonav_abort = window_getFaderValue(wid, "fadAutonav");


### PR DESCRIPTION
The existing functionality for disabling autonav tends to do things like abort a jump while under heavy fire, thus requiring that you restart the jump timer.  This patch adds an option to the main options menu to pause the game instead of aborting autonav.  Once unpaused, it will then wait two seconds (game-time) before either re-pausing or enabling time compression, so the player will have time to react.
