### PR TITLE
Made the Empire's limitation on secondary faction hits apply to missions.

### DIFF
--- a/dat/factions/standing/empire.lua
+++ b/dat/factions/standing/empire.lua
@@ -17,8 +17,7 @@ sec_hit_min = 10
 function faction_hit( current, amount, source, secondary )
    local start_standing = _fthis:playerStanding()
    local f = default_hit( current, amount, source, secondary )
-   if ( ( source == "distress" or source == "kill" ) and secondary and
-         amount < 0 and f < sec_hit_min ) then
+   if ( secondary and amount < 0 and f < sec_hit_min ) then
       f = math.min( start_standing, sec_hit_min )
    end
    return f


### PR DESCRIPTION
The secondary faction hit limitation is a way to prevent FLF-aligning
players from becoming flat-out enemies with the Empire from attacking
the Dvaereds. This change makes that limitation apply to missions,
rather than just aggression against Dvaered ships.

(Honestly, I don't remember why I limited it to distress and death in the first place. But it's clearly a bad decision.)