### PR TITLE
Reworked the Commodity Run mission to make it better.

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -95,7 +95,7 @@
   <lua>neutral/commodityRun</lua>
   <avail>
    <priority>5</priority>
-   <chance>60</chance>
+   <chance>90</chance>
    <location>Computer</location>
    <faction>Dvaered</faction>
    <faction>Empire</faction>


### PR DESCRIPTION
Notable changes are:

* It is no longer considered a failure if you land on the planet
  without the commodity. Instead, nothing happens until you have
  some of the commodity in question.

* Both the mission description and the OSD are substantially improved.

* The way the pay is determined has been changed. Instead of being
  "the cost of the commodity times 2 plus extra if you have more",
  a price per unit is randomly generated when the mission is created.
  The price per unit can be as little as the price of the commodity or
  as much as 9 times the price of the commodity, but typically ends up
  being 2 times the price of the commodity (the variation is mostly
  determined by the result of a threesigma call). This rewards
  choosing these missions opportunistically when the return is
  especially high.

* The chance of the mission appearing has beein increased from 60%
  to 90%, since the real chance is lowered by how the mission ensures
  that commodities available on the planet are not chosen.

In the process, some bugs were also fixed.