### PR TITLE
A quick fix to avoid rechecking the reassigned target_world variable on ...

### DIFF
--- a/dat/missions/runaway/runaway_search.lua
+++ b/dat/missions/runaway/runaway_search.lua
@@ -98,6 +98,7 @@ function land ()
       tk.msg(title, misn_nifiheim)
       misn.osdActive(2)
       misn.markerMove(runawayMarker, system.get("Shakar"))
+      return
    end
 
    --If we land on Nova Shakar, display message, reset target and carry on.
@@ -115,6 +116,7 @@ function land ()
       misn.osdActive(3)
 
       misn.markerMove(runawayMarker, system.get("Cygnus"))
+      return
    end
 
    --If we land on Torloth, change osd, display message, reset target and carry on.
@@ -136,6 +138,7 @@ function land ()
       misn.osdActive(4)
 
       misn.markerMove(runawayMarker, system.get("Goddard"))
+      return
    end
 
    --If we land on Zhiru to finish the mission, clean up, reward, and leave.


### PR DESCRIPTION
...the first check, thus autoclearing all conditions in a row. :/
- BSoD
  modified:   dat/missions/runaway/runaway_search.lua
