### PR TITLE
Use ship base stat instead of 1.0 for calculating of diminishing returns

### DIFF
--- a/src/outfit.c
+++ b/src/outfit.c
@@ -452,7 +452,7 @@ int outfit_isTurret( const Outfit* o )
  */
 int outfit_isMod( const Outfit* o )
 {
-   return (o->type==OUTFIT_TYPE_MODIFCATION);
+   return (o->type==OUTFIT_TYPE_MODIFICATION);
 }
 /**
  * @brief Checks if outfit is an afterburner.
@@ -929,7 +929,7 @@ static OutfitType outfit_strToOutfitType( char *buf )
    O_CMP("launcher",       OUTFIT_TYPE_LAUNCHER);
    O_CMP("ammo",           OUTFIT_TYPE_AMMO);
    O_CMP("turret launcher",OUTFIT_TYPE_TURRET_LAUNCHER);
-   O_CMP("modification",   OUTFIT_TYPE_MODIFCATION);
+   O_CMP("modification",   OUTFIT_TYPE_MODIFICATION);
    O_CMP("afterburner",    OUTFIT_TYPE_AFTERBURNER);
    O_CMP("fighter bay",    OUTFIT_TYPE_FIGHTER_BAY);
    O_CMP("fighter",        OUTFIT_TYPE_FIGHTER);
@@ -2439,7 +2439,7 @@ void outfit_free (void)
          free(o->u.fig.ship);
       if (outfit_isGUI(o) && o->u.gui.gui)
          free(o->u.gui.gui);
-      if (o->type == OUTFIT_TYPE_MODIFCATION)
+      if (o->type == OUTFIT_TYPE_MODIFICATION)
          ss_free( o->u.mod.stats );
       if (outfit_isMap(o)) {
          array_free( o->u.map->systems );

--- a/src/outfit.h
+++ b/src/outfit.h
@@ -49,7 +49,7 @@ typedef enum OutfitType_ {
    OUTFIT_TYPE_LAUNCHER, /**< Launcher. */
    OUTFIT_TYPE_AMMO, /**< Launcher ammo. */
    OUTFIT_TYPE_TURRET_LAUNCHER, /**< Turret launcher. */
-   OUTFIT_TYPE_MODIFCATION, /**< Modifies the ship base features. */
+   OUTFIT_TYPE_MODIFICATION, /**< Modifies the ship base features. */
    OUTFIT_TYPE_AFTERBURNER, /**< Gives the ship afterburn capability. */
    OUTFIT_TYPE_JAMMER, /**< Used to nullify seeker missiles. */
    OUTFIT_TYPE_FIGHTER_BAY, /**< Contains other ships. */

--- a/src/pilot_outfit.c
+++ b/src/pilot_outfit.c
@@ -865,7 +865,7 @@ void pilot_calcStats( Pilot* pilot )
    Outfit* o;
    PilotOutfitSlot *slot;
    double ac, sc, ec, fc; /* temporary health coefficients to set */
-   ShipStats amount, *s;
+   ShipStats amount, *s, *default_s;
 
    /*
     * set up the basic stuff
@@ -982,6 +982,7 @@ void pilot_calcStats( Pilot* pilot )
 
    /* Slot voodoo. */
    s = &pilot->stats;
+   default_s = &pilot->ship->stats_array;
 
    /* Fire rate:
     *  amount = p * exp( -0.15 * (n-1) )
@@ -991,18 +992,18 @@ void pilot_calcStats( Pilot* pilot )
     *  6x 15% -> 42.51%
     */
    if (amount.fwd_firerate > 0) {
-      s->fwd_firerate = 1. + (s->fwd_firerate-1.) * exp( -0.15 * (double)(MAX(amount.fwd_firerate-1.,0)) );
+      s->fwd_firerate = default_s->fwd_firerate + (s->fwd_firerate-default_s->fwd_firerate) * exp( -0.15 * (double)(MAX(amount.fwd_firerate-1.,0)) );
    }
    /* Cruiser. */
    if (amount.tur_firerate > 0) {
-      s->tur_firerate = 1. + (s->tur_firerate-1.) * exp( -0.15 * (double)(MAX(amount.tur_firerate-1.,0)) );
+      s->tur_firerate = default_s->tur_firerate + (s->tur_firerate-default_s->tur_firerate) * exp( -0.15 * (double)(MAX(amount.tur_firerate-1.,0)) );
    }
    /*
     * Electronic warfare setting base parameters.
     */
-   s->ew_hide           = 1. + (s->ew_hide-1.)        * exp( -0.2 * (double)(MAX(amount.ew_hide-1.,0)) );
-   s->ew_detect         = 1. + (s->ew_detect-1.)      * exp( -0.2 * (double)(MAX(amount.ew_detect-1.,0)) );
-   s->ew_jump_detect    = 1. + (s->ew_jump_detect-1.) * exp( -0.2 * (double)(MAX(amount.ew_jump_detect-1.,0)) );
+   s->ew_hide           = default_s->ew_hide + (s->ew_hide-default_s->ew_hide)                      * exp( -0.2 * (double)(MAX(amount.ew_hide-1.,0)) );
+   s->ew_detect         = default_s->ew_detect + (s->ew_detect-default_s->ew_detect)                * exp( -0.2 * (double)(MAX(amount.ew_detect-1.,0)) );
+   s->ew_jump_detect    = default_s->ew_jump_detect + (s->ew_jump_detect-default_s->ew_jump_detect) * exp( -0.2 * (double)(MAX(amount.ew_jump_detect-1.,0)) );
 
    /* Square the internal values to speed up comparisons. */
    pilot->ew_base_hide   = pow2( s->ew_hide );


### PR DESCRIPTION
When the ship was configured with some stat over 100, using more than
one modifier outfit for that stat actually resulted in a lower value
than the ship's base value. This fixes that.