### PR TITLE
Removed positive characteristics from "beat up" engines.

### DIFF
--- a/dat/outfits/core_engine/beat_up_large_engine.xml
+++ b/dat/outfits/core_engine/beat_up_large_engine.xml
@@ -14,7 +14,7 @@
   <turn>40</turn>
   <speed>55</speed>
   <fuel>800</fuel>
-  <energy_usage>26</energy_usage>
-  <engine_limit>6500</engine_limit>
+  <energy_usage>72</energy_usage>
+  <engine_limit>4500</engine_limit>
  </specific>
 </outfit>

--- a/dat/outfits/core_engine/beat_up_medium_engine.xml
+++ b/dat/outfits/core_engine/beat_up_medium_engine.xml
@@ -14,7 +14,7 @@
   <turn>55</turn>
   <speed>105</speed>
   <fuel>400</fuel>
-  <energy_usage>16</energy_usage>
-  <engine_limit>1200</engine_limit>
+  <energy_usage>32</energy_usage>
+  <engine_limit>550</engine_limit>
  </specific>
 </outfit>

--- a/dat/outfits/core_engine/beat_up_small_engine.xml
+++ b/dat/outfits/core_engine/beat_up_small_engine.xml
@@ -14,7 +14,7 @@
   <turn>85</turn>
   <speed>175</speed>
   <fuel>200</fuel>
-  <energy_usage>5</energy_usage>
-  <engine_limit>300</engine_limit>
+  <energy_usage>12</energy_usage>
+  <engine_limit>150</engine_limit>
  </specific>
 </outfit>


### PR DESCRIPTION
These engines previously had particularly high engine mass limits
and particularly low energy usage. I have changed it so that they
have standard engine mass limits and particularly high energy usage.
These engines are supposed to be a last resort, after all.