### PR TITLE
Reverted 63960aa and 60540c2.

### DIFF
--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -1386,8 +1386,6 @@ void pilot_weaponSane( Pilot *p )
  */
 int pilot_outfitOff( Pilot *p, PilotOutfitSlot *o )
 {
-   double c;
-
    /* Must not be disabled or cooling down. */
    if ((pilot_isDisabled(p)) || (pilot_isFlag(p, PILOT_COOLDOWN)))
       return 0;
@@ -1399,11 +1397,7 @@ int pilot_outfitOff( Pilot *p, PilotOutfitSlot *o )
       o->stimer = -1;
    }
    else {
-      c = outfit_cooldown( o->outfit );
-      if (o->stimer != INFINITY)
-         o->stimer = c - (c * o->stimer / outfit_duration( o->outfit ));
-      else
-         o->stimer = c;
+      o->stimer = outfit_cooldown( o->outfit );
       o->state  = PILOT_OUTFIT_COOLDOWN;
    }
 


### PR DESCRIPTION
These changes collectively caused outfits to have shorter cooldown
periods when you didn't use them as long. But this change was made
with the intention of also adding 6a4bf10, which was rejected upstream.
Without that, all this does is create an advantage to doing several
short bursts of activating the outfit, or even having some sort of
keyboard macro do it for you. I don't think there's any possible
reason to want to implement this kind of thing on purpose.