### PR TITLE
Fix LUA_CFLAGS when using luajit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,7 +284,7 @@ case "$used_lua" in
   luajit)
     PKG_CHECK_MODULES([LUA], [luajit], [
       have_lua=yes
-      LUA_CFLAGS+="-DHAVE_LUAJIT"
+      LUA_CFLAGS+=" -DHAVE_LUAJIT"
     ], [
       AC_WARN([Lua is set to LuaJIT but can not find library; using internal Lua])
       have_lua=no


### PR DESCRIPTION
This was creating a value of "-I/usr/include/luajit-2.0-DHAVE_LUAJIT"
for LUA_CFLAGS, which did not work correctly. I noticed this after
starting again from a clean build tree. I don't know how it managed to
build before.