### PR TITLE
Fixing jumpout bug.

### DIFF
--- a/dat/events/sirius/preach.lua
+++ b/dat/events/sirius/preach.lua
@@ -362,6 +362,9 @@ end
 --everything is done
 function cleanup()
    player.pilot():setInvincible(false)
+   player.pilot():control(false)
+   camera.set()
+   player.cinematics(false)
    evt.finish()
 end
 


### PR DESCRIPTION
After I had "completed hyperspace prep", and was speeding away, the Sirius Preach event started, and after the jump was completed (and I was out of the event system), I was no longer able to control my ship. This should fix that. Resetting the camera and the cinematics was probably overkill, but I decided better safe than sorry.