### PR TITLE
fixed the escort attack function

### DIFF
--- a/src/escort.c
+++ b/src/escort.c
@@ -180,6 +180,7 @@ static int escort_command( Pilot *parent, int cmd, int param )
    int i, n;
    lua_State *L;
    Pilot *e;
+   LuaPilot p;
    char *buf;
 
    if (parent->nescorts == 0)
@@ -221,8 +222,10 @@ static int escort_command( Pilot *parent, int cmd, int param )
             return -1;
       }
       lua_getglobal(L, buf);
-      if (param >= 0)
-         lua_pushnumber(L, param);
+      if (param >= 0){
+         p.pilot = param;
+         lua_pushpilot(L, p);
+      }
 
       /* Run command. */
       if (lua_pcall(L, (param >= 0) ? 1 : 0, 0, 0))


### PR DESCRIPTION
The escort functions were still sending IDs to the lua scripts instead of pilot objects.