### PR TITLE
slim gui: Display fuel in addition to jumps remaining

### DIFF
--- a/dat/gui/slim.lua
+++ b/dat/gui/slim.lua
@@ -996,14 +996,15 @@ function render( dt, dt_mod )
    end
 
    --Bottom bar
-   local length = 5, navstring, fuel, fuelstring, consume
+   local length = 5, navstring, fuelstring
    gfx.renderTexRaw( bottom_bar, 0, 0, screen_w, 30, 1, 1, 0, 0, 1, 1 )
 
    local jumps = player.jumps()
+   local fuel = player.fuel()
    if jumps == 1 then
-      fuelstring = jumps .. " Jump"
-   elseif jumps > 1 then
-      fuelstring = jumps .. " Jumps"
+      fuelstring = fuel .. " (" .. jumps .. " Jump)"
+   elseif fuel > 0 then
+      fuelstring = fuel .. " (" .. jumps .. " Jumps)"
    else
       fuelstring = "none"
    end


### PR DESCRIPTION
It was confusing that a player in a ship that requires more that 100
fuel/jump can ask for fuel and is still told the ship has no fuel. This
makes it more clear.