### PR TITLE
Bugfix : AI trying to use Reverse thrust resulted in ship never braking

### DIFF
--- a/src/ai.c
+++ b/src/ai.c
@@ -849,7 +849,7 @@ void ai_think( Pilot* pilot, const double dt )
    }
 
    /* make sure pilot_acc and pilot_turn are legal */
-   pilot_acc   = CLAMP( 0., 1., pilot_acc );
+   pilot_acc   = CLAMP( -1., 1., pilot_acc );
    pilot_turn  = CLAMP( -1., 1., pilot_turn );
 
    /* Set turn and thrust. */


### PR DESCRIPTION
At least I found the issue with the Reverse thrust not working on AI ships. In ai.c, before applying acceleration, it was clamped in [0,1] instead of [-1,1]. This meant an AI ship could never accelerate backwards. I just changed the limits to [-1,1]. One second to change, but hours to find it ^-^