### PR TITLE
Fixes Baron mission

### DIFF
--- a/dat/missions/baron/baron_baron.lua
+++ b/dat/missions/baron/baron_baron.lua
@@ -141,7 +141,7 @@ function jumpin()
       pinnacle:setInvincible(true)
       pinnacle:control()
       pinnacle:setHilight(true)
-      pinnacle:goto(broship:pos() + vec2.new( 400, -400), false)
+      pinnacle:goto(planet.get("Ulios"):pos() + vec2.new( 400, -400), false)
       idlehook = hook.pilot(pinnacle, "idle", "idle")
       hook.pilot(pinnacle, "hail", "hail")
    end


### PR DESCRIPTION
Use of an undefined variable broke the Baron mission in
05dc196080f165c8b720760cdc47b5cce90e7eac such that a player could not
advance past the point where the Baron's ship needed to be hailed.