### PR TITLE
Removed the faction requirement for the commodity run mission.

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -97,15 +97,6 @@
    <priority>5</priority>
    <chance>90</chance>
    <location>Computer</location>
-   <faction>Dvaered</faction>
-   <faction>Empire</faction>
-   <faction>Frontier</faction>
-   <faction>Goddard</faction>
-   <faction>Independent</faction>
-   <faction>Sirius</faction>
-   <faction>Soromid</faction>
-   <faction>Za'lek</faction>
-   <faction>Trader</faction>
   </avail>
  </mission>
  <mission name="Trader Escort">


### PR DESCRIPTION
This mission's important conditions are related to the commodities
available on the specific planet. It makes no sense to restrict it
only to specific factions. Pirates and the FLF need basic commodities,
too.