### PR TITLE
Make faction.enemies() return the player's enemies for "Player" faction

### DIFF
--- a/dat/scripts/fleet_form.lua
+++ b/dat/scripts/fleet_form.lua
@@ -128,7 +128,7 @@ function Forma:reorganize()
  
 
    for _,p in ipairs(self.fleet) do
-      if p ~= pilot.player() and p ~= fleader then
+      if p ~= fleader then
          p:setFaction(fleader:faction())
       end
    end
@@ -459,17 +459,7 @@ function Forma:control()
    self.thook = hook.timer(100, "toRepeat", self) -- Call the wrapper, not this function.
 
    --combat. mmmm.
-   local enemies = {}
-   if self.fleader == pilot.player() then
-      local plist = pilot.get()
-      for _,p in ipairs(plist) do
-         if P:hostile() then
-            table.insert(enemies,p)
-         end
-      end
-   else
-      enemies = pilot.get(self.fleader:faction():enemies()) -- Get all enemies of the fleader. NOTE: This assumes an enemy of the fleader is also an enemy of the fleet! For now that's okay, but keep that in mind.
-   end
+   local enemies = pilot.get(self.fleader:faction():enemies())
 
    if self.fleader:hostile() then
       enemies[#enemies+1] = player.pilot() -- Includes the player as an enemy to be iterated over.

--- a/src/faction.c
+++ b/src/faction.c
@@ -367,6 +367,22 @@ int* faction_getAllies( int f, int *n )
       return NULL;
    }
 
+      /* Player's faction ratings can change, so regenerate each call. */
+   if (f == FACTION_PLAYER) {
+      int nallies = 0;
+      int *allies = malloc(sizeof(int)*faction_nstack);
+
+      for (int i=0; i<faction_nstack; i++) {
+         if (faction_stack[i].player>PLAYER_ALLY)
+            allies[nallies++] = i;
+      }
+      allies = realloc(allies, sizeof(int)*nallies);
+
+      free(faction_stack[f].allies);
+      faction_stack[f].allies = allies;
+      faction_stack[f].nallies = nallies;
+   }
+
    *n = faction_stack[f].nallies;
    return faction_stack[f].allies;
 }

--- a/src/faction.c
+++ b/src/faction.c
@@ -332,6 +332,22 @@ int* faction_getEnemies( int f, int *n )
       return NULL;
    }
 
+   /* Player's faction ratings can change, so regenerate each call. */
+   if (f == FACTION_PLAYER) {
+      int nenemies = 0;
+      int *enemies = malloc(sizeof(int)*faction_nstack);
+
+      for (int i=0; i<faction_nstack; i++) {
+         if (faction_stack[i].player<0)
+            enemies[nenemies++] = i;
+      }
+      enemies = realloc(enemies, sizeof(int)*nenemies);
+
+      free(faction_stack[f].enemies);
+      faction_stack[f].enemies = enemies;
+      faction_stack[f].nenemies = nenemies;
+   }
+
    *n = faction_stack[f].nenemies;
    return faction_stack[f].enemies;
 }

--- a/src/faction.c
+++ b/src/faction.c
@@ -338,7 +338,7 @@ int* faction_getEnemies( int f, int *n )
       int *enemies = malloc(sizeof(int)*faction_nstack);
 
       for (int i=0; i<faction_nstack; i++) {
-         if (faction_stack[i].player<0)
+         if (faction_stack[i].player<PLAYER_ENEMY)
             enemies[nenemies++] = i;
       }
       enemies = realloc(enemies, sizeof(int)*nenemies);


### PR DESCRIPTION
With this change, `faction.get("Player"):enemies()` returns the factions with whom the player has a reputation of less than 0.  I would have done this for faction.allies() too, but I'm not sure what number would be appropriate, since a reputation of more than 0 does not mean "ally".  This helps with `fleet_form` at the very least, and may be otherwise useful.