### PR TITLE
Increased the energy usage of the Emergency Shield Booster.

### DIFF
--- a/dat/outfits/activated/emergency_shield_booster.xml
+++ b/dat/outfits/activated/emergency_shield_booster.xml
@@ -13,6 +13,6 @@
   <active cooldown="25">8</active>
   <shield_regen>10</shield_regen>
   <shield_regen_mod>300</shield_regen_mod>
-  <energy_usage>30</energy_usage>
+  <energy_usage>160</energy_usage>
  </specific>
 </outfit>


### PR DESCRIPTION
The text describing this outfit claims that energy use is
"disproportionately high", which is complete nonsense. The cost
before was _incredibly_ cheap. It has been more than quintupled,
to 160. This amount of energy usage does not render the outfit
useless for small ships, though it does make the energy usage
actually a problem for these ships.
