### PR TITLE
fix in fleet_form

### DIFF
--- a/dat/scripts/fleet_form.lua
+++ b/dat/scripts/fleet_form.lua
@@ -513,7 +513,7 @@ end
 
 --Task management
 function Forma:manageTask()
-   if self.task[1] then 
+   if self.task and self.task[1] then 
       self.fleader:control()
       if self.task[1] == "goto" then
          self.fleader:goto(self.task[2])


### PR DESCRIPTION
This prevents the task management in fleet_form from reporting an error when the task is nil.