### PR TITLE
Made it so that the refueling ship in Cold Metal never leaves.

### DIFF
--- a/dat/missions/empire/collective/ec06.lua
+++ b/dat/missions/empire/collective/ec06.lua
@@ -229,6 +229,7 @@ function addRefuelShip ()
    refship:setFriendly()
    refship:setVisplayer()
    refship:setHilight()
+   refship:setNoJump()
 
    -- Maximize fuel
    refship:rmOutfit("all") -- Only will have fuel pods


### PR DESCRIPTION
I haven't tested this since I don't have a save where I'm at or
near that point, but it should do the trick. It's really annoying
if you fail to respond to the refueling ship and it runs away,
effectively forcing you to start the mission over again since there's
no other way to refuel for three systems.