### PR TITLE
Made the Empire not care about its allies being attacked.

### DIFF
--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -18,7 +18,7 @@ function faction_hit( current, amount, source, secondary )
    local start_standing = _fthis:playerStanding()
    local hit = default_hit(current, amount, source, secondary)
    if (source == "distress" or source == "kill") and secondary and amount < 0 then
-      if start_standing >= sec_hit_min and start_standing + hit < sec_hit_min:
+      if start_standing >= sec_hit_min and start_standing + hit < sec_hit_min then
          hit = sec_hit_min - start_standing
       end
    end

--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -9,12 +9,18 @@ _fdelta_kill     = {-5, 1} -- Maximum change constraints
 _fcap_misn     = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_empire"
 
-_fmod_distress_friend = 0
-_fmod_kill_friend     = 0
-
 _fthis         = faction.get("Empire")
+
+sec_hit_min = 10
 
 
 function faction_hit( current, amount, source, secondary )
-    return default_hit(current, amount, source, secondary)
+   local start_standing = _fthis:playerStanding()
+   local hit = default_hit(current, amount, source, secondary)
+   if (source == "distress" or source == "kill") and secondary and amount < 0 then
+      if start_standing >= sec_hit_min and start_standing + hit < sec_hit_min:
+         hit = sec_hit_min - start_standing
+      end
+   end
+   return hit
 end

--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -16,8 +16,8 @@ sec_hit_min = 10
 
 function faction_hit( current, amount, source, secondary )
    local start_standing = _fthis:playerStanding()
-   local hit = default_hit(current, amount, source, secondary)
-   if (source == "distress" or source == "kill") and secondary and amount < 0 then
+   local hit = default_hit( current, amount, source, secondary )
+   if ( source == "distress" or source == "kill" ) and secondary then
       if start_standing >= sec_hit_min and start_standing + hit < sec_hit_min then
          hit = sec_hit_min - start_standing
       end

--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -16,13 +16,10 @@ sec_hit_min = 10
 
 function faction_hit( current, amount, source, secondary )
    local start_standing = _fthis:playerStanding()
-   local hit = default_hit( current, amount, source, secondary )
-   if ( source == "distress" or source == "kill" ) and secondary and amount < 0 then
-      if start_standing >= sec_hit_min then
-         hit = math.max( amount, sec_hit_min - start_standing )
-      else
-         hit = 0
-      end
+   local f = default_hit( current, amount, source, secondary )
+   if ( ( source == "distress" or source == "kill" ) and secondary and
+         amount < 0 and f < sec_hit_min ) then
+      f = math.min( start_standing, sec_hit_min )
    end
-   return hit
+   return f
 end

--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -17,9 +17,11 @@ sec_hit_min = 10
 function faction_hit( current, amount, source, secondary )
    local start_standing = _fthis:playerStanding()
    local hit = default_hit( current, amount, source, secondary )
-   if ( source == "distress" or source == "kill" ) and secondary then
-      if start_standing >= sec_hit_min and start_standing + hit < sec_hit_min then
-         hit = sec_hit_min - start_standing
+   if ( source == "distress" or source == "kill" ) and secondary and amount < 0 then
+      if start_standing >= sec_hit_min then
+         hit = math.max( amount, sec_hit_min - start_standing )
+      else
+         hit = 0
       end
    end
    return hit

--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -8,6 +8,10 @@ _fdelta_distress = {-1, 0} -- Maximum change constraints
 _fdelta_kill     = {-5, 1} -- Maximum change constraints
 _fcap_misn     = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_empire"
+
+_fmod_distress_friend = 0
+_fmod_kill_friend     = 0
+
 _fthis         = faction.get("Empire")
 
 


### PR DESCRIPTION
The effect of this is that if the player attacks House Goddard or House
Dvaered, the Empire will not become hostile to the player. Only attacks
on the Empire's own ships will provoke this response.

This change is primarily meant to make it possible to align with the FLF, but
maintain good relations with the Empire.

This depends on #531 to have any effect; it uses new variables defined there.