### PR TITLE
Removed military ships from Dolmen in Pastor

### DIFF
--- a/dat/assets/dolmen.xml
+++ b/dat/assets/dolmen.xml
@@ -33,7 +33,6 @@
  <tech>
   <item>Missiles 2</item>
   <item>Star Maps</item>
-  <item>Empire Military Ships</item>
   <item>Engines High</item>
  </tech>
 </asset>


### PR DESCRIPTION
This issue is frequentiy reported by players. I hesitated between that and making Dolmen unlandable in early game.