### PR TITLE
Make LuaPilot an int instead of a struct, simplifying things

### DIFF
--- a/src/ai.c
+++ b/src/ai.c
@@ -2285,7 +2285,7 @@ static int aiL_getnearestplanet( lua_State *L )
    /* no friendly planet found */
    if (j == -1) return 0;
 
-   planet.id = cur_system->planets[j]->id;
+   planet = cur_system->planets[j]->id;
    lua_pushplanet(L, planet);
 
    return 1;
@@ -2306,7 +2306,7 @@ static int aiL_getrndplanet( lua_State *L )
    p = RNG(0, cur_system->nplanets-1);
 
    /* Copy the data into a vector */
-   planet.id = cur_system->planets[p]->id;
+   planet = cur_system->planets[p]->id;
    lua_pushplanet(L, planet);
 
    return 1;
@@ -2360,7 +2360,7 @@ static int aiL_getlandplanet( lua_State *L )
    /* we can actually get a random planet now */
    i = RNG(0,nplanets-1);
    p = cur_system->planets[ ind[i] ];
-   planet.id = p->id;
+   planet = p->id;
    lua_pushplanet( L, planet );
    cur_pilot->nav_planet   = ind[ i ];
    free(ind);
@@ -2412,7 +2412,7 @@ static int aiL_land( lua_State *L )
       pilot_setFlag( cur_pilot, PILOT_LANDING );
 
       hparam.type    = HOOK_PARAM_ASSET;
-      hparam.u.la.id = planet->id;
+      hparam.u.la    = planet->id;
 
       pilot_runHookParam( cur_pilot, PILOT_HOOK_LAND, &hparam, 1 );
    }

--- a/src/board.c
+++ b/src/board.c
@@ -140,11 +140,11 @@ void player_board (void)
     * run hook if needed
     */
    hparam[0].type       = HOOK_PARAM_PILOT;
-   hparam[0].u.lp.pilot = p->id;
+   hparam[0].u.lp       = p->id;
    hparam[1].type       = HOOK_PARAM_SENTINEL;
    hooks_runParam( "board", hparam );
    pilot_runHookParam(p, PILOT_HOOK_BOARD, hparam, 1);
-   hparam[0].u.lp.pilot = PLAYER_ID;
+   hparam[0].u.lp       = PLAYER_ID;
    pilot_runHookParam(p, PILOT_HOOK_BOARDING, hparam, 1);
 
    if (board_stopboard) {
@@ -559,10 +559,10 @@ int pilot_board( Pilot *p )
 
    /* Run pilot board hook. */
    hparam[0].type       = HOOK_PARAM_PILOT;
-   hparam[0].u.lp.pilot = p->id;
+   hparam[0].u.lp       = p->id;
    hparam[1].type       = HOOK_PARAM_SENTINEL;
    pilot_runHookParam(target, PILOT_HOOK_BOARDING, hparam, 1);
-   hparam[0].u.lp.pilot = target->id;
+   hparam[0].u.lp       = target->id;
    pilot_runHookParam(target, PILOT_HOOK_BOARD, hparam, 1);
 
    return 1;

--- a/src/comm.c
+++ b/src/comm.c
@@ -150,7 +150,7 @@ int comm_openPilot( unsigned int pilot )
 
    /* Run generic hail hooks. */
    hparam[0].type       = HOOK_PARAM_PILOT;
-   hparam[0].u.lp.pilot = p->id;
+   hparam[0].u.lp       = p->id;
    hparam[1].type       = HOOK_PARAM_SENTINEL;
    run = 0;
    run += hooks_runParam( "hail", hparam );

--- a/src/escort.c
+++ b/src/escort.c
@@ -180,7 +180,6 @@ static int escort_command( Pilot *parent, int cmd, int param )
    int i, n;
    lua_State *L;
    Pilot *e;
-   LuaPilot p;
    char *buf;
 
    if (parent->nescorts == 0)
@@ -223,8 +222,7 @@ static int escort_command( Pilot *parent, int cmd, int param )
       }
       lua_getglobal(L, buf);
       if (param >= 0){
-         p.pilot = param;
-         lua_pushpilot(L, p);
+         lua_pushpilot(L, param);
       }
 
       /* Run command. */

--- a/src/nlua_camera.c
+++ b/src/nlua_camera.c
@@ -79,17 +79,17 @@ int nlua_loadCamera( lua_State *L, int readonly )
 static int camL_set( lua_State *L )
 {
    LuaPilot lp;
-   LuaVector *lv;
+   Vector2d *vec;
    Pilot *p;
    int soft_over, speed;
 
    /* Handle arguments. */
    lp = 0;
-   lv = NULL;
+   vec = NULL;
    if (lua_ispilot(L,1))
       lp = lua_topilot(L,1);
    else if (lua_isvector(L,1))
-      lv = lua_tovector(L,1);
+      vec = lua_tovector(L,1);
    soft_over = lua_toboolean(L,2);
    if (lua_isnumber(L,3))
       speed = luaL_checkinteger(L,3);
@@ -102,8 +102,8 @@ static int camL_set( lua_State *L )
       if (p != NULL)
          cam_setTargetPilot( p->id, soft_over*speed );
    }
-   else if (lv != NULL)
-      cam_setTargetPos( lv->vec.x, lv->vec.y, soft_over*speed );
+   else if (vec != NULL)
+      cam_setTargetPos( vec->x, vec->y, soft_over*speed );
    else {
       if (player.p != NULL)
          cam_setTargetPilot( player.p->id, soft_over*speed );

--- a/src/nlua_camera.c
+++ b/src/nlua_camera.c
@@ -78,13 +78,13 @@ int nlua_loadCamera( lua_State *L, int readonly )
  */
 static int camL_set( lua_State *L )
 {
-   LuaPilot *lp;
+   LuaPilot lp;
    LuaVector *lv;
    Pilot *p;
    int soft_over, speed;
 
    /* Handle arguments. */
-   lp = NULL;
+   lp = 0;
    lv = NULL;
    if (lua_ispilot(L,1))
       lp = lua_topilot(L,1);
@@ -97,8 +97,8 @@ static int camL_set( lua_State *L )
       speed = 2500;
 
    /* Set the camera. */
-   if (lp != NULL) {
-      p = pilot_get( lp->pilot );
+   if (lp != 0) {
+      p = pilot_get( lp );
       if (p != NULL)
          cam_setTargetPilot( p->id, soft_over*speed );
    }

--- a/src/nlua_hook.c
+++ b/src/nlua_hook.c
@@ -681,7 +681,7 @@ static int hook_safe( lua_State *L )
 static int hook_pilot( lua_State *L )
 {
    unsigned int h;
-   LuaPilot *p;
+   LuaPilot p;
    int type;
    const char *hook_type;
    char buf[ PATH_MAX ];
@@ -690,7 +690,7 @@ static int hook_pilot( lua_State *L )
    if (lua_ispilot(L,1))
       p           = luaL_checkpilot(L,1);
    else if (lua_isnil(L,1))
-      p           = NULL;
+      p           = 0;
    else {
       NLUA_ERROR(L, "Invalid parameter #1 for hook.pilot, expecting pilot or nil.");
       return 0;
@@ -718,10 +718,10 @@ static int hook_pilot( lua_State *L )
    /* actually add the hook */
    nsnprintf( buf, sizeof(buf), "p_%s", hook_type );
    h = hook_generic( L, buf, 0., 3, 0 );
-   if (p==NULL)
+   if (p==0)
       pilots_addGlobalHook( type, h );
    else
-      pilot_addHook( pilot_get(p->pilot), type, h );
+      pilot_addHook( pilot_get(p), type, h );
 
    lua_pushnumber( L, h );
    return 1;

--- a/src/nlua_jump.c
+++ b/src/nlua_jump.c
@@ -334,10 +334,8 @@ static int jumpL_eq( lua_State *L )
 static int jumpL_position( lua_State *L )
 {
    JumpPoint *jp;
-   LuaVector v;
    jp = luaL_validjump(L,1);
-   vectcpy(&v.vec, &jp->pos);
-   lua_pushvector(L, v);
+   lua_pushvector(L, jp->pos);
    return 1;
 }
 

--- a/src/nlua_outfit.c
+++ b/src/nlua_outfit.c
@@ -96,9 +96,9 @@ int nlua_loadOutfit( lua_State *L, int readonly )
  *    @param ind Index position to find the outfit.
  *    @return Outfit found at the index in the state.
  */
-LuaOutfit* lua_tooutfit( lua_State *L, int ind )
+Outfit* lua_tooutfit( lua_State *L, int ind )
 {
-   return (LuaOutfit*) lua_touserdata(L,ind);
+   return *((Outfit**) lua_touserdata(L,ind));
 }
 /**
  * @brief Gets outfit at index or raises error if there is no outfit at index.
@@ -107,7 +107,7 @@ LuaOutfit* lua_tooutfit( lua_State *L, int ind )
  *    @param ind Index position to find outfit.
  *    @return Outfit found at the index in the state.
  */
-LuaOutfit* luaL_checkoutfit( lua_State *L, int ind )
+Outfit* luaL_checkoutfit( lua_State *L, int ind )
 {
    if (lua_isoutfit(L,ind))
       return lua_tooutfit(L,ind);
@@ -123,13 +123,10 @@ LuaOutfit* luaL_checkoutfit( lua_State *L, int ind )
  */
 Outfit* luaL_validoutfit( lua_State *L, int ind )
 {
-   LuaOutfit *lo;
    Outfit *o;
 
-   if (lua_isoutfit(L, ind)) {
-      lo = luaL_checkoutfit(L,ind);
-      o  = lo->outfit;
-   }
+   if (lua_isoutfit(L, ind))
+      o  = luaL_checkoutfit(L,ind);
    else if (lua_isstring(L, ind))
       o = outfit_get( lua_tostring(L, ind) );
    else {
@@ -149,10 +146,10 @@ Outfit* luaL_validoutfit( lua_State *L, int ind )
  *    @param outfit Outfit to push.
  *    @return Newly pushed outfit.
  */
-LuaOutfit* lua_pushoutfit( lua_State *L, LuaOutfit outfit )
+Outfit** lua_pushoutfit( lua_State *L, Outfit *outfit )
 {
-   LuaOutfit *o;
-   o = (LuaOutfit*) lua_newuserdata(L, sizeof(LuaOutfit));
+   Outfit **o;
+   o = (Outfit**) lua_newuserdata(L, sizeof(Outfit*));
    *o = outfit;
    luaL_getmetatable(L, OUTFIT_METATABLE);
    lua_setmetatable(L, -2);
@@ -194,10 +191,11 @@ int lua_isoutfit( lua_State *L, int ind )
  */
 static int outfitL_eq( lua_State *L )
 {
-   LuaOutfit *a, *b;
+   Outfit *a, *b;
+
    a = luaL_checkoutfit(L,1);
    b = luaL_checkoutfit(L,2);
-   if (a->outfit == b->outfit)
+   if (a == b)
       lua_pushboolean(L,1);
    else
       lua_pushboolean(L,0);
@@ -219,14 +217,14 @@ static int outfitL_eq( lua_State *L )
 static int outfitL_get( lua_State *L )
 {
    const char *name;
-   LuaOutfit lo;
+   Outfit *lo;
 
    /* Handle parameters. */
    name = luaL_checkstring(L,1);
 
    /* Get outfit. */
-   lo.outfit = outfit_get( name );
-   if (lo.outfit == NULL) {
+   lo = outfit_get( name );
+   if (lo == NULL) {
       NLUA_ERROR(L,"Outfit '%s' not found!", name);
       return 0;
    }

--- a/src/nlua_outfit.h
+++ b/src/nlua_outfit.h
@@ -15,14 +15,6 @@
 #define OUTFIT_METATABLE   "outfit" /**< Outfit metatable identifier. */
 
 
-/**
- * @brief Lua Outfit wrapper.
- */
-typedef struct LuaOutfit_s {
-   Outfit *outfit; /**< Outfit pointer. */
-} LuaOutfit; /**< Wrapper for a Outfit. */
-
-
 /*
  * Library loading
  */
@@ -31,10 +23,10 @@ int nlua_loadOutfit( lua_State *L, int readonly );
 /*
  * Outfit operations
  */
-LuaOutfit* lua_tooutfit( lua_State *L, int ind );
-LuaOutfit* luaL_checkoutfit( lua_State *L, int ind );
+Outfit* lua_tooutfit( lua_State *L, int ind );
+Outfit* luaL_checkoutfit( lua_State *L, int ind );
 Outfit* luaL_validoutfit( lua_State *L, int ind );
-LuaOutfit* lua_pushoutfit( lua_State *L, LuaOutfit outfit );
+Outfit** lua_pushoutfit( lua_State *L, Outfit* outfit );
 int lua_isoutfit( lua_State *L, int ind );
 
 

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -3424,14 +3424,12 @@ static int pilotL_flags( lua_State *L )
 static int pilotL_ship( lua_State *L )
 {
    Pilot *p;
-   LuaShip ls;
 
    /* Get the pilot. */
    p  = luaL_validpilot(L,1);
 
    /* Create the ship. */
-   ls.ship = p->ship;
-   lua_pushship(L, ls);
+   lua_pushship(L, p->ship);
    return 1;
 }
 

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -1041,7 +1041,6 @@ static int pilotL_inrange( lua_State *L )
  */
 static int pilotL_nav( lua_State *L )
 {
-   LuaPlanet lp;
    LuaSystem ls;
    Pilot *p;
 
@@ -1053,10 +1052,8 @@ static int pilotL_nav( lua_State *L )
    /* Get planet target. */
    if (p->nav_planet < 0)
       lua_pushnil(L);
-   else {
-      lp.id = cur_system->planets[ p->nav_planet ]->id;
-      lua_pushplanet( L, lp  );
-   }
+   else
+      lua_pushplanet( L, cur_system->planets[ p->nav_planet ]->id );
 
    /* Get hyperspace target. */
    if (p->nav_hyperspace < 0)

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -1617,7 +1617,6 @@ static int pilotL_outfits( lua_State *L )
 {
    int i, j;
    Pilot *p;
-   LuaOutfit lo;
 
    /* Parse parameters */
    p  = luaL_validpilot(L,1);
@@ -1631,9 +1630,8 @@ static int pilotL_outfits( lua_State *L )
          continue;
 
       /* Set the outfit. */
-      lo.outfit = p->outfits[i]->outfit;
       lua_pushnumber( L, j++ );
-      lua_pushoutfit( L, lo );
+      lua_pushoutfit( L, p->outfits[i]->outfit );
       lua_rawset( L, -3 );
    }
 

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -424,7 +424,6 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
    Vector2d vv,vp, vn;
    FleetPilot *plt;
    LuaFaction lf;
-   LuaVector *lv;
    LuaSystem *ls;
    StarSystem *ss;
    Planet *planet;
@@ -476,8 +475,7 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
 
    /* Handle third argument. */
    if (lua_isvector(L,3)) {
-      lv = lua_tovector(L,3);
-      vectcpy( &vp, &lv->vec );
+      vp = *lua_tovector(L,3);
       a = RNGF() * 2.*M_PI;
       vectnull( &vv );
    }
@@ -1684,14 +1682,12 @@ static int pilotL_rename( lua_State *L )
 static int pilotL_position( lua_State *L )
 {
    Pilot *p;
-   LuaVector v;
 
    /* Parse parameters */
    p     = luaL_validpilot(L,1);
 
    /* Push position. */
-   vectcpy( &v.vec, &p->solid->pos );
-   lua_pushvector(L, v);
+   lua_pushvector(L, p->solid->pos);
    return 1;
 }
 
@@ -1707,14 +1703,12 @@ static int pilotL_position( lua_State *L )
 static int pilotL_velocity( lua_State *L )
 {
    Pilot *p;
-   LuaVector v;
 
    /* Parse parameters */
    p     = luaL_validpilot(L,1);
 
    /* Push velocity. */
-   vectcpy( &v.vec, &p->solid->vel );
-   lua_pushvector(L, v);
+   lua_pushvector(L, p->solid->vel);
    return 1;
 }
 
@@ -1839,14 +1833,14 @@ static int pilotL_spaceworthy( lua_State *L )
 static int pilotL_setPosition( lua_State *L )
 {
    Pilot *p;
-   LuaVector *v;
+   Vector2d *vec;
 
    /* Parse parameters */
    p     = luaL_validpilot(L,1);
-   v     = luaL_checkvector(L,2);
+   vec   = luaL_checkvector(L,2);
 
    /* Warp pilot to new position. */
-   vectcpy( &p->solid->pos, &v->vec );
+   vectcpy( &p->solid->pos, vec );
 
    /* Update if necessary. */
    if (pilot_isPlayer(p))
@@ -1867,14 +1861,14 @@ static int pilotL_setPosition( lua_State *L )
 static int pilotL_setVelocity( lua_State *L )
 {
    Pilot *p;
-   LuaVector *v;
+   Vector2d *vec;
 
    /* Parse parameters */
    p     = luaL_validpilot(L,1);
-   v     = luaL_checkvector(L,2);
+   vec   = luaL_checkvector(L,2);
 
    /* Warp pilot to new position. */
-   vectcpy( &p->solid->vel, &v->vec );
+   vectcpy( &p->solid->vel, vec );
    return 0;
 }
 
@@ -3698,13 +3692,13 @@ static int pilotL_goto( lua_State *L )
 {
    Pilot *p;
    Task *t;
-   LuaVector *lv;
+   Vector2d *vec;
    int brake, compensate;
    const char *tsk;
 
    /* Get parameters. */
    p  = luaL_validpilot(L,1);
-   lv = luaL_checkvector(L,2);
+   vec = luaL_checkvector(L,2);
    if (lua_gettop(L) > 2)
       brake = lua_toboolean(L,3);
    else
@@ -3727,7 +3721,7 @@ static int pilotL_goto( lua_State *L )
    }
    t        = pilotL_newtask( L, p, tsk );
    t->dtype = TASKDATA_VEC2;
-   vectcpy( &t->dat.vec, &lv->vec );
+   vectcpy( &t->dat.vec, vec );
 
    return 0;
 }
@@ -3748,18 +3742,18 @@ static int pilotL_goto( lua_State *L )
 static int pilotL_face( lua_State *L )
 {
    Pilot *p, *pt;
-   LuaVector *vt;
+   Vector2d *vec;
    Task *t;
    int towards;
 
    /* Get parameters. */
    pt = NULL;
-   vt = NULL;
+   vec = NULL;
    p  = luaL_validpilot(L,1);
    if (lua_ispilot(L,2))
       pt = luaL_validpilot(L,2);
    else
-      vt = luaL_checkvector(L,2);
+      vec = luaL_checkvector(L,2);
    if (lua_gettop(L) > 2)
       towards = lua_toboolean(L,3);
    else
@@ -3776,7 +3770,7 @@ static int pilotL_face( lua_State *L )
    }
    else {
       t->dtype = TASKDATA_VEC2;
-      vectcpy( &t->dat.vec, &vt->vec );
+      vectcpy( &t->dat.vec, vec );
    }
 
    return 0;

--- a/src/nlua_pilot.h
+++ b/src/nlua_pilot.h
@@ -18,9 +18,7 @@
 /**
  * @brief Lua Pilot wrapper.
  */
-typedef struct LuaPilot_s {
-   unsigned int pilot; /**< ID of the pilot. */
-} LuaPilot; /**< Wrapper for a Pilot. */
+typedef unsigned int LuaPilot; /**< Wrapper for a Pilot. */
 
 
 /*
@@ -31,8 +29,8 @@ int nlua_loadPilot( lua_State *L, int readonly );
 /*
  * Pilot operations
  */
-LuaPilot* lua_topilot( lua_State *L, int ind );
-LuaPilot* luaL_checkpilot( lua_State *L, int ind );
+LuaPilot lua_topilot( lua_State *L, int ind );
+LuaPilot luaL_checkpilot( lua_State *L, int ind );
 LuaPilot* lua_pushpilot( lua_State *L, LuaPilot pilot );
 Pilot* luaL_validpilot( lua_State *L, int ind );
 int lua_ispilot( lua_State *L, int ind );

--- a/src/nlua_planet.c
+++ b/src/nlua_planet.c
@@ -779,7 +779,6 @@ static int planetL_shipsSold( lua_State *L )
 {
    Planet *p;
    int i, n;
-   LuaShip ls;
    Ship **s;
 
    /* Get result and tech. */
@@ -790,8 +789,7 @@ static int planetL_shipsSold( lua_State *L )
    lua_newtable(L);
    for (i=0; i<n; i++) {
       lua_pushnumber(L,i+1); /* index, starts with 1 */
-      ls.ship = s[i];
-      lua_pushship(L,ls); /* value = LuaShip */
+      lua_pushship(L,s[i]); /* value = LuaShip */
       lua_rawset(L,-3); /* store the value in the table */
    }
 

--- a/src/nlua_planet.c
+++ b/src/nlua_planet.c
@@ -801,7 +801,6 @@ static int planetL_outfitsSold( lua_State *L )
 {
    Planet *p;
    int i, n;
-   LuaOutfit lo;
    Outfit **o;
 
    /* Get result and tech. */
@@ -812,8 +811,7 @@ static int planetL_outfitsSold( lua_State *L )
    lua_newtable(L);
    for (i=0; i<n; i++) {
       lua_pushnumber(L,i+1); /* index, starts with 1 */
-      lo.outfit = o[i];
-      lua_pushoutfit(L,lo); /* value = LuaOutfit */
+      lua_pushoutfit(L,o[i]); /* value = LuaOutfit */
       lua_rawset(L,-3); /* store the value in the table */
    }
 

--- a/src/nlua_planet.c
+++ b/src/nlua_planet.c
@@ -197,7 +197,7 @@ Planet* luaL_validplanet( lua_State *L, int ind )
 
    if (lua_isplanet(L, ind)) {
       lp = luaL_checkplanet(L, ind);
-      p  = planet_getIndex(lp->id);
+      p  = planet_getIndex(*lp);
    }
    else if (lua_isstring(L, ind))
       p = planet_get( lua_tostring(L, ind) );
@@ -261,14 +261,12 @@ int lua_isplanet( lua_State *L, int ind )
  */
 static int planetL_cur( lua_State *L )
 {
-   LuaPlanet planet;
    LuaSystem sys;
    if (land_planet == NULL) {
       NLUA_ERROR(L,"Attempting to get landed planet when player not landed.");
       return 0; /* Not landed. */
    }
-   planet.id = planet_index(land_planet);
-   lua_pushplanet(L,planet);
+   lua_pushplanet(L,planet_index(land_planet));
    sys.id = system_index( system_get( planet_getSystem(land_planet->name) ) );
    lua_pushsystem(L,sys);
    return 2;
@@ -283,7 +281,6 @@ static int planetL_getBackend( lua_State *L, int landable )
    char **planets;
    int nplanets;
    const char *rndplanet;
-   LuaPlanet planet;
    LuaSystem luasys;
    LuaFaction *f;
    Planet *pnt;
@@ -297,8 +294,7 @@ static int planetL_getBackend( lua_State *L, int landable )
    /* If boolean return random. */
    if (lua_isboolean(L,1)) {
       pnt            = planet_get( space_getRndPlanet(landable, 0, NULL) );
-      planet.id      = planet_index( pnt );
-      lua_pushplanet(L,planet);
+      lua_pushplanet(L,planet_index( pnt ));
       luasys.id      = system_index( system_get( planet_getSystem(pnt->name) ) );
       lua_pushsystem(L,luasys);
       return 2;
@@ -392,8 +388,7 @@ static int planetL_getBackend( lua_State *L, int landable )
       NLUA_ERROR(L, "Planet '%s' can't find system '%s'", rndplanet, sysname);
       return 0;
    }
-   planet.id = planet_index( pnt );
-   lua_pushplanet(L,planet);
+   lua_pushplanet(L,planet_index( pnt ));
    luasys.id = system_index( sys );
    lua_pushsystem(L,luasys);
    return 2;
@@ -446,7 +441,6 @@ static int planetL_getLandable( lua_State *L )
  */
 static int planetL_getAll( lua_State *L )
 {
-   LuaPlanet lp;
    Planet *p;
    int i, ind, n;
 
@@ -457,9 +451,8 @@ static int planetL_getAll( lua_State *L )
       /* Ignore virtual assets. */
       if (p[i].real == ASSET_VIRTUAL)
          continue;
-      lp.id = planet_index( &p[i] );
       lua_pushnumber( L, ind++ );
-      lua_pushplanet( L, lp );
+      lua_pushplanet( L, planet_index( &p[i] ) );
       lua_settable(   L, -3 );
    }
    return 1;
@@ -502,7 +495,7 @@ static int planetL_eq( lua_State *L )
    LuaPlanet *a, *b;
    a = luaL_checkplanet(L,1);
    b = luaL_checkplanet(L,2);
-   lua_pushboolean(L,(a->id == b->id));
+   lua_pushboolean(L,(a == b));
    return 1;
 }
 

--- a/src/nlua_planet.c
+++ b/src/nlua_planet.c
@@ -721,10 +721,8 @@ static int planetL_getLandOverride( lua_State *L )
 static int planetL_position( lua_State *L )
 {
    Planet *p;
-   LuaVector v;
    p = luaL_validplanet(L,1);
-   vectcpy(&v.vec, &p->pos);
-   lua_pushvector(L, v);
+   lua_pushvector(L, p->pos);
    return 1;
 }
 

--- a/src/nlua_planet.h
+++ b/src/nlua_planet.h
@@ -18,9 +18,7 @@
 /**
  * @brief Lua Planet Wrapper.
  */
-typedef struct LuaPlanet_s {
-   int id; /**< ID to the planet. */
-} LuaPlanet;
+typedef int LuaPlanet;
 
 
 /*

--- a/src/nlua_player.c
+++ b/src/nlua_player.c
@@ -779,7 +779,6 @@ static int playerL_shipOutfits( lua_State *L )
    int i, j, nships;
    const PlayerShip_t *ships;
    Pilot *p;
-   LuaOutfit lo;
 
    /* Get name. */
    str = luaL_checkstring(L, 1);
@@ -813,9 +812,8 @@ static int playerL_shipOutfits( lua_State *L )
          continue;
 
       /* Set the outfit. */
-      lo.outfit = p->outfits[i]->outfit;
       lua_pushnumber( L, j++ );
-      lua_pushoutfit( L, lo );
+      lua_pushoutfit( L, p->outfits[i]->outfit );
       lua_rawset( L, -3 );
    }
 
@@ -836,15 +834,13 @@ static int playerL_outfits( lua_State *L )
 {
    int i, noutfits;
    const PlayerOutfit_t *outfits;
-   LuaOutfit lo;
 
    outfits = player_getOutfits( &noutfits );
 
    lua_newtable(L);
    for (i=0; i<noutfits; i++) {
-      lo.outfit = (Outfit*)outfits[i].o;
       lua_pushnumber(L, i+1);
-      lua_pushoutfit(L, lo );
+      lua_pushoutfit(L, (Outfit*)outfits[i].o );
       lua_rawset(L, -3);
    }
 

--- a/src/nlua_player.c
+++ b/src/nlua_player.c
@@ -421,9 +421,7 @@ static int playerL_getPosition( lua_State *L )
  */
 static int playerL_getPilot( lua_State *L )
 {
-   LuaPilot lp;
-   lp.pilot = PLAYER_ID;
-   lua_pushpilot(L, lp);
+   lua_pushpilot(L, PLAYER_ID);
    return 1;
 }
 

--- a/src/nlua_player.c
+++ b/src/nlua_player.c
@@ -406,10 +406,7 @@ static int playerL_getRating( lua_State *L )
  */
 static int playerL_getPosition( lua_State *L )
 {
-   LuaVector v;
-
-   vectcpy( &v.vec, &player.p->solid->pos );
-   lua_pushvector(L, v);
+   lua_pushvector(L, player.p->solid->pos);
    return 1;
 }
 

--- a/src/nlua_ship.c
+++ b/src/nlua_ship.c
@@ -341,7 +341,6 @@ static int shipL_getSlots( lua_State *L )
    Ship *s;
    OutfitSlot *slot;
    ShipOutfitSlot *sslot;
-   LuaOutfit lo;
    char *outfit_types[] = {"structure", "utility", "weapon"};
 
    s = luaL_validship(L,1);
@@ -387,9 +386,8 @@ static int shipL_getSlots( lua_State *L )
       lua_rawset(L, -3); /* table[key] = value */
 
       if (sslot->data != NULL) {
-         lo.outfit = sslot->data;
          lua_pushstring(L, "outfit"); /* key */
-         lua_pushoutfit(L, lo); /* value*/
+         lua_pushoutfit(L, sslot->data); /* value*/
          lua_rawset(L, -3); /* table[key] = value */
       }
 

--- a/src/nlua_ship.c
+++ b/src/nlua_ship.c
@@ -103,9 +103,9 @@ int nlua_loadShip( lua_State *L, int readonly )
  *    @param ind Index position to find the ship.
  *    @return Ship found at the index in the state.
  */
-LuaShip* lua_toship( lua_State *L, int ind )
+Ship* lua_toship( lua_State *L, int ind )
 {
-   return (LuaShip*) lua_touserdata(L,ind);
+   return *((Ship**) lua_touserdata(L,ind));
 }
 /**
  * @brief Gets ship at index or raises error if there is no ship at index.
@@ -114,7 +114,7 @@ LuaShip* lua_toship( lua_State *L, int ind )
  *    @param ind Index position to find ship.
  *    @return Ship found at the index in the state.
  */
-LuaShip* luaL_checkship( lua_State *L, int ind )
+Ship* luaL_checkship( lua_State *L, int ind )
 {
    if (lua_isship(L,ind))
       return lua_toship(L,ind);
@@ -130,13 +130,10 @@ LuaShip* luaL_checkship( lua_State *L, int ind )
  */
 Ship* luaL_validship( lua_State *L, int ind )
 {
-   LuaShip *ls;
    Ship *s;
 
-   if (lua_isship(L, ind)) {
-      ls = luaL_checkship(L,ind);
-      s  = ls->ship;
-   }
+   if (lua_isship(L, ind))
+      s = luaL_checkship(L,ind);
    else if (lua_isstring(L, ind))
       s = ship_get( lua_tostring(L, ind) );
    else {
@@ -156,10 +153,10 @@ Ship* luaL_validship( lua_State *L, int ind )
  *    @param ship Ship to push.
  *    @return Newly pushed ship.
  */
-LuaShip* lua_pushship( lua_State *L, LuaShip ship )
+Ship** lua_pushship( lua_State *L, Ship *ship )
 {
-   LuaShip *p;
-   p = (LuaShip*) lua_newuserdata(L, sizeof(LuaShip));
+   Ship **p;
+   p = (Ship**) lua_newuserdata(L, sizeof(Ship*));
    *p = ship;
    luaL_getmetatable(L, SHIP_METATABLE);
    lua_setmetatable(L, -2);
@@ -201,10 +198,10 @@ int lua_isship( lua_State *L, int ind )
  */
 static int shipL_eq( lua_State *L )
 {
-   LuaShip *a, *b;
+   Ship *a, *b;
    a = luaL_checkship(L,1);
    b = luaL_checkship(L,2);
-   if (a->ship == b->ship)
+   if (a == b)
       lua_pushboolean(L,1);
    else
       lua_pushboolean(L,0);
@@ -224,20 +221,20 @@ static int shipL_eq( lua_State *L )
 static int shipL_get( lua_State *L )
 {
    const char *name;
-   LuaShip ls;
+   Ship *ship;
 
    /* Handle parameters. */
    name = luaL_checkstring(L,1);
 
    /* Get ship. */
-   ls.ship = ship_get( name );
-   if (ls.ship == NULL) {
+   ship = ship_get( name );
+   if (ship == NULL) {
       NLUA_ERROR(L,"Ship '%s' not found!", name);
       return 0;
    }
 
    /* Push. */
-   lua_pushship(L, ls);
+   lua_pushship(L, ship);
    return 1;
 }
 /**

--- a/src/nlua_ship.h
+++ b/src/nlua_ship.h
@@ -15,14 +15,6 @@
 #define SHIP_METATABLE   "ship" /**< Ship metatable identifier. */
 
 
-/**
- * @brief Lua Ship wrapper.
- */
-typedef struct LuaShip_s {
-   Ship *ship; /**< Ship pointer. */
-} LuaShip; /**< Wrapper for a Ship. */
-
-
 /*
  * Library loading
  */
@@ -31,10 +23,10 @@ int nlua_loadShip( lua_State *L, int readonly );
 /*
  * Ship operations
  */
-LuaShip* lua_toship( lua_State *L, int ind );
-LuaShip* luaL_checkship( lua_State *L, int ind );
+Ship* lua_toship( lua_State *L, int ind );
+Ship* luaL_checkship( lua_State *L, int ind );
 Ship* luaL_validship( lua_State *L, int ind );
-LuaShip* lua_pushship( lua_State *L, LuaShip ship );
+Ship** lua_pushship( lua_State *L, Ship *ship );
 int lua_isship( lua_State *L, int ind );
 
 

--- a/src/nlua_system.c
+++ b/src/nlua_system.c
@@ -669,7 +669,6 @@ static int systemL_presences( lua_State *L )
 static int systemL_planets( lua_State *L )
 {
    int i, key;
-   LuaPlanet p;
    StarSystem *s;
 
    s = luaL_validsystem(L,1);
@@ -678,11 +677,10 @@ static int systemL_planets( lua_State *L )
    lua_newtable(L);
    key = 0;
    for (i=0; i<s->nplanets; i++) {
-      p.id = planet_index( s->planets[i] );
       if(s->planets[i]->real == ASSET_REAL) {
          key++;
          lua_pushnumber(L,key); /* key */
-         lua_pushplanet(L,p); /* value */
+         lua_pushplanet(L,planet_index( s->planets[i] )); /* value */
          lua_rawset(L,-3);
       }
    }

--- a/src/nlua_system.c
+++ b/src/nlua_system.c
@@ -886,15 +886,15 @@ static int systemL_mrkClear( lua_State *L )
 static int systemL_mrkAdd( lua_State *L )
 {
    const char *str;
-   LuaVector *lv;
+   Vector2d *vec;
    unsigned int id;
 
    /* Handle parameters. */
    str   = luaL_checkstring( L, 1 );
-   lv    = luaL_checkvector( L, 2 );
+   vec   = luaL_checkvector( L, 2 );
 
    /* Create marker. */
-   id    = ovr_mrkAddPoint( str, lv->vec.x, lv->vec.y );
+   id    = ovr_mrkAddPoint( str, vec->x, vec->y );
    lua_pushnumber( L, id );
    return 1;
 }

--- a/src/nlua_vec2.c
+++ b/src/nlua_vec2.c
@@ -111,23 +111,23 @@ int nlua_loadVector( lua_State *L )
  *
  *    @param L Lua state to get vector from.
  *    @param ind Index position of vector.
- *    @return The LuaVector at ind.
+ *    @return The Vector2d at ind.
  */
-LuaVector* lua_tovector( lua_State *L, int ind )
+Vector2d* lua_tovector( lua_State *L, int ind )
 {
-   return (LuaVector*) lua_touserdata(L,ind);
+   return (Vector2d*) lua_touserdata(L,ind);
 }
 /**
  * @brief Gets vector at index making sure type is valid.
  *
  *    @param L Lua state to get vector from.
  *    @param ind Index position of vector.
- *    @return The LuaVector at ind.
+ *    @return The Vector2d at ind.
  */
-LuaVector* luaL_checkvector( lua_State *L, int ind )
+Vector2d* luaL_checkvector( lua_State *L, int ind )
 {
    if (lua_isvector(L,ind))
-      return (LuaVector*) lua_touserdata(L,ind);
+      return (Vector2d*) lua_touserdata(L,ind);
    luaL_typerror(L, ind, VECTOR_METATABLE);
    return NULL;
 }
@@ -139,10 +139,10 @@ LuaVector* luaL_checkvector( lua_State *L, int ind )
  *    @param vec Vector to push.
  *    @return Vector just pushed.
  */
-LuaVector* lua_pushvector( lua_State *L, LuaVector vec )
+Vector2d* lua_pushvector( lua_State *L, Vector2d vec )
 {
-   LuaVector *v;
-   v = (LuaVector*) lua_newuserdata(L, sizeof(LuaVector));
+   Vector2d *v;
+   v = (Vector2d*) lua_newuserdata(L, sizeof(Vector2d));
    *v = vec;
    luaL_getmetatable(L, VECTOR_METATABLE);
    lua_setmetatable(L, -2);
@@ -185,7 +185,7 @@ int lua_isvector( lua_State *L, int ind )
  */
 static int vectorL_new( lua_State *L )
 {
-   LuaVector v;
+   Vector2d v;
    double x, y;
 
    if ((lua_gettop(L) > 1) && lua_isnumber(L,1) && lua_isnumber(L,2)) {
@@ -197,7 +197,7 @@ static int vectorL_new( lua_State *L )
       y = 0.;
    }
 
-   vect_cset( &v.vec, x, y );
+   vect_cset( &v, x, y );
    lua_pushvector(L, v);
    return 1;
 }
@@ -215,7 +215,7 @@ static int vectorL_new( lua_State *L )
  */
 static int vectorL_newP( lua_State *L )
 {
-   LuaVector v;
+   Vector2d v;
    double m, a;
 
    if ((lua_gettop(L) > 1) && lua_isnumber(L,1) && lua_isnumber(L,2)) {
@@ -227,7 +227,7 @@ static int vectorL_newP( lua_State *L )
       a = 0.;
    }
 
-   vect_pset( &v.vec, m, a );
+   vect_pset( &v, m, a );
    lua_pushvector(L, v);
    return 1;
 }
@@ -250,7 +250,7 @@ static int vectorL_newP( lua_State *L )
  */
 static int vectorL_add( lua_State *L )
 {
-   LuaVector vout, *v1, *v2;
+   Vector2d vout, *v1, *v2;
    double x, y;
 
    /* Get self. */
@@ -260,8 +260,8 @@ static int vectorL_add( lua_State *L )
    v2 = NULL;
    if (lua_isvector(L,2)) {
       v2 = lua_tovector(L,2);
-      x = v2->vec.x;
-      y = v2->vec.y;
+      x = v2->x;
+      y = v2->y;
    }
    else if ((lua_gettop(L) > 2) && lua_isnumber(L,2) && lua_isnumber(L,3)) {
       x = lua_tonumber(L,2);
@@ -273,14 +273,14 @@ static int vectorL_add( lua_State *L )
    }
 
    /* Actually add it */
-   vect_cset( &vout.vec, v1->vec.x + x, v1->vec.y + y );
+   vect_cset( &vout, v1->x + x, v1->y + y );
    lua_pushvector( L, vout );
 
    return 1;
 }
 static int vectorL_add__( lua_State *L )
 {
-   LuaVector *v1, *v2;
+   Vector2d *v1, *v2;
    double x, y;
 
    /* Get self. */
@@ -290,8 +290,8 @@ static int vectorL_add__( lua_State *L )
    v2 = NULL;
    if (lua_isvector(L,2)) {
       v2 = lua_tovector(L,2);
-      x = v2->vec.x;
-      y = v2->vec.y;
+      x = v2->x;
+      y = v2->y;
    }
    else if ((lua_gettop(L) > 2) && lua_isnumber(L,2) && lua_isnumber(L,3)) {
       x = lua_tonumber(L,2);
@@ -303,7 +303,7 @@ static int vectorL_add__( lua_State *L )
    }
 
    /* Actually add it */
-   vect_cset( &v1->vec, v1->vec.x + x, v1->vec.y + y );
+   vect_cset( v1, v1->x + x, v1->y + y );
    lua_pushvector( L, *v1 );
 
    return 1;
@@ -327,7 +327,7 @@ static int vectorL_add__( lua_State *L )
  */
 static int vectorL_sub( lua_State *L )
 {
-   LuaVector vout, *v1, *v2;
+   Vector2d vout, *v1, *v2;
    double x, y;
 
    /* Get self. */
@@ -337,8 +337,8 @@ static int vectorL_sub( lua_State *L )
    v2 = NULL;
    if (lua_isvector(L,2)) {
       v2 = lua_tovector(L,2);
-      x = v2->vec.x;
-      y = v2->vec.y;
+      x = v2->x;
+      y = v2->y;
    }
    else if ((lua_gettop(L) > 2) && lua_isnumber(L,2) && lua_isnumber(L,3)) {
       x = lua_tonumber(L,2);
@@ -350,13 +350,13 @@ static int vectorL_sub( lua_State *L )
    }
 
    /* Actually add it */
-   vect_cset( &vout.vec, v1->vec.x - x, v1->vec.y - y );
+   vect_cset( &vout, v1->x - x, v1->y - y );
    lua_pushvector( L, vout );
    return 1;
 }
 static int vectorL_sub__( lua_State *L )
 {
-   LuaVector *v1, *v2;
+   Vector2d *v1, *v2;
    double x, y;
 
    /* Get self. */
@@ -366,8 +366,8 @@ static int vectorL_sub__( lua_State *L )
    v2 = NULL;
    if (lua_isvector(L,2)) {
       v2 = lua_tovector(L,2);
-      x = v2->vec.x;
-      y = v2->vec.y;
+      x = v2->x;
+      y = v2->y;
    }
    else if ((lua_gettop(L) > 2) && lua_isnumber(L,2) && lua_isnumber(L,3)) {
       x = lua_tonumber(L,2);
@@ -379,7 +379,7 @@ static int vectorL_sub__( lua_State *L )
    }
 
    /* Actually add it */
-   vect_cset( &v1->vec, v1->vec.x - x, v1->vec.y - y );
+   vect_cset( v1, v1->x - x, v1->y - y );
    lua_pushvector( L, *v1 );
    return 1;
 }
@@ -397,7 +397,7 @@ static int vectorL_sub__( lua_State *L )
  */
 static int vectorL_mul( lua_State *L )
 {
-   LuaVector vout, *v1;
+   Vector2d vout, *v1;
    double mod;
 
    /* Get parameters. */
@@ -405,13 +405,13 @@ static int vectorL_mul( lua_State *L )
    mod   = luaL_checknumber(L,2);
 
    /* Actually add it */
-   vect_cset( &vout.vec, v1->vec.x * mod, v1->vec.y * mod );
+   vect_cset( &vout, v1->x * mod, v1->y * mod );
    lua_pushvector( L, vout );
    return 1;
 }
 static int vectorL_mul__( lua_State *L )
 {
-   LuaVector *v1;
+   Vector2d *v1;
    double mod;
 
    /* Get parameters. */
@@ -419,7 +419,7 @@ static int vectorL_mul__( lua_State *L )
    mod   = luaL_checknumber(L,2);
 
    /* Actually add it */
-   vect_cset( &v1->vec, v1->vec.x * mod, v1->vec.y * mod );
+   vect_cset( v1, v1->x * mod, v1->y * mod );
    lua_pushvector( L, *v1 );
    return 1;
 }
@@ -437,7 +437,7 @@ static int vectorL_mul__( lua_State *L )
  */
 static int vectorL_div( lua_State *L )
 {
-   LuaVector vout, *v1;
+   Vector2d vout, *v1;
    double mod;
 
    /* Get parameters. */
@@ -445,13 +445,13 @@ static int vectorL_div( lua_State *L )
    mod   = luaL_checknumber(L,2);
 
    /* Actually add it */
-   vect_cset( &vout.vec, v1->vec.x / mod, v1->vec.y / mod );
+   vect_cset( &vout, v1->x / mod, v1->y / mod );
    lua_pushvector( L, vout );
    return 1;
 }
 static int vectorL_div__( lua_State *L )
 {
-   LuaVector *v1;
+   Vector2d *v1;
    double mod;
 
    /* Get parameters. */
@@ -459,7 +459,7 @@ static int vectorL_div__( lua_State *L )
    mod   = luaL_checknumber(L,2);
 
    /* Actually add it */
-   vect_cset( &v1->vec, v1->vec.x / mod, v1->vec.y / mod );
+   vect_cset( v1, v1->x / mod, v1->y / mod );
    lua_pushvector( L, *v1 );
    return 1;
 }
@@ -476,14 +476,14 @@ static int vectorL_div__( lua_State *L )
  */
 static int vectorL_get( lua_State *L )
 {
-   LuaVector *v1;
+   Vector2d *v1;
 
    /* Get self. */
    v1 = luaL_checkvector(L,1);
 
    /* Push the vector. */
-   lua_pushnumber(L, v1->vec.x);
-   lua_pushnumber(L, v1->vec.y);
+   lua_pushnumber(L, v1->x);
+   lua_pushnumber(L, v1->y);
    return 2;
 }
 
@@ -500,13 +500,13 @@ static int vectorL_get( lua_State *L )
  */
 static int vectorL_polar( lua_State *L )
 {
-   LuaVector *v1;
+   Vector2d *v1;
 
    /* Get self. */
    v1 = luaL_checkvector(L,1);
 
-   lua_pushnumber(L, VMOD(v1->vec));
-   lua_pushnumber(L, VANGLE(v1->vec)*180./M_PI);
+   lua_pushnumber(L, VMOD(*v1));
+   lua_pushnumber(L, VANGLE(*v1)*180./M_PI);
    return 2;
 }
 
@@ -522,7 +522,7 @@ static int vectorL_polar( lua_State *L )
  */
 static int vectorL_set( lua_State *L )
 {
-   LuaVector *v1;
+   Vector2d *v1;
    double x, y;
 
    /* Get parameters. */
@@ -530,7 +530,7 @@ static int vectorL_set( lua_State *L )
    x  = luaL_checknumber(L,2);
    y  = luaL_checknumber(L,3);
 
-   vect_cset( &v1->vec, x, y );
+   vect_cset( v1, x, y );
    return 0;
 }
 
@@ -546,7 +546,7 @@ static int vectorL_set( lua_State *L )
  */
 static int vectorL_setP( lua_State *L )
 {
-   LuaVector *v1;
+   Vector2d *v1;
    double m, a;
 
    /* Get parameters. */
@@ -554,7 +554,7 @@ static int vectorL_setP( lua_State *L )
    m  = luaL_checknumber(L,2);
    a  = luaL_checknumber(L,3)/180.*M_PI;
 
-   vect_pset( &v1->vec, m, a );
+   vect_pset( v1, m, a );
    return 0;
 }
 
@@ -571,7 +571,7 @@ static int vectorL_setP( lua_State *L )
  */
 static int vectorL_distance( lua_State *L )
 {
-   LuaVector *v1, *v2;
+   Vector2d *v1, *v2;
    double dist;
 
    /* Get self. */
@@ -585,9 +585,9 @@ static int vectorL_distance( lua_State *L )
 
    /* Get distance. */
    if (v2 == NULL)
-      dist = vect_odist(&v1->vec);
+      dist = vect_odist(v1);
    else
-      dist = vect_dist(&v1->vec, &v2->vec);
+      dist = vect_dist(v1, v2);
 
    /* Return the distance. */
    lua_pushnumber(L, dist);
@@ -607,7 +607,7 @@ static int vectorL_distance( lua_State *L )
  */
 static int vectorL_distance2( lua_State *L )
 {
-   LuaVector *v1, *v2;
+   Vector2d *v1, *v2;
    double dist2;
 
    /* Get self. */
@@ -621,9 +621,9 @@ static int vectorL_distance2( lua_State *L )
 
    /* Get distance. */
    if (v2 == NULL)
-      dist2 = vect_odist2(&v1->vec);
+      dist2 = vect_odist2(v1);
    else
-      dist2 = vect_dist2(&v1->vec, &v2->vec);
+      dist2 = vect_dist2(v1, v2);
 
    /* Return the distance. */
    lua_pushnumber(L, dist2);
@@ -638,10 +638,10 @@ static int vectorL_distance2( lua_State *L )
  */
 static int vectorL_mod( lua_State *L )
 {
-   LuaVector *v;
+   Vector2d *v;
 
    v = luaL_checkvector(L,1);
-   lua_pushnumber(L, VMOD(v->vec));
+   lua_pushnumber(L, VMOD(*v));
    return 1;
 }
 

--- a/src/nlua_vec2.h
+++ b/src/nlua_vec2.h
@@ -14,14 +14,6 @@
 #define VECTOR_METATABLE   "vec2"   /**< Vector metatable identifier. */
 
 
-/**
- * @brief Lua Vector2d Wrapper.
- */
-typedef struct LuaVector_s {
-   Vector2d vec; /**< The actual Vector2d. */
-} LuaVector;
-
-
 /*
  * Vector library.
  */
@@ -30,9 +22,9 @@ int nlua_loadVector( lua_State *L );
 /*
  * Vector operations.
  */
-LuaVector* lua_tovector( lua_State *L, int ind );
-LuaVector* luaL_checkvector( lua_State *L, int ind );
-LuaVector* lua_pushvector( lua_State *L, LuaVector vec );
+Vector2d* lua_tovector( lua_State *L, int ind );
+Vector2d* luaL_checkvector( lua_State *L, int ind );
+Vector2d* lua_pushvector( lua_State *L, Vector2d vec );
 int lua_isvector( lua_State *L, int ind );
 
 

--- a/src/nxml_lua.c
+++ b/src/nxml_lua.c
@@ -92,7 +92,6 @@ static int nxml_saveJump( xmlTextWriterPtr writer,
 static int nxml_persistDataNode( lua_State *L, xmlTextWriterPtr writer, int intable )
 {
    int ret, b;
-   LuaPlanet *p;
    LuaSystem *s;
    LuaFaction *f;
    Ship *sh;
@@ -190,8 +189,7 @@ static int nxml_persistDataNode( lua_State *L, xmlTextWriterPtr writer, int inta
       /* User data must be handled here. */
       case LUA_TUSERDATA:
          if (lua_isplanet(L,-1)) {
-            p = lua_toplanet(L,-1);
-            pnt = planet_getIndex( p->id );
+            pnt = planet_getIndex( *lua_toplanet(L,-1) );
             if (pnt != NULL)
                nxml_saveData( writer, "planet",
                      name, pnt->name, keynum );
@@ -297,7 +295,6 @@ int nxml_persistLua( lua_State *L, xmlTextWriterPtr writer )
  */
 static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
 {
-   LuaPlanet p;
    LuaSystem s;
    LuaFaction f;
    LuaTime lt;
@@ -342,8 +339,7 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
          else if (strcmp(type,"planet")==0) {
             pnt = planet_get(xml_get(node));
             if (pnt != NULL) {
-               p.id = planet_index(pnt);
-               lua_pushplanet(L,p);
+               lua_pushplanet(L,planet_index(pnt));
             }
             else
                WARN("Failed to load unexistent planet '%s'", xml_get(node));

--- a/src/nxml_lua.c
+++ b/src/nxml_lua.c
@@ -95,7 +95,7 @@ static int nxml_persistDataNode( lua_State *L, xmlTextWriterPtr writer, int inta
    LuaPlanet *p;
    LuaSystem *s;
    LuaFaction *f;
-   LuaShip *sh;
+   Ship *sh;
    LuaTime *lt;
    LuaJump *lj;
    Planet *pnt;
@@ -223,7 +223,7 @@ static int nxml_persistDataNode( lua_State *L, xmlTextWriterPtr writer, int inta
          }
          else if (lua_isship(L,-1)) {
             sh = lua_toship(L,-1);
-            str = sh->ship->name;
+            str = sh->name;
             if (str == NULL)
                break;
             nxml_saveData( writer, "ship",
@@ -300,7 +300,6 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
    LuaPlanet p;
    LuaSystem s;
    LuaFaction f;
-   LuaShip sh;
    LuaTime lt;
    LuaJump lj;
    Planet *pnt;
@@ -362,10 +361,8 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
             f.f = faction_get(xml_get(node));
             lua_pushfaction(L,f);
          }
-         else if (strcmp(type,"ship")==0) {
-            sh.ship = ship_get(xml_get(node));
-            lua_pushship(L,sh);
-         }
+         else if (strcmp(type,"ship")==0)
+            lua_pushship(L,ship_get(xml_get(node)));
          else if (strcmp(type,"time")==0) {
             lt.t = xml_getLong(node);
             lua_pushtime(L,lt);

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -1390,7 +1390,7 @@ void pilot_updateDisable( Pilot* p, const unsigned int shooter )
       /* Run hook */
       if (shooter > 0) {
          hparam.type       = HOOK_PARAM_PILOT;
-         hparam.u.lp.pilot = shooter;
+         hparam.u.lp       = shooter;
       }
       else {
          hparam.type       = HOOK_PARAM_NIL;
@@ -1447,7 +1447,7 @@ static void pilot_dead( Pilot* p, unsigned int killer )
    /* Pilot must die before setting death flag and probably messing with other flags. */
    if (killer > 0) {
       hparam.type       = HOOK_PARAM_PILOT;
-      hparam.u.lp.pilot = killer;
+      hparam.u.lp       = killer;
    }
    else
       hparam.type       = HOOK_PARAM_NIL;

--- a/src/pilot_hook.c
+++ b/src/pilot_hook.c
@@ -44,7 +44,7 @@ int pilot_runHookParam( Pilot* p, int hook_type, HookParam* param, int nparam )
    /* Set up hook parameters. */
    if (nparam <= 3) {
       hstaparam[0].type       = HOOK_PARAM_PILOT;
-      hstaparam[0].u.lp.pilot = p->id;
+      hstaparam[0].u.lp       = p->id;
       n  = 1;
       memcpy( &hstaparam[n], param, sizeof(HookParam)*nparam );
       n += nparam;
@@ -55,7 +55,7 @@ int pilot_runHookParam( Pilot* p, int hook_type, HookParam* param, int nparam )
    else {
       hdynparam   = malloc( sizeof(HookParam) * (nparam+2) );
       hdynparam[0].type       = HOOK_PARAM_PILOT;
-      hdynparam[0].u.lp.pilot = p->id;
+      hdynparam[0].u.lp       = p->id;
       memcpy( &hdynparam[1], param, sizeof(HookParam)*nparam );
       hdynparam[nparam+1].type  = HOOK_PARAM_SENTINEL;
       hparam                  = hdynparam;

--- a/src/space.c
+++ b/src/space.c
@@ -1221,7 +1221,7 @@ void space_update( const double dt )
             hparam[0].type  = HOOK_PARAM_STRING;
             hparam[0].u.str = "asset";
             hparam[1].type  = HOOK_PARAM_ASSET;
-            hparam[1].u.la.id = cur_system->planets[i]->id;
+            hparam[1].u.la  = cur_system->planets[i]->id;
             hparam[2].type  = HOOK_PARAM_SENTINEL;
             hooks_runParam( "discover", hparam );
          }
@@ -1532,7 +1532,6 @@ void planet_updateLand( Planet *p )
    int errf;
    char *str;
    lua_State *L;
-   LuaPlanet lp;
 
    /* Must be inhabited. */
    if (!planet_hasService( p, PLANET_SERVICE_INHABITED ) ||
@@ -1563,8 +1562,7 @@ void planet_updateLand( Planet *p )
    else
       str = p->land_func;
    lua_getglobal( L, str );
-   lp.id = p->id;
-   lua_pushplanet( L, lp );
+   lua_pushplanet( L, p->id );
    if (lua_pcall(L, 1, 5, errf)) { /* error has occurred */
       WARN("Landing: '%s' : %s", str, lua_tostring(L,-1));
 #if DEBUGGING

--- a/src/space.c
+++ b/src/space.c
@@ -975,7 +975,6 @@ static void system_scheduler( double dt, int init )
    int i, n, errf;
    lua_State *L;
    SystemPresence *p;
-   LuaPilot *lp;
    Pilot *pilot;
 
    /* Go through all the factions and reduce the timer. */
@@ -1083,8 +1082,7 @@ static void system_scheduler( double dt, int init )
                lua_pop(L,2); /* tk, k */
                continue;
             }
-            lp    = lua_topilot(L,-1);
-            pilot = pilot_get( lp->pilot );
+            pilot = pilot_get( lua_topilot(L,-1) );
             if (pilot == NULL) {
                lua_pop(L,2); /* tk, k */
                continue;


### PR DESCRIPTION
Creating a `LuaPilot` struct and setting the `.pilot` property repeatedly seems verbose to me (the same applies for the other lua types).

If there is no problem with this, I will go on to make the same changes for the other lua types.