### PR TITLE
Changed target change conditions in atk_think

### DIFF
--- a/dat/ai/include/atk_drone.lua
+++ b/dat/ai/include/atk_drone.lua
@@ -24,22 +24,14 @@ function atk_drone_think ()
 
    local enemy    = ai.getenemy_size(0, 200)  -- find a small ship to attack
    local nearest_enemy = ai.getenemy()
-   local dist     = 0
-   local sizedist = 0
-
-   if enemy ~= nil then
-      sizedist = ai.dist(enemy)
-   end
-   if nearest_enemy ~= nil then
-      dist = ai.dist(nearest_enemy)
-   end
+   local dist     = ai.dist(target)
 
    local range = ai.getweaprange(3, 0)
    -- Get new target if it's closer
    --prioritize targets within the size limit
    if enemy ~= target and enemy ~= nil then
       -- Shouldn't switch targets if close
-      if sizedist > range * mem.atk_changetarget then
+      if dist > range * mem.atk_changetarget then
          ai.pushtask("attack", enemy )
       end
 

--- a/dat/ai/include/atk_fighter.lua
+++ b/dat/ai/include/atk_fighter.lua
@@ -24,22 +24,14 @@ function atk_fighter_think ()
 
    local enemy    = ai.getenemy_size(0, 200)
    local nearest_enemy = ai.getenemy()
-   local dist     = 0
-   local sizedist = 0
-
-   if enemy ~= nil then
-      sizedist = ai.dist(enemy)
-   end   
-   if nearest_enemy ~= nil then   
-      dist = ai.dist(nearest_enemy)
-   end
+   local dist     = ai.dist(target)
 
    local range = ai.getweaprange(3, 0)
    -- Get new target if it's closer
    --prioritize targets within the size limit
    if enemy ~= target and enemy ~= nil then
       -- Shouldn't switch targets if close
-      if sizedist > range * mem.atk_changetarget then
+      if dist > range * mem.atk_changetarget then
          ai.pushtask("attack", enemy )
       end
       

--- a/dat/ai/include/atk_target.lua
+++ b/dat/ai/include/atk_target.lua
@@ -103,15 +103,8 @@ end
 function atk_heuristic_big_game_think ()
    local enemy         = ai.getenemy_heuristic(0.9, 0.9, 0.9, 20000)
    local nearest_enemy = ai.getenemy()
-   local dist = 0
-   local sizedist = 0
+   local dist = ai.dist(target)
 
-   if enemy ~= nil then
-      sizedist = ai.dist(enemy)
-   end   
-   if nearest_enemy ~= nil then
-      dist = ai.dist(nearest_enemy)
-   end
    local target = ai.target()
    -- Stop attacking if it doesn't exist
    if not target:exists() then
@@ -124,7 +117,7 @@ function atk_heuristic_big_game_think ()
    -- prioritize targets within the size limit
    if enemy ~= target and enemy ~= nil then
       -- Shouldn't switch targets if close
-      if sizedist > range * mem.atk_changetarget then
+      if dist > range * mem.atk_changetarget then
          ai.pushtask("attack", enemy )
       end
       


### PR DESCRIPTION
I changed the target change conditions in many atk_think versions. I think the condition was not really coherent (or maybe I missed something...).

This changes the behaviour of ships, mainly pirates ones : They don't madly head to capships anymore.