### PR TITLE
Fixes to Autonav speed.

### DIFF
--- a/src/player_autonav.c
+++ b/src/player_autonav.c
@@ -451,11 +451,19 @@ int player_autonavShouldResetSpeed (void)
    }
 
    if (hostiles && hostiles_last) {
-      if (failpc > .995)
+      if (failpc > .995) {
          will_reset = 1;
+         speedup_timer = 0.;
+      }
       else if ((shield < lasts && shield < failpc) || armour < lasta) {
          will_reset = 1;
          speedup_timer = 2.;
+      }
+      else if (speedup_timer > 0) {
+         /* This check needs to be after the second check so new hits
+          * bring the timer back up. Otherwise, we will have sporadic
+          * bursts of speed. */
+         will_reset = 1;
       }
    }
 
@@ -559,11 +567,7 @@ void player_updateAutonav( double dt )
    }
 
    /* We'll update the time compression here. */
-   if (speedup_timer > 0) {
-      /* Wait a while before restarting time acceleration. */
-      speedup_timer -= dt;
-      return;
-   }
+   speedup_timer -= dt;
    if (autopause_timer > 0) {
       /* Don't start time acceleration right away.  Let the player react. */
       autopause_timer -= dt;


### PR DESCRIPTION
- Time never slows down unless hostiles are present.
- Actually detects hostile presence, not just enemy presence; in particular, certain hostiles spawned by missions didn't cause time slow-down previously.
- Damage this frame is now required for time to slow down if the slider is below "Enemy Presence".
- When speed resets due to damage, time will not accelerate again for a couple seconds.
- Hostiles aren't considered to be present unless they are nearby for two consecutive frames. This works around a problem where time would reset frequently for one frame, which was annoying.
