### PR TITLE
Shark fixes

### DIFF
--- a/dat/missions/shark/sh00_ancestorkill.lua
+++ b/dat/missions/shark/sh00_ancestorkill.lua
@@ -116,7 +116,9 @@ function accept()
       misn.setTitle(misn_title)
       misn.setReward(misn_reward:format(numstring(reward)))
       misn.setDesc(misn_desc)
-      misn.osdCreate(misn_title, osd_msg)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
+
       markeri = misn.markerAdd(missys, "low")
       
       jumpouthook = hook.jumpout("jumpout")
@@ -140,6 +142,10 @@ function land()
    if planet.cur() == mispla and stage == 4 then
       tk.msg(title[5], text[6]:format(battlesys:name(), missys:name()))
       player.pay(reward)
+      misn.osdDestroy(osd)
+      hook.rm(enterhook)
+      hook.rm(landhook)
+      hook.rm(jumpouthook)
       misn.finish(true)
    end
    if stage == 2 then   --You were supposed to kill him, not to go away !

--- a/dat/missions/shark/sh01_corvette.lua
+++ b/dat/missions/shark/sh01_corvette.lua
@@ -83,7 +83,9 @@ function accept()
       misn.setTitle(misn_title)
       misn.setReward(misn_reward:format(numstring(reward/2)))
       misn.setDesc(misn_desc)
-      misn.osdCreate(misn_title, osd_msg)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
+
       marker = misn.markerAdd(battlesys, "low")
       
       jumpouthook = hook.jumpout("jumpout")
@@ -108,6 +110,10 @@ function land()
    if stage == 2 and planet.cur() == paypla then
       tk.msg(title[3], text[3])
       player.pay(reward)
+      misn.osdDestroy(osd)
+      hook.rm(enterhook)
+      hook.rm(landhook)
+      hook.rm(jumpouthook)
       misn.finish(true)
    end
 end

--- a/dat/missions/shark/sh02_tapping.lua
+++ b/dat/missions/shark/sh02_tapping.lua
@@ -93,14 +93,15 @@ function accept()
       misn.accept()
       tk.msg(title[2], text[2]:format(mispla:name(),missys:name()))
       
-      misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
-      misn.setDesc(misn_desc)
-
       osd_msg[1] = osd_msg[1]:format(mispla:name(),missys:name())
       osd_msg[2] = osd_msg[2]:format(pplname, psyname)
 
-      misn.osdCreate(misn_title, osd_msg)
+      misn.setTitle(misn_title)
+      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setDesc(misn_desc)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
+
       marker = misn.markerAdd(missys, "low")
       
       landhook = hook.land("land")
@@ -122,6 +123,9 @@ function land()
       if misn.cargoRm(records) then
          tk.msg(title[3], text[3])
          player.pay(reward)
+         misn.osdDestroy(osd)
+         hook.rm(enterhook)
+         hook.rm(landhook)
          misn.finish(true)
       end
    end

--- a/dat/missions/shark/sh03_hailing.lua
+++ b/dat/missions/shark/sh03_hailing.lua
@@ -82,14 +82,15 @@ function accept()
       misn.accept()
       tk.msg(title[2], text[2])
       
-      misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
-      misn.setDesc(misn_desc)
-
       osd_msg[1] = osd_msg[1]:format(missys:name())
       osd_msg[2] = osd_msg[2]:format(pplname, psyname)
 
-      misn.osdCreate(misn_title, osd_msg)
+      misn.setTitle(misn_title)
+      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setDesc(misn_desc)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
+
       marker = misn.markerAdd(missys, "low")
       
       landhook = hook.land("land")
@@ -106,6 +107,9 @@ function land()
    if stage == 1 and planet.cur() == paypla then
    tk.msg(title[3], text[3]:format(nextpla:name(), nextsys:name()))
       player.pay(reward)
+      misn.osdDestroy(osd)
+      hook.rm(enterhook)
+      hook.rm(landhook)
       misn.finish(true)
    end
 end

--- a/dat/missions/shark/sh04_meeting.lua
+++ b/dat/missions/shark/sh04_meeting.lua
@@ -96,7 +96,9 @@ function accept()
       misn.setTitle(misn_title)
       misn.setReward(misn_reward:format(numstring(reward)))
       misn.setDesc(misn_desc)
-      misn.osdCreate(misn_title, osd_msg)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
+
       marker = misn.markerAdd(missys, "low")
 		
       smith = misn.cargoAdd("Person", 0)  --Adding the cargo
@@ -124,6 +126,9 @@ function land()
       if misn.cargoRm(smith) then
          tk.msg(title[3], text[3])
          player.pay(reward)
+         misn.osdDestroy(osd)
+         hook.rm(enterhook)
+         hook.rm(landhook)
          misn.finish(true)
       end
    end

--- a/dat/missions/shark/sh05_flf.lua
+++ b/dat/missions/shark/sh05_flf.lua
@@ -99,7 +99,9 @@ function accept()
       misn.setTitle(misn_title)
       misn.setReward(misn_reward:format(numstring(reward)))
       misn.setDesc(misn_desc)
-      misn.osdCreate(misn_title, osd_msg)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
+
       marker = misn.markerAdd(missys, "low")
       
       landhook = hook.land("land")
@@ -120,6 +122,9 @@ function land()
    if stage == 1 and planet.cur() == paypla then
       tk.msg(title[3], text[3]:format(nextsys:name()))
       player.pay(reward)
+      misn.osdDestroy(osd)
+      hook.rm(enterhook)
+      hook.rm(landhook)
       misn.finish(true)
    end
 end

--- a/dat/missions/shark/sh06_arandon.lua
+++ b/dat/missions/shark/sh06_arandon.lua
@@ -48,6 +48,7 @@ if lang == "es" then
    bar_desc[1] = [[It's fun to see how this guy's dishonesty has led him to help the most idealistic group in the galaxy.]]
 	
    -- OSD
+   osd_title = "A Journey To %s"
    osd_msg[1] = "Go to %s and wait for the FLF ship, then hail and board it."
    osd_msg[2] = "Go back to %s in %s"
    
@@ -85,7 +86,9 @@ function accept()
       misn.setTitle(misn_title:format(missys:name()))
       misn.setReward(misn_reward)
       misn.setDesc(misn_desc)
-      misn.osdCreate(misn_title:format(missys:name()), osd_msg)
+      osd = misn.osdCreate(osd_title:format(missys:name()), osd_msg)
+      misn.osdActive(1)
+
       marker = misn.markerAdd(missys, "low")
 		
       smith = misn.cargoAdd("Person", 0)  --Adding the cargo
@@ -99,12 +102,14 @@ function accept()
 end
 
 function land()
-   
 	--Job is done
    if stage == 1 and planet.cur() == paypla then
       if misn.cargoRm(smith) then
          tk.msg(title[3], text[3])
          player.pay(reward)
+         misn.osdDestroy(osd)
+         hook.rm(enterhook)
+         hook.rm(landhook)
          misn.finish(true)
       end
    end

--- a/dat/missions/shark/sh07_pirates.lua
+++ b/dat/missions/shark/sh07_pirates.lua
@@ -4,7 +4,7 @@
    
    Stages :
    0) There are pirates to kill
-	1) Way to Alteris
+   1) Way to Alteris
 	
 --]]
 
@@ -43,7 +43,10 @@ if lang == "es" then
 	
    title[5] = "That was impressive"
    text[5] = [[As you land, Smith is already there. "Thanks to your actions I managed to create the sales subsidiary and I think nobody will prevent us from selling Sharks anymore. It was very nice working with you. Here is your bounty. Good luck in the future."]]
-	
+
+   title[6] = "Target is gone !"
+   text[6] = [[It seems the pirate went away. Don't worry: I bet you that if you come back in some time, he will still be there."]]
+
    -- Mission details
    misn_title = "The Last Detail"
    misn_reward = "%s credits"
@@ -155,11 +158,18 @@ end
 function enter()
    --Arrived in system
    if system.cur() == gawsys and gawdead == false then  --The Gawain
-      baddie = pilot.addRaw( "Gawain","dummy", nil, "Dummy" )[1]
+
+      -- Choose a random point in the system for him to stay around
+      sysrad = rnd.rnd() * system.cur():radius()
+      angle = rnd.rnd() * 360
+      pos = vec2.newP(sysrad, angle)
+
+      baddie = pilot.addRaw( "Gawain","dummy", nil, "Thugs" )[1]
       baddie:rename(gawname)
       baddie:setHostile()
       baddie:setHilight()
       baddie:control()
+      baddie:goto(pos)
 		
       --The pirate becomes nice defensive outfits
       baddie:rmOutfit("all")
@@ -168,6 +178,8 @@ function enter()
       baddie:addOutfit("S&K Ultralight Stealth Plating")
       baddie:addOutfit("Milspec Aegis 2201 Core System")
       baddie:addOutfit("Tricon Zephyr Engine")
+      baddie:setHealth(100,100)
+      baddie:setEnergy(100)
 		
       baddie:addOutfit("Shield Capacitor",2)
       baddie:addOutfit("Small Shield Booster")
@@ -175,9 +187,10 @@ function enter()
 		
       baddie:addOutfit("Laser Cannon MK3",2)
 		
-      --hook.pilot(baddie, "idle", "idle")
+      hook.pilot(baddie, "idle", "idle", pos)
       hook.pilot(baddie, "attacked", "attacked")
       hook.pilot(baddie, "death", "gawain_dead")
+      hook.pilot(baddie, "jump", "generic_jumped")
 		
       elseif system.cur() == kersys1 and kerdead1 == false then  --The Kestrel
       pilot.clear()
@@ -192,6 +205,7 @@ function enter()
       baddie:setHostile()
 		
       hook.pilot( baddie, "death", "kestrel_dead1")
+      hook.pilot(baddie, "jump", "generic_jumped")
 		
       elseif system.cur() == kersys2 and kerdead2 == false then  --The Kestrel
       pilot.clear()
@@ -207,6 +221,7 @@ function enter()
       baddie:setHostile()
 		
       hook.pilot( baddie, "death", "kestrel_dead2")
+      hook.pilot(baddie, "jump", "generic_jumped")
 		
       elseif system.cur() == godsys and goddead == false then  --The Goddard
       pilot.clear()
@@ -224,20 +239,22 @@ function enter()
       baddie:setHostile()
 		
       hook.pilot( baddie, "death", "goddard_dead")
+      hook.pilot(baddie, "jump", "generic_jumped")
 		
    end
    
 end
 
-function idle()  --the Gawain is flying around ??? needs fixed if you want an idle() function
-   baddie:goto(planet.get("Anubis"):pos() + vec2.new( 800,  800), false)
-   baddie:goto(planet.get("Anubis"):pos() + vec2.new(-800,  800), false)
-   baddie:goto(planet.get("Anubis"):pos() + vec2.new(-800, -800), false)
-   baddie:goto(planet.get("Anubis"):pos() + vec2.new( 800, -800), false)
+function idle(pilot,pos)  --the Gawain is flying around a random point
+   baddie:goto(pos + vec2.new( 800,  800), false, false)
+   baddie:goto(pos + vec2.new(-800,  800), false, false)
+   baddie:goto(pos + vec2.new(-800, -800), false, false)
+   baddie:goto(pos + vec2.new( 800, -800), false, false)
 end
 
 function attacked()  --the Gawain is going away
    if baddie:exists() then
+      baddie:taskClear() 
       baddie:runaway(player.pilot(), true)
    end
 end
@@ -276,4 +293,8 @@ function generic_dead()
       misn.osdActive(2)
       marker2 = misn.markerAdd(paysys, "low")
    end
+end
+
+function gnenric_jumped()
+   tk.msg(title[6], text[6])
 end

--- a/dat/missions/shark/sh07_pirates.lua
+++ b/dat/missions/shark/sh07_pirates.lua
@@ -111,7 +111,7 @@ function accept()
    --set the names of the pirates (and make sure they aren't duplicates)
    gawname = pirate_name()
    kername1 = pirate_name() .. " III"
-   kername2 = pirate_name() .. " V"
+   kername2 = pirate_name() .. " Jr."
    godname = pirate_name() .. " II"
 	
    if tk.yesno(title[1], text[1]) then

--- a/dat/missions/shark/sh07_pirates.lua
+++ b/dat/missions/shark/sh07_pirates.lua
@@ -175,9 +175,9 @@ function enter()
 		
       baddie:addOutfit("Laser Cannon MK3",2)
 		
-      hook.pilot(baddie, "idle", "idle")
+      --hook.pilot(baddie, "idle", "idle")
       hook.pilot(baddie, "attacked", "attacked")
-      hook.pilot( baddie, "death", "gawain_dead")
+      hook.pilot(baddie, "death", "gawain_dead")
 		
       elseif system.cur() == kersys1 and kerdead1 == false then  --The Kestrel
       pilot.clear()

--- a/dat/missions/shark/sh07_pirates.lua
+++ b/dat/missions/shark/sh07_pirates.lua
@@ -9,8 +9,9 @@
 --]]
 
 --Needed scripts
-include "pilot/pirate.lua"
-include "numstring.lua"
+include "dat/scripts/pilot/pirate.lua"
+include "dat/scripts/numstring.lua"
+include "dat/scripts/jumpdist.lua"
 
 lang = naev.lang()
 if lang == "es" then
@@ -22,17 +23,17 @@ if lang == "es" then
    bar_desc = {}
    
    title[1] = "The mission"
-   text[1] = [["Hello again, "says Smith. "As you know, I've agreed with the FLF on a contract that will make it possible for Nexus to sell them hundreds of "Shark" light fighters. This income will easily make up for the losses due to the partial replacement of the "Shark" by drones in the Imperial fleet.
+   text[1] = [["Hello again," says Smith. "As you know, I've agreed with the FLF on a contract that will make it possible for Nexus to sell them hundreds of "Shark" light fighters. This income will easily make up for the losses due to the partial replacement of the "Shark" by drones in the Imperial fleet.
    Of course, this transaction must remain a secret. Even the head of the FLF thinks that we are working for an outlaw organization instead of a multi-stellar company. We are going to create a sales subsidiary on a pirate world so nobody will find out who really is behind this deal.
-   But, as you know, the pirate worlds are the territory of the "Skulls and Bones", the outlaw shipyard that makes copies of legal ships and sells it to pirates. If they discover our project, they will do everything to destroy us. That's why we need to make the first move: the Skulls and Bones use four major hitmen, who are also pirates. I want you to kill these four pirates in order to show the S&B that they can't win against us. I think it's the safest way to do what we have to do. Of course, there is a bounty on each of their heads.
+   But, as you know, the pirate worlds are the territory of the "Skulls & Bones", the outlaw shipyard that makes copies of legal ships and sells them to pirates. If they discover our project, they will do everything to destroy us. That's why we need to make the first move: Skulls & Bones use four major hitmen, who are also pirates. I want you to kill these four pirates in order to show the Skulls & Bones that they can't win against us. I think it's the safest way to do what we have to do. Of course, there is a bounty on each of their heads.
    Are you in?"]]
 	
    refusetitle = "Sorry, not interested"
    refusetext = [["Ok, too bad, you are the only one I can trust for this job. Don't hesitate to come back if you change your mind."]]
    
    title[2] = "Very good"
-   text[2] = [["So, here are the details: %s is around %s, flying his Gawain: he is taking undercover holidays, spending all the money he has stolen from traders. %s is in %s and %s is around %s with his Kestrel. Be careful, they have escorts. %s is in %s with his fearsome stolen Goddard and his escort.
-   Come back when you have finished: I will give you your bounties."]]
+   text[2] = [["So, here are the details: %s is around %s, flying his Gawain: he is taking an undercover holiday, spending all the money he has stolen from traders. %s is in %s and %s is around %s with his Kestrel. Be careful, they have escorts. %s is in %s with his fearsome stolen Goddard and his escort.
+   Come back when you have finished; I will give you your bounties."]]
 	
    title[3] = "Well done!"
    text[3] = [[This one will never get in our way again.]]
@@ -41,16 +42,16 @@ if lang == "es" then
    text[4] = "You have killed the four pirates: Adam Smith is probably waiting for you in %s with lots of money."
 	
    title[5] = "That was impressive"
-   text[5] = [[As you land, Smith is already there."Thank your actions, I managed to create the sales subsidiary and I think nobody will prevent us anymore from selling Sharks. It was very nice to work with you. Here is your bounty. Good luck in the future."]]
+   text[5] = [[As you land, Smith is already there. "Thanks to your actions I managed to create the sales subsidiary and I think nobody will prevent us from selling Sharks anymore. It was very nice working with you. Here is your bounty. Good luck in the future."]]
 	
    -- Mission details
    misn_title = "The Last Detail"
    misn_reward = "%s credits"
-   misn_desc = "Nexus Shipyard asked you to kill 4 pirates"
+   misn_desc = "Nexus Shipyard asked you to kill four pirates"
    
    -- NPC
    npc_desc[1] = "Arnold Smith"
-   bar_desc[1] = [[Smith has probably a mission for you that implies "fixing a detail" as he says.]]
+   bar_desc[1] = [[Smith probably has a mission for you that involves "fixing a detail", as he says.]]
 	
    -- OSD
    osd_title = "The Last Detail"
@@ -60,14 +61,29 @@ end
 
 function create ()
    
-   --Change here to change the planets and the systems
-	--sadly, I didn't manage to figure out how to pick random systems :(
-   
-   gawsys = system.get("Tau Prime")
-   kersys1 = system.get("Gamel")
-   kersys2 = system.get("Khaas")
-   godsys = system.get("Treacle")
-	
+   --Will now pick systems between min and max jumps in distance
+   local min = 3
+   local max = 7
+   local systems = getsysatdistance(system.cur(), min, max)
+   if #systems == 0 then
+      local systems = getsysatdistance(system.cur(), 1, 15)
+      if #systems == 0 then
+         osd_title = "Houston, we have a problem!"
+         gawsys = system.get("Alteris")
+         kersys1 = system.get("Alteris")
+         kersys2 = system.get("Alteris")
+         godsys = system.get("Alteris")
+      end
+   end
+   local index = rnd.rnd(1, #systems/4) --This avoids picking the same
+   gawsys = systems[index]
+   local index = rnd.rnd(index, #systems/3) --system twice, which would
+   kersys1 = systems[index]
+   local index = rnd.rnd(index, #systems/2) --make the missions rather
+   kersys2 = systems[index]
+   local index = rnd.rnd(index, #systems) --harder!
+   godsys = systems[index]
+
    pplname = "Darkshed"
    psyname = "Alteris"
    paysys = system.get(psyname)
@@ -92,25 +108,11 @@ function accept()
    kerdead2 = false
    goddead = false
 	
-   --set the names of the pirates
+   --set the names of the pirates (and make sure they aren't duplicates)
    gawname = pirate_name()
-	
-   kername1 = pirate_name()
-   while kername1 == gawname do  --That's not beautyfull, but it works...
-      --I don't want 2 pirates to have the same name
-      kername1 = pirate_name()
-   end
-	
-   kername2 = pirate_name()
-   while kername2 == gawname or kername2 == kername1 do
-      kername2 = pirate_name()
-   end
-	
-   godname = pirate_name()
-   while godname == gawname or godname == kername1 or godname == kername2 do
-      godname = pirate_name()
-   end
-   
+   kername1 = pirate_name() .. " III"
+   kername2 = pirate_name() .. " V"
+   godname = pirate_name() .. " II"
 	
    if tk.yesno(title[1], text[1]) then
       misn.accept()
@@ -121,7 +123,8 @@ function accept()
       misn.setTitle(misn_title)
       misn.setReward(misn_reward:format(numstring(reward)))
       misn.setDesc(misn_desc)
-      misn.osdCreate(misn_title, osd_msg)
+      osd = misn.osdCreate(osd_title, osd_msg)
+      misn.osdActive(1)
 		
       gawmarker = misn.markerAdd(gawsys, "low")
       kermarker1 = misn.markerAdd(kersys1, "high")
@@ -142,12 +145,15 @@ function land()
    if stage == 1 and planet.cur() == planet.get("Darkshed") then
       tk.msg(title[5], text[5])
       player.pay(reward)
+      misn.osdDestroy(osd)
+      hook.rm(enterhook)
+      hook.rm(landhook)
       misn.finish(true)
    end
 end
 
 function enter()
-   
+   --Arrived in system
    if system.cur() == gawsys and gawdead == false then  --The Gawain
       baddie = pilot.addRaw( "Gawain","dummy", nil, "Dummy" )[1]
       baddie:rename(gawname)
@@ -171,9 +177,7 @@ function enter()
 		
       hook.pilot(baddie, "idle", "idle")
       hook.pilot(baddie, "attacked", "attacked")
-      hook.pilot( baddie, "death", "gawain_dead" )
-		
-      idle()
+      hook.pilot( baddie, "death", "gawain_dead")
 		
       elseif system.cur() == kersys1 and kerdead1 == false then  --The Kestrel
       pilot.clear()
@@ -208,7 +212,7 @@ function enter()
       pilot.clear()
       pilot.toggleSpawn(false)
 		
-      baddie = pilot.add( "Goddard Goddard", nil, vec2.new(0,0))[1] --Faction's ships come up with upgraded weaponry
+      baddie = pilot.add( "Goddard Goddard", nil, vec2.new(0,0))[1] --Faction's ships come with upgraded weaponry
       baddie:setFaction("Pirate")
       baddie:changeAI( "pirate" )
 		
@@ -225,7 +229,7 @@ function enter()
    
 end
 
-function idle()  --the Gawain is flying around Anubis
+function idle()  --the Gawain is flying around ??? needs fixed if you want an idle() function
    baddie:goto(planet.get("Anubis"):pos() + vec2.new( 800,  800), false)
    baddie:goto(planet.get("Anubis"):pos() + vec2.new(-800,  800), false)
    baddie:goto(planet.get("Anubis"):pos() + vec2.new(-800, -800), false)


### PR DESCRIPTION
Includes tear downs for hooks and OSD in shark missions, not sure if they created the bug reported about them (#598) but maybe? (I don't know enough about state maintenance in Lua).

Also cleaned up mission eight (sh07), although, on second thoughts, the error might be being created by mission seven (sh06), but it's done now - proofread, odd typo etc.

Added random systems for where to find the pirates you need to kill - initially they are three to seven jumps away; change the variables min and max to alter this - as well as changing the way the pirates' names are made not to clash (in that unlikely scenario) to be cleaner.

One regression is that the first pirate no longer idles around a planet - I didn't have time to make sure the systems had to have planets as well as picking a planet for him to idle around... didn't seem like an issue and idle() was left in if someone wants to add it back in or I find more time later :)