### PR TITLE
add bountyhunters patrols in Dvaered space

### DIFF
--- a/dat/factions/spawn/common.lua
+++ b/dat/factions/spawn/common.lua
@@ -69,7 +69,12 @@ end
 scom.spawn = function( pilots )
    local spawned = {}
    for k,v in ipairs(pilots) do
-      local p = pilot.add( v["pilot"] )
+      local p
+      if not v["pilot"][1] then
+         p = pilot.add( v["pilot"] )
+      else
+         p = scom.spawnRaw( v["pilot"][1], v["pilot"][2], v["pilot"][3], v["pilot"][4], v["pilot"][5])
+      end
       if #p == 0 then
          error("No pilots added")
       end
@@ -79,6 +84,15 @@ scom.spawn = function( pilots )
       end
    end
    return spawned
+end
+
+
+-- @brief spawn a pilot with addRaw
+scom.spawnRaw = function( ship, name, ai, equip, faction)
+   local p = pilot.addRaw( ship, ai, nil, equip )
+   p[1]:rename(name)
+   p[1]:setFaction(faction)
+   return p
 end
 
 

--- a/dat/factions/spawn/dvaered.lua
+++ b/dat/factions/spawn/dvaered.lua
@@ -1,12 +1,14 @@
 include("dat/factions/spawn/common.lua")
-
+include("dat/factions/spawn/mercenary_helper.lua")
 
 -- @brief Spawns a small patrol fleet.
 function spawn_patrol ()
     local pilots = {}
     local r = rnd.rnd()
 
-    if r < 0.5 then
+    if r < 0.1 then
+        pilots = spawnLtMerc("Dvaered")
+    elseif r < 0.5 then
         scom.addPilot( pilots, "Dvaered Vendetta", 25 );
         scom.addPilot( pilots, "Dvaered Ancestor", 20 );
     elseif r < 0.8 then
@@ -28,7 +30,9 @@ function spawn_squad ()
     local pilots = {}
     local r = rnd.rnd()
 
-    if r < 0.5 then
+    if r < 0.1 then
+        pilots = spawnMdMerc("Dvaered")
+    elseif r < 0.5 then
         scom.addPilot( pilots, "Dvaered Vendetta", 25 );
         scom.addPilot( pilots, "Dvaered Ancestor", 20 );
         scom.addPilot( pilots, "Dvaered Vigilance", 70 );
@@ -51,23 +55,27 @@ end
 function spawn_capship ()
     local pilots = {}
 
-    -- Generate the capship
-    scom.addPilot( pilots, "Dvaered Goddard", 120 )
-
-    -- Generate the escorts
-    r = rnd.rnd()
-    if r < 0.5 then
-        scom.addPilot( pilots, "Dvaered Vendetta", 25 );
-        scom.addPilot( pilots, "Dvaered Vendetta", 25 );
-        scom.addPilot( pilots, "Dvaered Ancestor", 20 );
-    elseif r < 0.8 then
-        scom.addPilot( pilots, "Dvaered Vendetta", 25 );
-        scom.addPilot( pilots, "Dvaered Ancestor", 20 );
-        scom.addPilot( pilots, "Dvaered Phalanx", 45 );
+    if rnd.rnd() < 0.1 then
+        pilots = spawnBgMerc("Dvaered")
     else
-        scom.addPilot( pilots, "Dvaered Vendetta", 25 );
-        scom.addPilot( pilots, "Dvaered Vendetta", 25 );
-        scom.addPilot( pilots, "Dvaered Vigilance", 70 );
+        -- Generate the capship
+        scom.addPilot( pilots, "Dvaered Goddard", 120 )
+
+        -- Generate the escorts
+        r = rnd.rnd()
+        if r < 0.5 then
+            scom.addPilot( pilots, "Dvaered Vendetta", 25 );
+            scom.addPilot( pilots, "Dvaered Vendetta", 25 );
+            scom.addPilot( pilots, "Dvaered Ancestor", 20 );
+        elseif r < 0.8 then
+            scom.addPilot( pilots, "Dvaered Vendetta", 25 );
+            scom.addPilot( pilots, "Dvaered Ancestor", 20 );
+            scom.addPilot( pilots, "Dvaered Phalanx", 45 );
+        else
+            scom.addPilot( pilots, "Dvaered Vendetta", 25 );
+            scom.addPilot( pilots, "Dvaered Vendetta", 25 );
+            scom.addPilot( pilots, "Dvaered Vigilance", 70 );
+        end
     end
 
     return pilots

--- a/dat/factions/spawn/mercenary_helper.lua
+++ b/dat/factions/spawn/mercenary_helper.lua
@@ -1,0 +1,89 @@
+--This script chooses the mercenaries that spawn
+include("dat/factions/spawn/common.lua")
+
+function spawnLtMerc(faction)
+    local pilots = {}
+    local r = rnd.rnd()
+
+    if r < 0.1 then
+        scom.addPilot( pilots, {"Lancelot","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Phalanx","Bountyhunter","mercenary","Civilian", faction}, 45 );
+    elseif r < 0.3 then
+        scom.addPilot( pilots, {"Hyena","Bountyhunter","mercenary","Civilian", faction}, 15 );
+        scom.addPilot( pilots, {"Hyena","Bountyhunter","mercenary","Civilian", faction}, 15 );
+        scom.addPilot( pilots, {"Shark","Bountyhunter","mercenary","Civilian", faction}, 20 );
+    elseif r < 0.5 then
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Shark","Bountyhunter","mercenary","Civilian", faction}, 20 );
+    elseif r < 0.8 then
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Lancelot","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Ancestor","Bountyhunter","mercenary","Civilian", faction}, 20 );
+    else
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Ancestor","Bountyhunter","mercenary","Civilian", faction}, 20 );
+        scom.addPilot( pilots, {"Admonisher","Bountyhunter","mercenary","Civilian", faction}, 45 );
+    end
+
+    return pilots
+end
+
+function spawnMdMerc(faction)
+    local pilots = {}
+    local r = rnd.rnd()
+
+    if r < 0.5 then
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Ancestor","Bountyhunter","mercenary","Civilian", faction}, 20 );
+        scom.addPilot( pilots, {"Vigilance","Bountyhunter","mercenary","Civilian", faction}, 70 );
+    elseif r < 0.8 then
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Lancelot","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Ancestor","Bountyhunter","mercenary","Civilian", faction}, 20 );
+        scom.addPilot( pilots, {"Pacifier","Bountyhunter","mercenary","Civilian", faction}, 70 );
+    else
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Vigilance","Bountyhunter","mercenary","Civilian", faction}, 70 );
+        scom.addPilot( pilots, {"Phalanx","Bountyhunter","mercenary","Civilian", faction}, 45 );
+    end
+
+    return pilots
+end
+
+function spawnBgMerc(faction)
+    local pilots = {}
+
+    -- Generate the capship
+    r = rnd.rnd()
+    if r < 0.5 then
+        scom.addPilot( pilots, {"Kestrel","Bountyhunter","mercenary","Civilian", faction}, 90 );
+    elseif r < 0.8 then
+        scom.addPilot( pilots, {"Hawking","Bountyhunter","mercenary","Civilian", faction}, 105 );
+    else
+        scom.addPilot( pilots, {"Goddard","Bountyhunter","mercenary","Civilian", faction}, 120 );
+    end
+
+    -- Generate the escorts
+    r = rnd.rnd()
+    if r < 0.1 then
+        scom.addPilot( pilots, {"Lancelot","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Phalanx","Bountyhunter","mercenary","Civilian", faction}, 45 );
+    elseif r < 0.3 then
+        scom.addPilot( pilots, {"Hyena","Bountyhunter","mercenary","Civilian", faction}, 15 );
+        scom.addPilot( pilots, {"Hyena","Bountyhunter","mercenary","Civilian", faction}, 15 );
+        scom.addPilot( pilots, {"Shark","Bountyhunter","mercenary","Civilian", faction}, 20 );
+    elseif r < 0.5 then
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Shark","Bountyhunter","mercenary","Civilian", faction}, 20 );
+    elseif r < 0.8 then
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Lancelot","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Ancestor","Bountyhunter","mercenary","Civilian", faction}, 20 );
+    else
+        scom.addPilot( pilots, {"Vendetta","Bountyhunter","mercenary","Civilian", faction}, 25 );
+        scom.addPilot( pilots, {"Ancestor","Bountyhunter","mercenary","Civilian", faction}, 20 );
+        scom.addPilot( pilots, {"Admonisher","Bountyhunter","mercenary","Civilian", faction}, 45 );
+    end
+
+    return pilots
+end


### PR DESCRIPTION
In Dvaered controlled space, some bountyhunters spawn alongside dvaered ships.
I followed Booben's advice to write an helper in the spawn directory.
This was heavier than I thought, I had to change the common spawn file in order to make it possible to use the function addRaw.