### PR TITLE
Can't do cargo missions to Thurion or Proteron now.

### DIFF
--- a/dat/scripts/cargo_common.lua
+++ b/dat/scripts/cargo_common.lua
@@ -28,7 +28,7 @@ function cargo_selectPlanets(missdist, routepos)
             for i, v in ipairs(s:planets()) do
                 if v:services()["inhabited"] and v ~= planet.cur() and v:class() ~= 0 and
                         not (s==system.cur() and ( vec2.dist( v:pos(), routepos ) < 2500 ) ) and
-                        v:canLand() then
+                        v:canLand() and cargoValidDest( v ) then
                     planets[#planets + 1] = {v, s}
                 end
            end
@@ -119,4 +119,18 @@ function cargoGetTransit( timelimit, numjumps, traveldist )
     local arrivalt = time.get() + time.create(0, 0, traveldist * stuperpx +
             numjumps * pstats.jump_delay + 10180 + 240 * numjumps)
     return arrivalt
+end
+
+function cargoValidDest( targetplanet )
+   -- The blacklist are factions which cannot be delivered to by factions other than themselves, i.e. the Thurion and Proteron.
+   local blacklist = {
+                     faction.get("Proteron"),
+                     faction.get("Thurion"),
+                     }
+   for i,f in ipairs( blacklist ) do
+      if planet.cur():faction() == blacklist[i] and targetplanet:faction() ~= blacklist[i] then
+         return false
+      end
+   end
+   return true
 end


### PR DESCRIPTION
Pretty simple fix. One could get a cargo mission from Doeston to Tobanna, so this fixes that. 
Basically, you can't ship to Thurion unless you are on a Thurion world. And same goes for Proteron.
Tested, looks good, works as intended.