### PR TITLE
Increased the distance of the FLF ships that attack you in es00.

### DIFF
--- a/dat/missions/empire/shipping/es00.lua
+++ b/dat/missions/empire/shipping/es00.lua
@@ -125,8 +125,8 @@ function enter ()
       -- Get a position near the player
       enter_vect = player.pos()
       a = rnd.rnd() * 2 * math.pi
-      d = rnd.rnd( 100, 200 )
-      enter_vect:add( math.cos(a) * d, math.sin(a) * d )
+      d = rnd.rnd( 1500, 2000 )
+      enter_vect = player.pos() + vec2.new( math.cos(a) * d, math.sin(a) * d )
 
       -- Create some pilots to go after the player
       p = pilot.add( "FLF Sml Force", nil, enter_vect )


### PR DESCRIPTION
Well, actually, I made them actually _have_ a distance. vec2.add
with pairs of coordinates is broken; trying to use that method just
does nothing. At any rate, I increased the _intended_ distance.
Those FLF ships being so close makes getting out impossible without
a highly _armored_ ship; not a fast ship, but a highly armored ship.
This is completely nonsensical. The ships spawning a ways away makes
escaping from them with a fast ship much more realistic.

That bug with vec2.add still needs to be fixed, though. For now, I
worked around it by creating a new vector and adding them together
instead.
