### PR TITLE
Renamed stdout and stderr files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ core
 
 /.cproject
 /.project
+/Makefile.save-2015-05-27-0556

--- a/src/log.c
+++ b/src/log.c
@@ -111,11 +111,11 @@ void log_redirect (void)
    outfile = malloc(PATH_MAX);
    errfile = malloc(PATH_MAX);
 
-   nsnprintf( outfile, PATH_MAX, "%slogs/stdout_%s.txt", nfile_dataPath(),
+   nsnprintf( outfile, PATH_MAX, "%slogs/%s_stdout.txt", nfile_dataPath(),
          timestr );
    freopen( outfile, "w", stdout );
 
-   nsnprintf( errfile, PATH_MAX, "%slogs/stderr_%s.txt", nfile_dataPath(),
+   nsnprintf( errfile, PATH_MAX, "%slogs/%s_stderr.txt", nfile_dataPath(),
          timestr );
    freopen( errfile, "w", stderr );
 


### PR DESCRIPTION
It is annoying that in the log folder, files are not grouped by run. They are difficult to find.

So I changed the order for having the date first. Thus, example names can be 2015-08-30_stderr.txt : alpha sort matches date sort.

You can get ri of the .gitignore file, It got included and I don't know how to remove it, now the commit is made...