### PR TITLE
Changed _fcap_mod_sec into six more specific variables.

### DIFF
--- a/dat/factions/standing/skel.lua
+++ b/dat/factions/standing/skel.lua
@@ -10,7 +10,14 @@ _fdelta_distress = {-1, 0} -- Maximum change constraints
 _fdelta_kill     = {-5, 1} -- Maximum change constraints
 _fcap_misn       = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var   = nil -- Mission variable to use for limits
-_fcap_mod_sec    = 0.3 -- Modulation from secondary
+
+-- Secondary hit modifiers.
+_fmod_distress_enemy  = 0 -- Distress of the faction's enemies
+_fmod_distress_friend = 0.3 -- Distress of the faction's allies
+_fmod_kill_enemy      = 0.3 -- Kills of the faction's enemies
+_fmod_kill_friend     = 0.3 -- Kills of the faction's allies
+_fmod_misn_enemy      = 0.3 -- Missions done for the faction's enemies
+_fmod_misn_friend     = 0.3 -- Missions done for the faction's allies
 
 
 lang = naev.lang()
@@ -92,13 +99,27 @@ function default_hit( current, amount, source, secondary )
    local mod = 1
    if source == "distress" then
       delta = clone(_fdelta_distress)
-      -- Ignore positive distresses
-      if amount > 0 then
-         return f
+
+      -- Adjust for secondary hit
+      if secondary then
+         if amount > 0 then
+            mod = mod * _fmod_distress_enemy
+         else
+            mod = mod * _fmod_distress_friend
+         end
       end
    elseif source == "kill" then
       cap   = _fcap_kill
       delta = clone(_fdelta_kill)
+
+      -- Adjust for secondary hit
+      if secondary then
+         if amount > 0 then
+            mod = mod * _fmod_kill_enemy
+         else
+            mod = mod * _fmod_kill_friend
+         end
+      end
    else
       if _fcap_misn_var == nil then
          cap   = _fcap_misn
@@ -109,10 +130,17 @@ function default_hit( current, amount, source, secondary )
             var.push( _fcap_misn_var, cap )
          end
       end
+
+      -- Adjust for secondary hit
+      if secondary then
+         if amount > 0 then
+            mod = mod * _fmod_misn_friend
+         else
+            mod = mod * _fmod_misn_enemy
+         end
+      end
    end
 
-   -- Adjust for secondary hit
-   if secondary then mod = mod * _fcap_mod_sec end
    amount = mod * amount
    delta[1] = mod * delta[1]
    delta[2] = mod * delta[2]


### PR DESCRIPTION
Now, there is a different modifier variable for each possible
situation: distress of an enemy, distress of a friend, death of an
enemy, death of a friend, a mission completed by an enemy, and a
mission completed by a friend. For now, I've set all values to 0.3,
the value that _fcap_mod_sec was, with the exception of the variable
for distress of an enemy, which has been set to 0 because there was
previously code which specifically prevented enemy distress from
causing standing gain.

This change makes it possible to do much more fine-tuning to the way
standing gains and losses "leak out" to other factions.