### PR TITLE
Stderr & Stdout timestamped duplicates

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -40,6 +40,8 @@ static int nerrcopy = 0; /* Number of bytes written to errcopy. */
 /**< Output filenames for stdout and stderr. */
 static char *outfile = NULL;
 static char *errfile = NULL;
+static char *outfiledouble = NULL;
+static char *errfiledouble = NULL;
 
 /* Whether to copy stdout and stderr to temporary buffers. */
 int copying = 0;
@@ -110,14 +112,17 @@ void log_redirect (void)
 
    outfile = malloc(PATH_MAX);
    errfile = malloc(PATH_MAX);
+   outfiledouble = malloc(PATH_MAX);
+   errfiledouble = malloc(PATH_MAX);
 
-   nsnprintf( outfile, PATH_MAX, "%slogs/%s_stdout.txt", nfile_dataPath(),
-         timestr );
+   nsnprintf( outfile, PATH_MAX, "%slogs/stdout.txt", nfile_dataPath() );
    freopen( outfile, "w", stdout );
 
-   nsnprintf( errfile, PATH_MAX, "%slogs/%s_stderr.txt", nfile_dataPath(),
-         timestr );
+   nsnprintf( errfile, PATH_MAX, "%slogs/stderr.txt", nfile_dataPath() );
    freopen( errfile, "w", stderr );
+
+   nsnprintf( outfiledouble, PATH_MAX, "%slogs/%s_stdout.txt", nfile_dataPath(), timestr );
+   nsnprintf( errfiledouble, PATH_MAX, "%slogs/%s_stderr.txt", nfile_dataPath(), timestr );
 
    /* stderr should be unbuffered */
    setvbuf( stderr, NULL, _IONBF, 0 );
@@ -249,6 +254,9 @@ void log_clean (void)
    if (err.st_size == 0) {
       unlink(outfile);
       unlink(errfile);
+   } else {
+      nfile_copyIfExists(outfile, outfiledouble);
+      nfile_copyIfExists(errfile, errfiledouble);
    }
 }
 

--- a/src/nfile.c
+++ b/src/nfile.c
@@ -429,11 +429,8 @@ int nfile_fileExists( const char* path, ... )
 int nfile_backupIfExists( const char* path, ... )
 {
    char file[PATH_MAX];
-   va_list ap;
    char backup[PATH_MAX];
-   FILE *f_in, *f_out;
-   char buf[ 8*1024 ];
-   size_t lr, lw;
+   va_list ap;
 
    if (path == NULL)
       return -1;
@@ -447,44 +444,7 @@ int nfile_backupIfExists( const char* path, ... )
 
    nsnprintf(backup, PATH_MAX, "%s.backup", file);
 
-   /* Open files. */
-   f_in  = fopen( file, "rb" );
-   f_out = fopen( backup, "wb" );
-   if ((f_in==NULL) || (f_out==NULL)) {
-      WARN( "Failure to create back up of '%s': %s", file, strerror(errno) );
-      if (f_in!=NULL)
-         fclose(f_in);
-      return -1;
-   }
-
-   /* Copy data over. */
-   do {
-      lr = fread( buf, 1, sizeof(buf), f_in );
-      if (ferror(f_in))
-         goto err;
-      else if (!lr) {
-         if (feof(f_in))
-            break;
-         goto err;
-      }
-
-      lw = fwrite( buf, 1, lr, f_out );
-      if (ferror(f_out) || (lr != lw))
-         goto err;
-   } while (lr > 0);
-
-   /* Close files. */
-   fclose( f_in );
-   fclose( f_out );
-
-   return 0;
-
-err:
-   WARN( "Failure to create back up of '%s': %s", file, strerror(errno) );
-   fclose( f_in );
-   fclose( f_out );
-
-   return -1;
+   return nfile_copyIfExists( path, backup );
 }
 
 
@@ -493,7 +453,7 @@ err:
  *
  *    @param path1 printf formatted string pointing to the file to copy from.
  *    @param path2 printf formatted string pointing to the file to copy to.
- *    @return 0 on success, or if file does not exist, -1 on error.
+ *    @return 0 on success, or if file1 does not exist, -1 on error.
  */
 int nfile_copyIfExists( const char* path1, const char* path2 )
 {

--- a/src/nfile.h
+++ b/src/nfile.h
@@ -15,6 +15,7 @@ int nfile_dirMakeExist( const char* path, ... ); /* Creates if doesn't exist, 0 
 int nfile_dirExists( const char* path, ... ); /* Returns 1 on exists. */
 int nfile_fileExists( const char* path, ... ); /* Returns 1 on exists */
 int nfile_backupIfExists( const char* path, ... );
+int nfile_copyIfExists( const char* path1, const char* path2 );
 char** nfile_readDir( int* nfiles, const char* path, ... );
 char** nfile_readDirRecursive( int* nfiles, const char* path, ... );
 char* nfile_readFile( int* filesize, const char* path, ... );


### PR DESCRIPTION
First write to hard-named stderr and stdout, then copy them to timestamped files.

Allows for auto-reload of err/out files in text editor while keping track of runs.

Could later be made customizable in conf.lua, then in the Options panel :
  - A checkbox for writing stderr/out at all (redirect_file, already exists)
  - If checked, 2 sub-checkboxes :
    - Keep if stderr is empty (keep_if_stderr_empty)
    - Create timestamped duplicates (timestamped_stderrout)

I will make another branch for including the new conf.lua parameters, then still another to include them in the Options panel.