### PR TITLE
Easter Egg for Sightseeing Mission

### DIFF
--- a/dat/events/neutral/npc.lua
+++ b/dat/events/neutral/npc.lua
@@ -190,6 +190,7 @@ else --default english
                                {"Collective Espionage 1", "The Empire is trying to really do something about the Collective, I hear. Who knows, maybe you can even help them out if you make it to Omega Station."},
                                {"Hitman", "There are often shady characters hanging out in the Alteris system. I'd stay away from there if I were you, someone might offer you a dirty kind of job!"},
 							   {"Za'lek Shipping Delivery", "So there's some Za'lek scientist looking for a cargo monkey out on Niflheim in the Dohriabi system. I hear it's pretty good money."},
+                               {"Sightseeing", "Rich folk will pay extra to go on a an offworld sightseeing tour in a luxury yacht. Look like you can put a price on luxury!"},
                               }
 
    -- Event hint messages. Each element should be a table containing the event name and the corresponding hint.

--- a/dat/missions/neutral/sightseeing.lua
+++ b/dat/missions/neutral/sightseeing.lua
@@ -129,8 +129,13 @@ function create ()
    if friend < foe then
       misn.finish( false )
    end
+   if player.pilot():ship():class() == "Luxury Yacht" then
+   credits = (missys:jumpDist()*2500 + attractions*4000)*rnd.rnd(2,6)
+   credits = credits + rnd.sigma() * (credits/5)
+   else
    credits = missys:jumpDist()*2500 + attractions*4000
    credits = credits + rnd.sigma() * (credits/3)
+   end
 
    -- Set mission details
    misn.setTitle( misn_title:format( missys:name() ) )


### PR DESCRIPTION
Flying a luxury yacht (currently only the gaiwan) rewards the player 2 - 6 times more credits, maxing out around 150,000 credits. Fits into
the ship’s luxury theme and makes these missions more lucrative.

Otherwise, captains can make about 25,000 credits at most from these missions.

Players can learn about this easter egg through a mission tip from a npc in a bar.