### PR TITLE
Cargo overhaul

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -91,6 +91,23 @@
    <faction>Trader</faction>
   </avail>
  </mission>
+ <mission name="Commodity Run">
+  <lua>neutral/commodityRun</lua>
+  <avail>
+   <priority>5</priority>
+   <chance>60</chance>
+   <location>Computer</location>
+   <faction>Dvaered</faction>
+   <faction>Empire</faction>
+   <faction>Frontier</faction>
+   <faction>Goddard</faction>
+   <faction>Independent</faction>
+   <faction>Sirius</faction>
+   <faction>Soromid</faction>
+   <faction>Za'lek</faction>
+   <faction>Trader</faction>
+  </avail>
+ </mission>
  <mission name="Dead Or Alive Bounty">
   <lua>neutral/pirbounty_dead</lua>
   <avail>

--- a/dat/missions/empire/longdistanceshipping/es_longdistancecargo.lua
+++ b/dat/missions/empire/longdistanceshipping/es_longdistancecargo.lua
@@ -18,6 +18,7 @@ else -- default english
 Cargo: %s (%d tonnes)
 Jumps: %d
 Travel distance: %d
+Piracy risk: %s
 Time limit: %s]]
 
 
@@ -91,17 +92,49 @@ function create()
     if numjumps > jumpsperstop then
         timelimit:add(time.create( 0, 0, math.floor((numjumps-1) / jumpsperstop) * stuperjump ))
     end
+
+    -- To determine risk of piracy, simulate a trip there and calculate pirates presence.
+    -- Assume shortest route with no interruptions.
+   jumps = system.jumpPath( system.cur(), destsys:name() )
+   risk = system.cur():presences()["Pirate"]
+   if risk == nil then risk = 0 end
+   if jumps then
+      for k, v in ipairs(jumps) do
+         travelrisk = v:system():presences()["Pirate"]
+         if travelrisk == nil then
+            travelrisk = 0
+         end
+         risk = risk+travelrisk
+      end
+   end
+   
+   -- Determines average piracy risk and how much pay is padded for delivery to high-piracy areas.
+    avgrisk = risk/(numjumps + 1)
+    
+    if avgrisk == 0 then
+       piracyrisk = "None"
+       riskreward = 0
+    elseif avgrisk <= 25 then
+       piracyrisk = "Low"
+       riskreward = 10
+    elseif avgrisk > 25 and avgrisk <= 100 then
+       piracyrisk = "Medium"
+       riskreward = 25
+    else
+       piracyrisk = "High"
+       riskreward = 50
+    end
     
     -- Choose amount of cargo and mission reward. This depends on the mission tier.
     finished_mod = 2.0 -- Modifier that should tend towards 1.0 as naev is finished as a game
     amount     = rnd.rnd(10 + 3 * tier, 20 + 4 * tier) 
-    jumpreward = 1000
-    distreward = 0.3
-    reward     = 1.5^tier * (numjumps * jumpreward + traveldist * distreward) * finished_mod * (1. + 0.05*rnd.twosigma())
+	jumpreward = commodity.price(cargo)*1.5
+    distreward = math.log(300*commodity.price(cargo))/100
+    reward     = 1.5^tier * (avgrisk*riskreward + numjumps * jumpreward + traveldist * distreward) * finished_mod * (1. + 0.05*rnd.twosigma())
     
     misn.setTitle("ES: Long distance cargo transport (" .. amount .. " tonnes of " .. cargo .. ")")
     misn.markerAdd(destsys, "computer")
-    misn.setDesc(title:format(destplanet:name(), destsys:name(), cargo, amount, numjumps, traveldist, (timelimit - time.get()):str()))
+    misn.setDesc(title:format(destplanet:name(), destsys:name(), cargo, amount, numjumps, traveldist, piracyrisk, (timelimit - time.get()):str()))
     misn.setReward(misn_reward:format(numstring(reward)))
 
 end

--- a/dat/missions/empire/longdistanceshipping/es_longdistancecargo.lua
+++ b/dat/missions/empire/longdistanceshipping/es_longdistancecargo.lua
@@ -30,6 +30,12 @@ Time limit: %s]]
    slow[1] = "Too slow"
    slow[2] = [[This shipment must arrive within %s, but it will take at least %s for your ship to reach %s, and the Empire is not fond of delays. Accept the mission anyway?]]
 
+   piracyrisk = {}
+   piracyrisk[1] = "None"
+   piracyrisk[2] = "Low"
+   piracyrisk[3] = "Medium"
+   piracyrisk[4] = "High"
+
    msg_title = {}
    msg_title[1] = "Mission Accepted"
    msg_title[2] = "Too many missions"
@@ -65,7 +71,7 @@ function create()
     local routepos = origin_p:pos()
 
     -- target destination
-    destplanet, destsys, numjumps, traveldist, cargo, tier = cargo_calculateRoute()
+    destplanet, destsys, numjumps, traveldist, cargo, avgrisk, tier = cargo_calculateRoute()
     if destplanet == nil then
        misn.finish(false)
     end
@@ -93,38 +99,21 @@ function create()
         timelimit:add(time.create( 0, 0, math.floor((numjumps-1) / jumpsperstop) * stuperjump ))
     end
 
-    -- To determine risk of piracy, simulate a trip there and calculate pirates presence.
-    -- Assume shortest route with no interruptions.
-   jumps = system.jumpPath( system.cur(), destsys:name() )
-   risk = system.cur():presences()["Pirate"]
-   if risk == nil then risk = 0 end
-   if jumps then
-      for k, v in ipairs(jumps) do
-         travelrisk = v:system():presences()["Pirate"]
-         if travelrisk == nil then
-            travelrisk = 0
-         end
-         risk = risk+travelrisk
-      end
-   end
-   
-   -- Determines average piracy risk and how much pay is padded for delivery to high-piracy areas.
-    avgrisk = risk/(numjumps + 1)
-    
+	--Determine risk of piracy
     if avgrisk == 0 then
-       piracyrisk = "None"
+       piracyrisk = piracyrisk[1]
        riskreward = 0
     elseif avgrisk <= 25 then
-       piracyrisk = "Low"
+       piracyrisk = piracyrisk[2]
        riskreward = 10
     elseif avgrisk > 25 and avgrisk <= 100 then
-       piracyrisk = "Medium"
+       piracyrisk = piracyrisk[3]
        riskreward = 25
     else
-       piracyrisk = "High"
+       piracyrisk = piracyrisk[4]
        riskreward = 50
     end
-    
+
     -- Choose amount of cargo and mission reward. This depends on the mission tier.
     finished_mod = 2.0 -- Modifier that should tend towards 1.0 as naev is finished as a game
     amount     = rnd.rnd(10 + 3 * tier, 20 + 4 * tier) 

--- a/dat/missions/neutral/cargo.lua
+++ b/dat/missions/neutral/cargo.lua
@@ -36,6 +36,11 @@ Piracy Risk: %s]]
     full[1] = "No room in ship"
     full[2] = "You don't have enough cargo space to accept this mission. You need %d tons of free space (you need %d more)."
 
+	piracyrisk = {}
+	piracyrisk[1] = "None"
+	piracyrisk[2] = "Low"
+	piracyrisk[3] = "Medium"
+	piracyrisk[4] = "High"
    --=Landing=--
 
    cargo_land_title = "Delivery success!"
@@ -61,42 +66,24 @@ end
 function create()
     -- Note: this mission does not make any system claims. 
 
-    -- Calculate the route, distance, jumps and cargo to take
-    destplanet, destsys, numjumps, traveldist, cargo, tier = cargo_calculateRoute()
+    -- Calculate the route, distance, jumps, risk of piracy, and cargo to take
+    destplanet, destsys, numjumps, traveldist, cargo, avgrisk, tier = cargo_calculateRoute()
     
     if destplanet == nil then
        misn.finish(false)
     end
     
-    -- To determine risk of piracy, simulate a trip there and calculate pirates presence.
-    -- Assume shortest route with no interruptions.
-   jumps = system.jumpPath( system.cur(), destsys:name() )
-   risk = system.cur():presences()["Pirate"]
-   if risk == nil then risk = 0 end
-   if jumps then
-      for k, v in ipairs(jumps) do
-         travelrisk = v:system():presences()["Pirate"]
-         if travelrisk == nil then
-            travelrisk = 0
-         end
-         risk = risk+travelrisk
-      end
-   end
-   
-   -- Determines average piracy risk and how much pay is padded for delivery to high-piracy areas.
-    avgrisk = risk/(numjumps + 1)
-    
     if avgrisk == 0 then
-       piracyrisk = "None"
+       piracyrisk = piracyrisk[1]
        riskreward = 0
     elseif avgrisk <= 25 then
-       piracyrisk = "Low"
+       piracyrisk = piracyrisk[2]
        riskreward = 10
     elseif avgrisk > 25 and avgrisk <= 100 then
-       piracyrisk = "Medium"
+       piracyrisk = piracyrisk[3]
        riskreward = 25
     else
-       piracyrisk = "High"
+       piracyrisk = piracyrisk[4]
        riskreward = 50
     end
        

--- a/dat/missions/neutral/cargo.lua
+++ b/dat/missions/neutral/cargo.lua
@@ -91,22 +91,23 @@ function create()
        riskreward = 0
     elseif avgrisk <= 25 then
        piracyrisk = "Low"
-       riskreward = 50
-    elseif avgrisk > 25 and avgrisk <= 75 then
+       riskreward = 10
+    elseif avgrisk > 25 and avgrisk <= 100 then
        piracyrisk = "Medium"
-       riskreward = 100
+       riskreward = 25
     else
        piracyrisk = "High"
-       riskreward = 150
+       riskreward = 50
     end
-    
+       
     -- Choose amount of cargo and mission reward. This depends on the mission tier.
+    -- Reward depends on type of cargo hauled. Hauling expensive commodities gives a better deal.
     -- Note: Pay is independent from amount by design! Not all deals are equally attractive!
     finished_mod = 2.0 -- Modifier that should tend towards 1.0 as naev is finished as a game
     amount = rnd.rnd(5 + 25 * tier, 20 + 60 * tier)
-    jumpreward = 200
-    distreward = 0.09
-    reward = 1.5^tier * (avgrisk * riskreward + numjumps * jumpreward + traveldist * distreward) * finished_mod * (1. + 0.05*rnd.twosigma())
+    jumpreward = commodity.price(cargo)
+    distreward = math.log(100*commodity.price(cargo))/100
+    reward = 1.5^tier * (avgrisk*riskreward + numjumps * jumpreward + traveldist * distreward) * finished_mod * (1. + 0.05*rnd.twosigma())
     
     misn.setTitle(buildCargoMissionDescription( nil, amount, cargo, destplanet, destsys ))
     misn.markerAdd(destsys, "computer")

--- a/dat/missions/neutral/cargo_rush.lua
+++ b/dat/missions/neutral/cargo_rush.lua
@@ -30,7 +30,9 @@ else -- default english
 Cargo: %s (%d tonnes)
 Jumps: %d
 Travel distance: %d
-Time limit: %s]]
+Piracy Risk: %s
+Time limit: %s
+]]
 
     full = {}
     full[1] = "No room in ship"
@@ -100,17 +102,50 @@ function create()
     timelimit  = time.get() + time.create(0, 0, allowance)
     timelimit2 = time.get() + time.create(0, 0, allowance * 1.2)
 
+    -- To determine risk of piracy, simulate a trip there and calculate pirates presence.
+    -- Assume shortest route with no interruptions.
+   jumps = system.jumpPath( system.cur(), destsys:name() )
+   risk = system.cur():presences()["Pirate"]
+   if risk == nil then risk = 0 end
+   if jumps then
+      for k, v in ipairs(jumps) do
+         travelrisk = v:system():presences()["Pirate"]
+         if travelrisk == nil then
+            travelrisk = 0
+         end
+         risk = risk+travelrisk
+      end
+   end
+   
+   -- Determines average piracy risk and how much pay is padded for delivery to high-piracy areas.
+    avgrisk = risk/(numjumps + 1)
+    
+    if avgrisk == 0 then
+       piracyrisk = "None"
+       riskreward = 0
+    elseif avgrisk <= 25 then
+       piracyrisk = "Low"
+       riskreward = 10
+    elseif avgrisk > 25 and avgrisk <= 100 then
+       piracyrisk = "Medium"
+       riskreward = 25
+    else
+       piracyrisk = "High"
+       riskreward = 50
+    end
+
+
     -- Choose amount of cargo and mission reward. This depends on the mission tier.
     -- Note: Pay is independent from amount by design! Not all deals are equally attractive!
     finished_mod = 2.0 -- Modifier that should tend towards 1.0 as naev is finished as a game
     amount     = rnd.rnd(10 + 5 * tier, 20 + 6 * tier) -- 45 max (quicksilver)
-    jumpreward = 1000
-    distreward = 0.12
-    reward     = 1.5^tier * (numjumps * jumpreward + traveldist * distreward) * finished_mod * (1. + 0.05*rnd.twosigma())
+    jumpreward = commodity.price(cargo)*1.2
+    distreward = math.log(300*commodity.price(cargo))/100
+    reward     = 1.5^tier * (avgrisk*riskreward + numjumps * jumpreward + traveldist * distreward) * finished_mod * (1. + 0.05*rnd.twosigma())
 
     misn.setTitle( buildCargoMissionDescription(cargosize[tier], amount, cargo, destplanet, destsys ))
     misn.markerAdd(destsys, "computer")
-    misn.setDesc(cargosize[tier] .. title_p1[rnd.rnd(1, #title_p1)]:format(destplanet:name(), destsys:name()) .. title_p2:format(cargo, amount, numjumps, traveldist, (timelimit - time.get()):str()))
+    misn.setDesc(cargosize[tier] .. title_p1[rnd.rnd(1, #title_p1)]:format(destplanet:name(), destsys:name()) .. title_p2:format(cargo, amount, numjumps, traveldist, piracyrisk, (timelimit - time.get()):str()))
     misn.setReward(misn_reward:format(numstring(reward)))
 end
 

--- a/dat/missions/neutral/cargo_rush.lua
+++ b/dat/missions/neutral/cargo_rush.lua
@@ -38,11 +38,17 @@ Time limit: %s
     full[1] = "No room in ship"
     full[2] = "You don't have enough cargo space to accept this mission. It requires %d tonnes of free space (you need %d more)."
 
-   slow = {}
-   slow[1] = "Too slow"
-   slow[2] = [[This shipment must arrive within %s, but it will take at least %s for your ship to reach %s, missing the deadline.
+   	slow = {}
+  	slow[1] = "Too slow"
+  	slow[2] = [[This shipment must arrive within %s, but it will take at least %s for your ship to reach %s, missing the deadline.
 
 Accept the mission anyway?]]
+
+	piracyrisk = {}
+	piracyrisk[1] = "None"
+	piracyrisk[2] = "Low"
+	piracyrisk[3] = "Medium"
+	piracyrisk[4] = "High"
 
    --=Landing=--
    
@@ -80,8 +86,8 @@ end
 function create()
     -- Note: this mission does not make any system claims. 
 
-    -- Calculate the route, distance, jumps and cargo to take
-    destplanet, destsys, numjumps, traveldist, cargo, tier = cargo_calculateRoute()
+    -- Calculate the route, distance, jumps, risk of piracy, and cargo to take
+    destplanet, destsys, numjumps, traveldist, cargo, avgrisk, tier = cargo_calculateRoute()
     if destplanet == nil then
        misn.finish(false)
     end
@@ -102,38 +108,19 @@ function create()
     timelimit  = time.get() + time.create(0, 0, allowance)
     timelimit2 = time.get() + time.create(0, 0, allowance * 1.2)
 
-    -- To determine risk of piracy, simulate a trip there and calculate pirates presence.
-    -- Assume shortest route with no interruptions.
-   jumps = system.jumpPath( system.cur(), destsys:name() )
-   risk = system.cur():presences()["Pirate"]
-   if risk == nil then risk = 0 end
-   if jumps then
-      for k, v in ipairs(jumps) do
-         travelrisk = v:system():presences()["Pirate"]
-         if travelrisk == nil then
-            travelrisk = 0
-         end
-         risk = risk+travelrisk
-      end
-   end
-   
-   -- Determines average piracy risk and how much pay is padded for delivery to high-piracy areas.
-    avgrisk = risk/(numjumps + 1)
-    
     if avgrisk == 0 then
-       piracyrisk = "None"
+       piracyrisk = piracyrisk[1]
        riskreward = 0
     elseif avgrisk <= 25 then
-       piracyrisk = "Low"
+       piracyrisk = piracyrisk[2]
        riskreward = 10
     elseif avgrisk > 25 and avgrisk <= 100 then
-       piracyrisk = "Medium"
+       piracyrisk = piracyrisk[3]
        riskreward = 25
     else
-       piracyrisk = "High"
+       piracyrisk = piracyrisk[4]
        riskreward = 50
     end
-
 
     -- Choose amount of cargo and mission reward. This depends on the mission tier.
     -- Note: Pay is independent from amount by design! Not all deals are equally attractive!

--- a/dat/missions/neutral/commodityRun.lua
+++ b/dat/missions/neutral/commodityRun.lua
@@ -1,0 +1,118 @@
+--[[
+-- Commodity delivery missions. Player receives a bonus for bringing more of a commodity back.
+--]]
+
+include "dat/scripts/numstring.lua"
+
+lang = naev.lang()
+if lang == "es" then
+else -- default english
+
+    --Mission Details
+    misn_title = "%s Delivery"
+    misn_desc = "%s in the %s system needs a delivery of %s."
+    misn_reward = "%s credits/ton plus a bonus."
+      
+    --accept_title = "Mission Accepted"
+    --accept_text = "We're in short supply of %s. Find a station that sells %s and bring back as much as your ship can hold. We give bigger bonuses for bigger loads. Don't come back without it!"
+    
+    osd_title = "Commodity Delivery"
+    osd_msg = "Delivery of %s to %s in the %s system."
+       --=Landing=--change this
+
+   cargo_land_title = "Delivery success!"
+
+   cargo_land_p1 = {}
+   cargo_land_p1[1] = "The crates of "
+   cargo_land_p1[2] = "The drums of "
+   cargo_land_p1[3] = "The containers of "
+
+   cargo_land_p2 = {}
+   cargo_land_p2[1] = " are carried out of your ship and tallied. After several different men double-check the register to confirm the amount, you paid %s credits and summarily dismissed."
+   cargo_land_p2[2] = " are quickly and efficiently unloaded, labeled, and readied for distribution. The delivery manager thanks you with a credit chip worth %s credits."
+   cargo_land_p2[3] = " are unloaded from your vessel by a team of dockworkers who are in no rush to finish, eventually delivering %s credits after the number of tons is determined."
+   cargo_land_p2[4] = " are unloaded by robotic drones that scan and tally the contents. The human overseerer hands you %s credits when they finish."
+
+    cargo_land_title_fail = "Mission Failed!"
+    
+    cargo_land_fail = "The delivery manager is visibly upset with you. 'What is this?! You're missing the %s per the contract! This is unacceptable. We will find a more competant captain to complete this mission.' He shakes his head and walks off."
+
+
+end
+
+--Create the mission
+function create()
+    -- Note: this mission does not make any system claims.
+  
+    ReturnPlanet = planet.cur()
+    ReturnSystem = system.cur()
+	
+	PossibleCommodities = planet.commoditiesSold("Darkshed") --TODO: find a better way to index all available commodities
+	Commodity = PossibleCommodities[rnd.rnd(1,#PossibleCommodities)]
+	for k,v in pairs(planet.cur():commoditiesSold()) do
+		if v == Commodity then
+  			misn.finish(false)
+  		end
+	end
+
+    --Set Mission Details
+    misn.setTitle(misn_title:format(Commodity:name()))
+    misn.markerAdd(system.cur(), "computer")
+    misn.setDesc(misn_desc:format(planet.cur():name(),system.cur():name(),Commodity:name()))
+    misn.setReward(misn_reward:format(commodity.price(Commodity:name())))
+    
+end
+
+-- Mission is accepted
+function accept()
+
+    misn.accept() -- I think this is where the tk.msg goes?
+    misn.osdCreate(osd_title, {osd_msg:format(Commodity:name(),ReturnPlanet:name(), ReturnSystem:name())})
+    hook.land("land")
+end
+
+-- Land hook
+function land()
+    --Does the player have the right cargo? If so, how much?
+    amount = pilot.cargoHas(player.pilot(),Commodity:name())  
+    --Determine bonus for amount delivered. 
+    if amount <= 20 then
+        Bonus = 1.05 -- 10% bonus for <20 tons
+    elseif amount > 20 and amount <= 40 then
+        Bonus = 1.10 -- 20% bonus for 20 - 40 tons
+    elseif amount > 40 and amount <= 60 then
+        Bonus = 1.15 -- 30% bonus for 40 - 60 tons
+    elseif amount > 60 and amount <= 80 then
+        Bonus = 1.20 -- 40% bonus for 60 - 80 tons
+    elseif amount > 80 and amount <= 100 then
+        Bonus = 1.25 -- 50% bonus for 80 - 100 tons
+    elseif amount >100 and amount <= 150 then
+        Bonus = 1.30 -- 60% bonus for 100 - 150 tons
+    elseif amount > 150 and amount <= 200 then
+        Bonus = 1.35 -- 80% bonus for 150 - 200 tons
+    elseif amount > 200 and amount <= 250 then
+        Bonus = 1.40 -- 40% bonus for 150 - 200 tons
+    elseif amount > 250 and amount <= 300 then
+    	Bonus = 1.45 -- 45% bonus for 250 - 300 tons
+    else
+    	Bonus = 1.5 -- 50% bonus for 300+ tons
+    end
+    
+    --Reward
+    finished_mod = 2.0 -- Modifier that should tend towards 1.0 as naev is finished as a game
+    reward =  finished_mod * (commodity.price(Commodity:name()) * amount * Bonus)
+    
+    if planet.cur() == ReturnPlanet and amount > 0 then      
+        tk.msg(cargo_land_title, cargo_land_p1[rnd.rnd(1, #cargo_land_p1)] .. Commodity:name() .. cargo_land_p2[rnd.rnd(1, #cargo_land_p2)]:format(numstring(reward)))
+        pilot.cargoRm(player.pilot(),Commodity:name(),amount)
+        player.pay(reward)
+        misn.finish(true)
+    else
+    	tk.msg(cargo_land_title_fail, cargo_land_fail:format(Commodity:name()))
+    	misn.finish(true)
+    end
+end
+
+function abort ()
+    misn.finish(false)
+end

--- a/dat/missions/neutral/commodityRun.lua
+++ b/dat/missions/neutral/commodityRun.lua
@@ -77,19 +77,19 @@ function land()
     amount = pilot.cargoHas(player.pilot(),Commodity:name())  
     --Determine bonus for amount delivered. 
     if amount <= 20 then
-        Bonus = 1.05 -- 10% bonus for <20 tons
+        Bonus = 1.05 -- 5% bonus for <20 tons
     elseif amount > 20 and amount <= 40 then
-        Bonus = 1.10 -- 20% bonus for 20 - 40 tons
+        Bonus = 1.10 -- 10% bonus for 20 - 40 tons
     elseif amount > 40 and amount <= 60 then
-        Bonus = 1.15 -- 30% bonus for 40 - 60 tons
+        Bonus = 1.15 -- 15% bonus for 40 - 60 tons
     elseif amount > 60 and amount <= 80 then
-        Bonus = 1.20 -- 40% bonus for 60 - 80 tons
+        Bonus = 1.20 -- 20% bonus for 60 - 80 tons
     elseif amount > 80 and amount <= 100 then
-        Bonus = 1.25 -- 50% bonus for 80 - 100 tons
+        Bonus = 1.25 -- 25% bonus for 80 - 100 tons
     elseif amount >100 and amount <= 150 then
-        Bonus = 1.30 -- 60% bonus for 100 - 150 tons
+        Bonus = 1.30 -- 30% bonus for 100 - 150 tons
     elseif amount > 150 and amount <= 200 then
-        Bonus = 1.35 -- 80% bonus for 150 - 200 tons
+        Bonus = 1.35 -- 35% bonus for 150 - 200 tons
     elseif amount > 200 and amount <= 250 then
         Bonus = 1.40 -- 40% bonus for 150 - 200 tons
     elseif amount > 250 and amount <= 300 then

--- a/dat/missions/neutral/commodityRun.lua
+++ b/dat/missions/neutral/commodityRun.lua
@@ -116,3 +116,4 @@ end
 function abort ()
     misn.finish(false)
 end
+

--- a/dat/scripts/cargo_common.lua
+++ b/dat/scripts/cargo_common.lua
@@ -166,3 +166,4 @@ function difference(a, b)
     end
     return r
 end
+

--- a/dat/scripts/cargo_common.lua
+++ b/dat/scripts/cargo_common.lua
@@ -90,6 +90,22 @@ function cargo_calculateRoute ()
    local numjumps   = origin_s:jumpDist(destsys)
    local traveldist = cargo_calculateDistance(routesys, routepos, destsys, destplanet)
    
+   
+   --Determine amount of piracy along the route
+   local jumps = system.jumpPath( system.cur(), destsys:name() )
+   local risk = system.cur():presences()["Pirate"]
+   if risk == nil then risk = 0 end
+   if jumps then
+      for k, v in ipairs(jumps) do
+         local travelrisk = v:system():presences()["Pirate"]
+         if travelrisk == nil then
+            travelrisk = 0
+         end
+         local risk = risk+travelrisk
+      end
+   end
+	local avgrisk = risk/(numjumps + 1)
+   
    -- We now know where. But we don't know what yet. Randomly choose a commodity type.
    -- TODO: I'm using the standard cargo types for now, but this should be changed to custom cargo once local-defined commodities are implemented.
    local cargoes = difference(planet.cur():commoditiesSold(),destplanet:commoditiesSold())
@@ -99,7 +115,7 @@ function cargo_calculateRoute ()
    local cargo = cargoes[rnd.rnd(1,#cargoes)]:name()
 
    -- Return lots of stuff
-   return destplanet, destsys, numjumps, traveldist, cargo, tier
+   return destplanet, destsys, numjumps, traveldist, cargo, avgrisk, tier
 end
 
 

--- a/dat/scripts/cargo_common.lua
+++ b/dat/scripts/cargo_common.lua
@@ -92,8 +92,11 @@ function cargo_calculateRoute ()
    
    -- We now know where. But we don't know what yet. Randomly choose a commodity type.
    -- TODO: I'm using the standard cargo types for now, but this should be changed to custom cargo once local-defined commodities are implemented.
-   local cargoes = {"Food", "Industrial Goods", "Medicine", "Luxury Goods", "Ore"}
-   local cargo = cargoes[rnd.rnd(1, #cargoes)]
+   local cargoes = difference(planet.cur():commoditiesSold(),destplanet:commoditiesSold())
+   if #cargoes == 0 then
+      return
+   end
+   local cargo = cargoes[rnd.rnd(1,#cargoes)]:name()
 
    -- Return lots of stuff
    return destplanet, destsys, numjumps, traveldist, cargo, tier
@@ -134,4 +137,16 @@ function cargoValidDest( targetplanet )
       end
    end
    return true
+end
+
+--Determines the items in table a that are not in table b.
+--Used to determine what cargo is sold at current planet but not at destination planet.
+function difference(a, b)
+    local ai = {}
+    local r = {}
+    for k,v in pairs(a) do r[k] = v; ai[v]=true end
+    for k,v in pairs(b) do 
+        if ai[v]~=nil then   r[k] = nil   end
+    end
+    return r
 end


### PR DESCRIPTION
Brief Summary:Cargo delivery missions now only deliver commodities offered at the origin planet to planets that do not sell that commodity. Jump and distance rewards depend on the base price of the commodity being delivered. Rewards are also higher for traversing pirated space.A new mission was created that asks players to deliver a commodity not sold on that planet. Players must buy the commodity and return. Pay is dependent on base price of the commodity and how much is delivered. 

A more detailed description of the change is available on the forum at: http://bit.ly/1XNq7Xi 