### PR TITLE
Limit to one reverse thruster

### DIFF
--- a/dat/outfits/modifiers/reverse_thrusters.xml
+++ b/dat/outfits/modifiers/reverse_thrusters.xml
@@ -7,6 +7,7 @@
   <price>20000</price>
   <description>Most ships can only thrust in one direction, because mounting engines on all sides of the ship tends to be impractical. However, it can be helpful to be able to thrust backwards to some, and for those people there is a solution: hull-mounted reverse thrusters. These thrusters can't propel the ship quite as well as real engines, due to their limited output.</description>
   <gfx_store>afterburner</gfx_store>
+  <limit>reverse_thruster</limit>
   <cpu>-2</cpu>
  </general>
  <specific type="modification">


### PR DESCRIPTION
Additional reverse thrusters currently have no effect, so they should be
limited to only one, or alternately additional ones should add more
reverse thrust. This commit implements the first option.