### PR TITLE
fix land/jump hooks in fleet_form

### DIFF
--- a/dat/scripts/fleet_form.lua
+++ b/dat/scripts/fleet_form.lua
@@ -199,26 +199,14 @@ end
 
 -- Jump hook. Ensures the entire fleet jumps if the fleader jumps.
 -- Takes an ID that tells this function which formation the pilot belonged to.
-function Forma:jumper(jumper)
+function Forma:jumper(jumper, jumpoint)
    if jumper == self.fleader then
       self:dead(jumper) -- Jumping out is the same as dying, for our purpose; we need to not run this before the if statement.
-      closeJumpBool = false
       self.fleader:setSpeedLimit(0)
       for _, p in ipairs(self.fleet) do
-         
-         --find the closest jump point, and make the whole fleet use that jump.
-         if closeJumpBool == false then
-            for _, j in ipairs(system.cur():jumps()) do
-               if closeJump == nil then
-                  closeJump = j
-               elseif p:pos():dist(closeJump:pos()) > p:pos():dist(j:pos()) then
-                  closeJump = j
-               end
-            end
-            closeJumpBool = true
-         end
+         --Make the whole fleet use the jump.
          p:control() -- control pilots or clear their orders.
-         p:hyperspace(closeJump:dest())
+         p:hyperspace(jumpoint:dest())
       end
 
       -- Stop the control loop, or it will override our hyperspace() order.
@@ -234,27 +222,14 @@ end
 
 -- Land hook. Ensures the entire fleet lands if the fleader lands.
 -- Takes an ID that tells this function which formation the pilot belonged to.
-function Forma:lander(lander)
+function Forma:lander(lander, planet)
    if lander == self.fleader then
       self:dead(lander) -- Landing is the same as dying, for our purpose.
-      closeAssetBool = false
       self.fleader:setSpeedLimit(0)
       for _, p in ipairs(self.fleet) do
-         
-         --find the closest asset and have the fleet land on it.
-         if closeAssetBool == false then
-            for _, a in ipairs(system.cur():planets()) do
-               if closeAsset == nil then
-                  closeAsset = a
-               elseif p:pos():dist(closeAsset:pos()) > p:pos():dist(a:pos()) then
-                  closeAsset = a
-               end
-            end
-         closeAssetBool = true
-         end
-      
+         --Have the fleet land on the asset.
          p:control() -- control pilots or clear their orders.
-         p:land(closeAsset)
+         p:land(planet)
       end
 
       -- Stop the control loop, or it will override our land() order.
@@ -274,12 +249,12 @@ function dead(victim, killer, forma)
    forma:dead(victim)
 end
 
-function jumper(jumper, system, forma)
-   forma:jumper(jumper)
+function jumper(jumper, jumpoint, forma)
+   forma:jumper(jumper, jumpoint)
 end
 
 function lander(lander, planet, forma)
-   forma:lander(lander)
+   forma:lander(lander, planet)
 end
 
 --Used in formation creation, this creates vec2s for each ship to follow.

--- a/dat/scripts/fleet_form.lua
+++ b/dat/scripts/fleet_form.lua
@@ -5,6 +5,7 @@ Created by Loki and BTAxis
 Usage:
 First create a fleet with pilot.add()
 Then pass that to the Forma:new() function.
+Then use Forma:setTask() to control the fleader
 -usage is: 
       Forma:new(fleet,"formation",combat_dist, preferred_fleet_leader)
 --combat_dist is the distance from the fleet leader to an enemy before the formation breaks and ships attack.
@@ -15,7 +16,7 @@ Control the fleet's movements by controlling the fleet leader, or "fleader".
 example:
 my_fleet = pilot.add("Pirate Hyena Pack")
 my_fleet = Forma:new(my_fleet,"echelon left",1500)
-my_fleet.fleader:control()
+my_fleet:setTask("goto",vec2.new(0,0))
 
 Current formations are:
 buffer            echelon left
@@ -41,6 +42,7 @@ Forma = {
          d1 = {},
          d2 = {},
          d3 = {},
+         task = nil,
 }
 
 -- The functions below that start with Forma: are all elements of the Forma table above.
@@ -476,6 +478,7 @@ function Forma:control()
    else --If no badguys are in range...
       if self.incombat then --...and the fleet is no longer in combat, then...
          self.incombat = false --...flip the combat flag, and continue the function.
+         self:manageTask()     --give the fleader his orders back
       end
    end
       
@@ -505,5 +508,37 @@ function Forma:control()
          end
          -- Logic for fleet leader goes here. For now, let's allow the fleader to act according to the regular AI.
       end
+   end
+end
+
+--Task management
+function Forma:manageTask()
+   if self.task[1] then 
+      self.fleader:control()
+      if self.task[1] == "goto" then
+         self.fleader:goto(self.task[2])
+      elseif self.task[1] == "land" then
+         self.fleader:land(self.task[2])
+      elseif self.task[1] == "hyperspace" then
+         self.fleader:hyperspace(self.task[2])
+      elseif self.task[1] == "follow" and self.task[2]:exists() then
+         self.fleader:follow(self.task[2])
+      elseif self.task[1] == "attack" and self.task[2]:exists() then
+         self.fleader:attack(self.task[2])
+      elseif self.task[1] == "runaway" and self.task[2]:exists() then
+         self.fleader:runaway(self.task[2])
+      elseif self.task[1] == "brake" then
+         self.fleader:brake()
+      else
+         error "task unknown"
+      end
+   end
+end
+
+function Forma:setTask(title, arg)
+   self.task = {title, arg}
+
+   if not self.incombat then
+      self:manageTask()
    end
 end


### PR DESCRIPTION
I think the use of land and jump hooks was wrong, what caused an error. I also made sure to remove the hooks over fleet's pilots when the fleet is disbanded.

I think it would be better to use the system given by the jump hook instead of looking for the closest jump, but I await your opinion.