### PR TITLE
Made the AI wider use missiles

### DIFF
--- a/dat/ai/include/atk_generic.lua
+++ b/dat/ai/include/atk_generic.lua
@@ -99,20 +99,95 @@ end
 -- Enters ranged combat with the target
 --]]
 function _atk_g_ranged( target, dist )
-   local dir = ai.face(target) -- Normal face the target
 
-   -- Check if in range to shoot missiles
-   if dist < ai.getweaprange( 4 ) and dir < 30 then
-      ai.weapset( 4 )
+   -- Pilot thinks dogfight is the best
+   -- TODO : use also reldps
+   if ai.relhp(target) >= 0.5 
+         or ai.getweapspeed(4) < target:stats().speed_max*1.2 
+         or ai.getweaprange(4) < ai.getweaprange(1)*1.5 then
+
+      local dir = ai.face(target) -- Normal face the target
+
+      -- Check if in range to shoot missiles
+      if dist < ai.getweaprange( 4 ) and dir < 30 then
+         ai.weapset( 4 )
+      end
+
+      -- Approach for melee
+      if dir < 10 then
+         ai.accel()
+      end
+
+   else   --Pilot fears his enemy
+
+   --[[ The pilot tries first to place himself at range and at constant velocity.
+        When he is stabilized, he starts shooting until he has to correct his trajectory again
+
+        If he doesn't manage to shoot missiles after a few seconds 
+        (because the target dodges),
+        he gives up and just faces the target and shoot (provided he is in range)
+   ]]
+
+      local p = ai.pilot()
+
+      -- Estimate the range
+      local radial_vel = ai.relvel(target, true)
+      local range = ai.getweaprange( 4 )
+      range = math.min ( range - dist * radial_vel / ( ai.getweapspeed( 4 ) - radial_vel ), range )
+
+      local goal = ai.follow_accurate(target, range * 0.8, 0, 10, 20, "keepangle")
+      local mod = vec2.mod(goal - p:pos())
+
+      --Must approach or stabilize
+      if mod > 3000 then
+         -- mustapproach allows a hysteretic behaviour
+         mem.mustapproach = true
+      end
+      if dist > range*0.95 then
+         mem.outofrange = true
+      end
+
+      if (mem.mustapproach and not ai.timeup(1) ) or mem.outofrange then
+         local dir   = ai.face(goal)
+         if dir < 10 and mod > 300 then
+            ai.accel()
+            --mem.stabilized = false
+         -- ship must be stabilized since 2 secs
+         elseif ai.relvel(target) < 5 and not ai.timeup(1) then--[[if not mem.stabilized then
+            mem.stabilized = true
+            ai.settimer(0, 2000)
+         elseif not ai.timeup(1) and ai.timeup(0) then
+            -- If the ship manages to catch its mark, reset the timer]]
+            --ai.settimer(1, 10000)
+            mem.mustapproach = false
+         end
+         if dist < range*0.85 then
+            mem.outofrange = false
+         end
+
+      else -- In range
+         local dir  = ai.face(target)
+         if dir < 30 then
+            mem.totmass = p:stats().mass
+            ai.weapset( 4 )
+            -- If he managed to shoot, the mass decreased
+            if p:stats().mass < mem.totmass - 0.01 and not ai.timeup(1) then
+               ai.settimer(1, 13000)
+            end
+         end
+      end
+
+      --The pilot just arrived in the good zone : 
+      --From now, if ship doesn't manage to stabilize within a few seconds, shoot anyway
+      if dist < 1.5*range and not mem.inzone then
+         mem.inzone = true
+         ai.settimer(1, mod/p:stats().speed*700 )
+      end
+
    end
 
    -- Always launch fighters for now
    ai.weapset( 5 )
-
-   -- Approach for melee
-   if dir < 10 then
-      ai.accel()
-   end
 end
 
 

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -587,6 +587,10 @@ static void pilot_weapSetUpdateRange( PilotWeaponSet *ws )
       if (lev >= PILOT_WEAPSET_MAX_LEVELS)
          continue;
 
+      /* Empty Launchers aren't valid */
+      if (outfit_isLauncher(ws->slots[i].slot->outfit) && ws->slots[i].slot->u.ammo.quantity <= 0)
+         continue;
+
       /* Get range. */
       range = outfit_range(ws->slots[i].slot->outfit);
       if (range >= 0.) {
@@ -1025,6 +1029,7 @@ static int pilot_shootWeapon( Pilot* p, PilotOutfitSlot* w, double time )
    Vector2d vp, vv;
    double rate_mod, energy_mod;
    double energy;
+   int j;
 
    /* Make sure weapon has outfit. */
    if (w->outfit == NULL)
@@ -1118,6 +1123,12 @@ static int pilot_shootWeapon( Pilot* p, PilotOutfitSlot* w, double time )
       p->solid->mass     -= w->u.ammo.outfit->mass;
 
       pilot_updateMass( p );
+
+      /* If last ammo was shot, update the range */
+      if (w->u.ammo.quantity <= 0) {
+         for (j=0; j<PILOT_WEAPON_SETS; j++)
+            pilot_weapSetUpdateRange( &p->weapon_sets[j] );
+      }
    }
 
    /*
@@ -1231,8 +1242,11 @@ void pilot_weaponAuto( Pilot *p )
 
    /* All should be inrange. */
    if (!pilot_isPlayer(p))
-      for (i=0; i<PILOT_WEAPON_SETS; i++)
+      for (i=0; i<PILOT_WEAPON_SETS; i++){
          pilot_weapSetInrange( p, i, 1 );
+         /* Update range and speed (at 0)*/
+         pilot_weapSetUpdateRange( &p->weapon_sets[i] );
+      }
 
    /* Iterate through all the outfits. */
    for (i=0; i<p->noutfits; i++) {


### PR DESCRIPTION
This commit tends to have weak ships with missiles keep off dogfight and use their launchers.

I had also to do some changes in the hardcode : 
* Add a function that gives the speed of a weaponSet
* Change aiL_relvel and aiL_follow_accurate to increase their abilities ( add an optional parameter, lua api doesn't change )

And changes to avoid having out of ammo pilots trying to shoot : 
* Have empty launchers being ignored in the weapset range calculation
* Re-compute the range when the last ammo has been shot
* Initialize all the weaponset's range at 0 in weaponAddauto (If a script removes a weapon to a pilot, the range of this weapon must be forgotten).