### PR TITLE
Fix in equip/helper

### DIFF
--- a/dat/factions/equip/helper.lua
+++ b/dat/factions/equip/helper.lua
@@ -228,7 +228,7 @@ function equip_findOutfit( shipname, slot, outfits )
       cache_outfit(o)
 
       if ocache[o] <= scache[shipname][slot] then
-         return v
+         return o
       end
    end
 


### PR DESCRIPTION
An error in the file resulted in some ships (mainly Sirius Fidelity) having few weapons (because they tried to equip outfits that didn't pass into the slots)