### PR TITLE
Removed an alarming number of empty Commodity services.

### DIFF
--- a/dat/assets/agino.xml
+++ b/dat/assets/agino.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/ahmed.xml
+++ b/dat/assets/ahmed.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/aldernael.xml
+++ b/dat/assets/aldernael.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/aldous.xml
+++ b/dat/assets/aldous.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>The planet Aldous is a giant sea of a fluid toxic to humans. Even the tiniest exposure to the toxic material in Aldous' ocean is lethal. As far as habitability is concerned, planets like this one come in dead last on the list. Nevertheless, a handful of brave souls have chosen to make this planet their home. The ocean may be toxic, but it also happens to be the perfect environment for producing high quality positronic circuitry.</description>

--- a/dat/assets/aleph.xml
+++ b/dat/assets/aleph.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>In an impressive feat of de-terraforming, the Dvaered have transformed Aleph from a borderline class M to a barren wasteland. Though the world is primarily residential and sports no superheavy industry, the wastefulness of the Dvaered inhabitants more than makes up for that.</description>

--- a/dat/assets/benedict.xml
+++ b/dat/assets/benedict.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/benteen.xml
+++ b/dat/assets/benteen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Benteen is one of the Empire's primary agriworlds. It grows most of the crops that are bound for the western systems. It is a quiet world, with little in the way of the bustle and fuss of other, more core, planets.</description>

--- a/dat/assets/boowoy.xml
+++ b/dat/assets/boowoy.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/brock.xml
+++ b/dat/assets/brock.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/castellan_iii.xml
+++ b/dat/assets/castellan_iii.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Castellan III is, like most Dvaered planets, a mining world and, like most Dvaered mining worlds, the conditions are hellish. The planet has virtually no way to support natural life so it needs a constant stream of resources to support it. The majority of these are food and medical supplies for the miners.</description>

--- a/dat/assets/colley.xml
+++ b/dat/assets/colley.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Colley is a popular retirement and vacation spot due to its quiet and unassuming nature. The world has mild weather and is ideally closeted away from the cares and worries of the wider galaxy.</description>

--- a/dat/assets/cornwal_ordinance.xml
+++ b/dat/assets/cornwal_ordinance.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/corvus_vib.xml
+++ b/dat/assets/corvus_vib.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Being a small moon in an already growing system fewer colonists have paid attention to Corvus VI-b - the name itself is a bit of a giveaway. However the colonists of this moon appreciate it's larger neighbours which, inadvertently, provide protection by being more important, juicier and more obvious targets.</description>

--- a/dat/assets/cristen.xml
+++ b/dat/assets/cristen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>All water on Cristen is toxic and, as such, the planet is inhospitable to all but the most hardy forms of life. However, the toxicity of the water system also means that certain substances can be obtained very easily here. Due to this the settlement on Cristen is one giant complex, isolated from the outside environment.</description>

--- a/dat/assets/crow.xml
+++ b/dat/assets/crow.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/dolmen.xml
+++ b/dat/assets/dolmen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/dono.xml
+++ b/dat/assets/dono.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Dono is one of the more laid-back Soromid worlds. It is quite Earth-like and the Soromid make use of the strange properties of the local flora and fauna in their genetic experiments. It is a quiet world, with little that stands out about it.</description>

--- a/dat/assets/dun_hill.xml
+++ b/dat/assets/dun_hill.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Dun Hill is one of those little mining worlds that is regarded as being totally insignificant. Indeed, the world has no real personality of its own as the population is imported from nearby planets. It isn't a pleasant place to live but, none-the-less, it has valuable resources the Empire would rather not go without.</description>

--- a/dat/assets/dunmer.xml
+++ b/dat/assets/dunmer.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Even the Dvaered realise that not every world can be devoted to industry. Food has to be grown somewhere and crop-growing stations are not yet practical, for the Dvaered, on a large scale. Hence the setting aside of Dunmer for agriculture. Despite its small size, the planet actually has a significantly larger population than Castellan III, due to its much more pleasant climate.</description>

--- a/dat/assets/edorn.xml
+++ b/dat/assets/edorn.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/falas.xml
+++ b/dat/assets/falas.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Falas is a sparsely populated garrison planet with little to no resources of any use. However, it was cheaper to build an outpost here than to build a whole new space station.</description>

--- a/dat/assets/finn.xml
+++ b/dat/assets/finn.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Finn is a prison rock. The surface is completely uninhabitable but the natural caverns underground make for a perfect prison complex. The Empire dumps its worst criminals here, leaving them to fend for themselves, many of the convicts from the Jade Court end up here too.</description>

--- a/dat/assets/gennus.xml
+++ b/dat/assets/gennus.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/golem.xml
+++ b/dat/assets/golem.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/gorchenchev_shipyards.xml
+++ b/dat/assets/gorchenchev_shipyards.xml
@@ -21,7 +21,6 @@
    <land>srs_mil_restricted</land>
    <refuel/>
    <bar/>
-   <commodity/>
    <shipyard/>
   </services>
   <commodities/>

--- a/dat/assets/gorgate.xml
+++ b/dat/assets/gorgate.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/grandard.xml
+++ b/dat/assets/grandard.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/griffin_iii.xml
+++ b/dat/assets/griffin_iii.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/harnaar.xml
+++ b/dat/assets/harnaar.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/haurn.xml
+++ b/dat/assets/haurn.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Haurn is a small planet with mild planetary conditions. The Soromid have designated it a dedicated farming world. Apart from a few small settlements, most of the planet's land surface is given to agriculture.</description>

--- a/dat/assets/jade_court.xml
+++ b/dat/assets/jade_court.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Jade Court is a large judiciary installation. Though owned by the Empire, the station itself counts as neutral territory. Cases here come from all over the galaxy, presided over by judges who are not affiliated with any of the major factions. Typically, any large international case that local law enforcement is unable to handle on its own will be taken to Jade.</description>

--- a/dat/assets/jankelo.xml
+++ b/dat/assets/jankelo.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/janko.xml
+++ b/dat/assets/janko.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/jaxheen.xml
+++ b/dat/assets/jaxheen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/jemard.xml
+++ b/dat/assets/jemard.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <shipyard/>
   </services>
   <commodities/>

--- a/dat/assets/jermose.xml
+++ b/dat/assets/jermose.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/jeronon.xml
+++ b/dat/assets/jeronon.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/kaulas.xml
+++ b/dat/assets/kaulas.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Volcanic A class planets aren't usually prime candidates for colonization. But sometimes it can be advantageous for an industry to put a factory or two on a planet like Kaulas. Geothermal energy is available in plentiful supply, and some select spots on the planet's surface are stable enough to set up a natural furnace for producing things that require a lot of heat in their production process.</description>

--- a/dat/assets/lanze.xml
+++ b/dat/assets/lanze.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/leszec.xml
+++ b/dat/assets/leszec.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>The Dvaered are keeping a "rehabilitation facility" here. As you might expect it's a prison, but unlike most Dvaered prisons - which just leave inmates to fend for themselves - this facility is a labor camp, staffed by wardens, guards and overseers for the various subsections. Prisoners never make for very eager workers though, so the actual yield of this facility isn't spectacular.</description>

--- a/dat/assets/long_rock.xml
+++ b/dat/assets/long_rock.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Long Rock is a mining world, where the Soromid harvest most of the resources they need. Their thirst for raw materials is considerably small due to the semi-organic nature of their ships, but there is still a demand, and Long Rock is here to deliver.</description>

--- a/dat/assets/magellan.xml
+++ b/dat/assets/magellan.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/marauder_station.xml
+++ b/dat/assets/marauder_station.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/margot.xml
+++ b/dat/assets/margot.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/megas.xml
+++ b/dat/assets/megas.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/mendez.xml
+++ b/dat/assets/mendez.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>From space, Mendez looks like a dustball. Its surface is mostly brown and the only visible clouds are dust storms. It is therefore rather surprising that the Soromid use this planet as a major food growing world. The Soromid have developed a kind of crop that will grow in the harsh conditions of Mendez. Unfortunately, the leaves are brown and tough and, while nutritious, don't taste very good.</description>

--- a/dat/assets/mugen.xml
+++ b/dat/assets/mugen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>An unusually stable hot world, Mugen has become home to a wide variety of industrial processing companies. Using the planet's own heat via the stable magma streams that suffuse what passes for the planet's crust, smelting and refining operations can be carried out at significantly reduced cost.</description>

--- a/dat/assets/nanek.xml
+++ b/dat/assets/nanek.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/nocalin.xml
+++ b/dat/assets/nocalin.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/nolan.xml
+++ b/dat/assets/nolan.xml
@@ -20,7 +20,6 @@
   <services>
    <land>dv_mil_restricted</land>
    <refuel/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Yet another prison world. While Nolan is not the harshest world in Dvaered space, it's shrouded in near-perpetual darkness. Convicts are kept here to be shipped off to Veren for their typically brief work stints.</description>

--- a/dat/assets/olljan.xml
+++ b/dat/assets/olljan.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/omar.xml
+++ b/dat/assets/omar.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/oni.xml
+++ b/dat/assets/oni.xml
@@ -20,7 +20,6 @@
   <services>
    <land/>
    <refuel/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Oni is a harsh place to live, with a thick, toxic atmosphere, violent weather and frequent seismic activity. All of this makes it a favored dumping ground for criminals and other undesirables of Dvaered society. Soldiers assigned here consider it to be a punishment almost as severe as being a prisoner. It's one of the few planets controlled by the central Dvaered government, as no sane warlord wants the place.</description>

--- a/dat/assets/phosarrus.xml
+++ b/dat/assets/phosarrus.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/porro_farming_station.xml
+++ b/dat/assets/porro_farming_station.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Stations like this one are a marvel of technology. They span only a few dozen kilometers in diameter, yet have the food production capability to feed several planets. Food is grown so rapidly that it takes a constant stream of merchant ships to take it all away.</description>

--- a/dat/assets/priscus.xml
+++ b/dat/assets/priscus.xml
@@ -21,7 +21,6 @@
    <land>srm_mil_restricted</land>
    <refuel/>
    <bar/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/rhaana.xml
+++ b/dat/assets/rhaana.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Rhanna is one of the outer worlds of Dvaered control. The population is high, but forced to live in insulated containment centers. It is a poor world, with little to recommend it to the wider galaxy. Thusly, it's very quiet.</description>

--- a/dat/assets/rockhardt.xml
+++ b/dat/assets/rockhardt.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/rodney.xml
+++ b/dat/assets/rodney.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Rodney is a world where precious gems are mined and sold further south to bolster the Soromid economy. The planet also grows several valuable crops, and is mined for valuable minerals. While this makes it a valuable addition to the Soromid economy, it makes it an aggressively dull place to live.</description>

--- a/dat/assets/rogan.xml
+++ b/dat/assets/rogan.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/ruadan_prime.xml
+++ b/dat/assets/ruadan_prime.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/ruadan_station.xml
+++ b/dat/assets/ruadan_station.xml
@@ -20,7 +20,6 @@
   <services>
    <land/>
    <refuel/>
-   <commodity/>
   </services>
   <commodities/>
   <description>This simple station serves as a refuel depot for those ships that do not have security clearance to land on Ruadan Prime or Ruadan Bastion. There is precious little else of interest here.</description>

--- a/dat/assets/ruin.xml
+++ b/dat/assets/ruin.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>It is said that when the first colonist ship landed here, its captain took a look outside and muttered to himself: "what a ruin of a planet". His cabin crew overheard, and the word stuck. Today, the planet is officially known as Ruin on all publicly sold star maps.</description>

--- a/dat/assets/salsax_station.xml
+++ b/dat/assets/salsax_station.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/shade__sunshine_station.xml
+++ b/dat/assets/shade__sunshine_station.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
   </services>
   <commodities/>
   <description>When the Soromid do something to do with biology, you can assume they do it really well. Shade &amp; Sunshine is a crop growing station with an amazing output. Between the eternal day granted by the station's alignment with the sun and the Soromid's skill with genetic manipulation, crops here are among the most bountiful in the entire galaxy.</description>

--- a/dat/assets/sharak.xml
+++ b/dat/assets/sharak.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/sirou_alpha.xml
+++ b/dat/assets/sirou_alpha.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/skater.xml
+++ b/dat/assets/skater.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/smaal.xml
+++ b/dat/assets/smaal.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/sollebor.xml
+++ b/dat/assets/sollebor.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/sternguard.xml
+++ b/dat/assets/sternguard.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Though a fairly unobtrusive world filled with lower-middle class Dvaered citizens, the Dvaered authorities nevertheless pay close attention to what goes on on Sternguard. Close to the Sirian border, the world is a prime candidate for conversion. At the moment the population seems to be stable, but the Dvaered know better than to relax their guard.</description>

--- a/dat/assets/stormgard.xml
+++ b/dat/assets/stormgard.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/thosson.xml
+++ b/dat/assets/thosson.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Thosson is mostly a normal aquatic world, capitalizing on its abundant supply of water. However, a small Soromid community on this world has taken it upon itself to evolve into water-dwelling creatures through genetic manipulation. So far they haven't had much success, and their position on the planet is rather marginal. By and large, the Soromid believe in space more than in oceans.</description>

--- a/dat/assets/trichu.xml
+++ b/dat/assets/trichu.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Trichu is both the base for a mining operation that extracts hydrogen from Adiadus IV and a manufacturing plant for low-level industrial goods. The goods are mostly consumed by other worlds in this system, but a small portion of it is exported abroad. Profit margins are minimal, but the facility at least manages to keep from going under.</description>

--- a/dat/assets/tulla.xml
+++ b/dat/assets/tulla.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/tummalin.xml
+++ b/dat/assets/tummalin.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Tummalin is the base of operations of a small mining company. Its primary, Longbow III, is rich in various unusual substances. However, the planet itself is far too unstable to permit a permanent presence, so all mining operations are carried out with mobile harvester ships. It's dangerous work, but as long as there's a market there will always be someone willing to do it.</description>

--- a/dat/assets/tumut.xml
+++ b/dat/assets/tumut.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Tumut is a young volcanic world that the Za'lek have taken some interest in as a massive geological study. Moreover, it is the primary location of several rare mineral mines that are hard to find in other parts of the inhabited galaxy. However, these mines are strictly small-scale, and the geological study takes large precedent.</description>

--- a/dat/assets/turnpike_station.xml
+++ b/dat/assets/turnpike_station.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/ummula.xml
+++ b/dat/assets/ummula.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/vao_vos.xml
+++ b/dat/assets/vao_vos.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>The Ulysses system is fairly close to the Sirian core, and the Sirian core always needs more energy. Vao Vos is a hot planet that orbits its sun rather closely, which makes it a suitable place to generate lots of power and package it up into high-efficiency power cells.</description>

--- a/dat/assets/vargos_rock.xml
+++ b/dat/assets/vargos_rock.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>This cold, dead, rocky world was named after the man who settled the colony here, an entrepreneur by the name of Shaan Vargo. Vargo was convinced that this planet harbored untold wealth in precious metals and minerals deep underneath its surface. He persisted in his belief right up until his death in the Incident, but the miners here never found anything like that. Instead, they found fairly common materials, which at least sell well enough to keep the colony marginally profitable.</description>

--- a/dat/assets/vault.xml
+++ b/dat/assets/vault.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/vercingetorix.xml
+++ b/dat/assets/vercingetorix.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/vinooso.xml
+++ b/dat/assets/vinooso.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/wagenni.xml
+++ b/dat/assets/wagenni.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/waldar.xml
+++ b/dat/assets/waldar.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/wardens_end.xml
+++ b/dat/assets/wardens_end.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/wellen.xml
+++ b/dat/assets/wellen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/werlen.xml
+++ b/dat/assets/werlen.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Werlen is a world devoted to the cultivation of the raw materials the Soromid use to fabricate their ships. The world is off-limits to casual traffic, and only those trusted by the Soromid are permitted access.</description>

--- a/dat/assets/westeros_station.xml
+++ b/dat/assets/westeros_station.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
   </services>
   <commodities/>
   <description>Serving as an auxilary trading platform for the nearby mining colony of Ahmed, Westeros Station allows for merchants to not have to brave the atmosphere of the nearby planetoid, making bulk transfers far easier.</description>

--- a/dat/assets/wonclock.xml
+++ b/dat/assets/wonclock.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/yaroslav_farming_station.xml
+++ b/dat/assets/yaroslav_farming_station.xml
@@ -21,7 +21,6 @@
    <land/>
    <refuel/>
    <bar/>
-   <commodity/>
   </services>
   <commodities/>
   <description>This farming facility provides the nearby systems with food. Some of the produce is shipped to the nearby world of Boowoy, but the majority is traded out of system.</description>

--- a/dat/assets/zaals.xml
+++ b/dat/assets/zaals.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/zalebus.xml
+++ b/dat/assets/zalebus.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
   </services>

--- a/dat/assets/zazarin.xml
+++ b/dat/assets/zazarin.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>

--- a/dat/assets/zhang_lu.xml
+++ b/dat/assets/zhang_lu.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
   </services>
   <commodities/>


### PR DESCRIPTION
These empty Commodity services are a problem if you're actually
looking for a place to buy/sell commodities, because the indicator
that a planet has commodities becomes almost useless. This took some
fiddling about with grep, but I think I've removed all instances
of planets with empty Commodity services (i.e. offering the service
but no commodities).