### PR TITLE
Made bribed ships show up as such, not "Neutral".

### DIFF
--- a/dat/factions/standing/skel.lua
+++ b/dat/factions/standing/skel.lua
@@ -41,7 +41,7 @@ else -- Default English
    _ftext_friendly = "Friendly"
    _ftext_neutral  = "Neutral"
    _ftext_hostile  = "Hostile"
-   _ftext_bribed   = "Neutral"
+   _ftext_bribed   = "Bribed"
 end
 
 


### PR DESCRIPTION
Showing up as "Neutral" is a relic of a previous engine limitation
which no longer exists. It makes no sense to keep this ambiguity.