### PR TITLE
Adjusted the fleets in Operation Cold Metal to make it more fun/climactic.

### DIFF
--- a/dat/missions/empire/collective/ec06.lua
+++ b/dat/missions/empire/collective/ec06.lua
@@ -123,12 +123,10 @@ function jumpin ()
             local fleetCpos = vec2.new(0, 0)
             deathsC = 0
 
-            fleetE[#fleetE + 1] = pilot.add("Empire Hawking", nil, fleetEpos)[1]
-            fleetE[#fleetE + 1] = pilot.add("Empire Hawking", nil, fleetE[1]:pos() + vec2.new(-500, 200))[1]
-            fleetE[#fleetE + 1] = pilot.add("Empire Hawking", nil, fleetE[1]:pos() + vec2.new(500, -200))[1]
-            fleetE[#fleetE + 1] = pilot.add("Empire Peacemaker", nil, fleetE[1]:pos() + vec2.new(-200, 460))[1]
-            fleetE[#fleetE + 1] = pilot.add("Empire Peacemaker", nil, fleetE[1]:pos() + vec2.new(500, 180))[1]
-            for i = 1, 7 do
+            fleetE[#fleetE + 1] = pilot.add("Empire Peacemaker", nil, fleetEpos)[1]
+            fleetE[#fleetE + 1] = pilot.add("Empire Hawking", nil, fleetE[1]:pos() + vec2.new(-200, 460))[1]
+            fleetE[#fleetE + 1] = pilot.add("Empire Hawking", nil, fleetE[1]:pos() + vec2.new(500, 180))[1]
+            for i = 1, 6 do
                 fleetE[#fleetE + 1] = pilot.add("Empire Pacifier", nil, fleetE[1]:pos() + vec2.new(-230, -275) + vec2.new(75*i - 260, -30*i + 105))[1]
             end
             for i = 1, 15 do
@@ -145,7 +143,15 @@ function jumpin ()
                 fleetC[#fleetC]:setNodisable()
                 fleetC[#fleetC]:setFaction( "Collective" )
             end
-            droneC = addShips("Collective Drone", nil, fleetCpos, 60)
+            droneC = {}
+            for i = 1, 60 do
+                local pos = fleetCpos + vec2.new(rnd.rnd(-10000, 10000), rnd.rnd(-10000, 10000))
+                if i <= 10 then
+                    droneC[#droneC + 1] = pilot.add("Collective Heavy Drone", nil, pos)[1]
+                else
+                    droneC[#droneC + 1] = pilot.add("Collective Drone", nil, pos)[1]
+                end
+            end
             
             for _, j in ipairs(fleetE) do
                 j:control()


### PR DESCRIPTION
There were two problems with Cold Metal: one, you don't even have to
participate; you can just sit back and let the Empire ships do all the
work and the mission will succeed. Two, if you go in and try to help
anyway, the Collective drones were so concentrated in one spot that
this was practically a death sentence if you didn't have a super-heavy
ship.

I can't think of a way to address the first problem, and it's not that
big of a deal, anyway (and might even be considered a good thing). But
I've addressed the second problem here by spreading out the Collective
drones. Being more spread out means you can join in the fight without
getting your butt blasted every time, so that at the very least makes
your participation more fun, if still entirely pointless.

I've also added some heavy Collective drones to the Collective fleet,
and reduced the size of the Empire fleet (now one Peacemaker instead
of three and six Pacifiers instead of seven), to at least make your
participation *feel* a little less pointless.

Sorry about the duplicate; I accidentally deleted the branch when I meant to delete a different one.