### PR TITLE
Fixed an error in trader's idle behaviour

### DIFF
--- a/dat/ai/tpl/generic.lua
+++ b/dat/ai/tpl/generic.lua
@@ -276,7 +276,7 @@ end
 
 -- Finishes create stuff like choose attack and prepare plans
 function create_post ()
-   mem.tookoff    = ai.pilot():flags().takeingoff
+   mem.tookoff    = ai.pilot():flags().takingoff
    attack_choose()
 end
 


### PR DESCRIPTION
A spelling error was causing ships to ignore the takingoff flag.