### PR TITLE
Fix compile errors when the flag -Werror=format-security is set

### DIFF
--- a/src/dev_system.c
+++ b/src/dev_system.c
@@ -247,7 +247,7 @@ int dsys_saveMap (StarSystem **uniedit_sys, int uniedit_nsys)
    for (i = 0; i < uniedit_nsys; i++) {
       s = uniedit_sys[i];
       xmlw_startElem( writer, "sys" );
-      xmlw_attr( writer, "name", s->name );
+      xmlw_attr( writer, "name", "%s", s->name );
 
       /* Iterate jumps and see if they lead to any other systems in our array. */
       for (j = 0; j < s->njumps; j++) {

--- a/src/log.c
+++ b/src/log.c
@@ -191,10 +191,10 @@ void log_copy( int enable )
    }
 
    if (noutcopy)
-      fprintf( stdout, outcopy );
+      fprintf( stdout, "%s", outcopy );
 
    if (nerrcopy)
-      fprintf( stderr, errcopy );
+      fprintf( stderr, "%s", errcopy );
 
    log_purge();
 }


### PR DESCRIPTION
In Fedora, we compile all of our packages with -Werror=format-security.  This patch fixes a few places where types aren't specified, which allows naev to compile with -Werror=format-security.