### PR TITLE
Actually test for possession of pirate landing pass

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -667,7 +667,7 @@
   <lua>pirate/pir_cargo</lua>
   <avail>
    <priority>3</priority>
-   <cond>faction.playerStanding("Pirate") &gt;= 0 and var.peek("pir_cargo") == true</cond>
+   <cond>faction.playerStanding("Pirate") &gt;= 0 and player.numOutfit("Pirate Landing Pass") &gt; 0</cond>
    <chance>960</chance>
    <location>Computer</location>
    <faction>Pirate</faction>

--- a/dat/missions/pirate/hitman3.lua
+++ b/dat/missions/pirate/hitman3.lua
@@ -147,7 +147,6 @@ function landed ()
    -- Give landing pass   
    player.addOutfit("Pirate Landing Pass")
    player.pay( 100000 ) -- 100k
-   var.push("pir_cargo", true)
 
    -- Finish mission
    misn.finish(true)

--- a/dat/outfits/misc/pirate_landing_pass.xml
+++ b/dat/outfits/misc/pirate_landing_pass.xml
@@ -5,7 +5,7 @@
   <mass>0</mass>
   <price>1</price>
   <gfx_store>license_pirate</gfx_store>
-  <!--this outfit really does absolutly nothing. its effects are implemented in the pirate mission, hitman 3 where you receive it.-->
+  <!--this outfit does not affect ability to land (which is based on reputation) but does allow access to pirate missions-->
   <description>This license gives you authorization to land on pirate worlds and gives access to missions in the pirate mission computer.</description>
  </general>
  <specific type="license"/>


### PR DESCRIPTION
Previously, the pass did nothing, and a variable was set to implement
the functionality. This seems like a slightly cleaner method.