### PR TITLE
Removed secondary faction hits from the Empire.

### DIFF
--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -8,6 +8,7 @@ _fdelta_distress = {-1, 0} -- Maximum change constraints
 _fdelta_kill     = {-5, 1} -- Maximum change constraints
 _fcap_misn     = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_empire"
+_fcap_mod_sec  = 0
 _fthis         = faction.get("Empire")
 
 


### PR DESCRIPTION
What this effectively means is when you attack House Goddard or
House Dvaered, your standing with the Empire is unaffected. Only
when you actually attack Empire ships is your standing affected.
In particular, this makes it possible to be friendly with the Empire
even when you side with the FLF.