### PR TITLE
Bug #217: Available money not updated in shipyard after purchasing a shi...

### DIFF
--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -503,6 +503,8 @@ static void shipyard_trade( unsigned int wid, char* str )
    player_modCredits( playerprice - targetprice ); /* Modify credits by the difference between ship values. */
 
    land_checkAddRefuel();
+   
+   wid = land_getWid(LAND_WINDOW_SHIPYARD);
 
    /* Update shipyard. */
    shipyard_update(wid, NULL);


### PR DESCRIPTION
Whenever the player swapped ships, it recreated the gui, causing the shipyard_update to be given an old window id
Removed reloading the gui whenever the current ship is swapped

Don't know if this has any unwanted side effects, but the game seems to run fine after removing it.
