### PR TITLE
Made enemy faction mod in faction_modPlayer primary, not secondary.

### DIFF
--- a/src/faction.c
+++ b/src/faction.c
@@ -546,7 +546,7 @@ void faction_modPlayer( int f, double mod, const char *source )
    /* Now mod enemies */
    for (i=0; i<faction->nenemies; i++)
       /* Modify faction standing. */
-      faction_modPlayerLua( faction->enemies[i], -mod, source, 1 );
+      faction_modPlayerLua( faction->enemies[i], -mod, source, 0 );
 }
 
 /**


### PR DESCRIPTION
The purpose of "secondary" modding is to reduce the effect of modding
allies. It makes no sense to also apply this to enemies, as this is
in the opposite direction and there's Lua code to handle it.