### PR TITLE
use a table in enumerate function, for lua 5.1 compatibility

### DIFF
--- a/dat/events/tutorial/tutorial-heat.lua
+++ b/dat/events/tutorial/tutorial-heat.lua
@@ -80,7 +80,7 @@ function create()
     tk.msg(title1, message1)
     tk.msg(title1, message2:format(tutGetKey("primary")))
     
-    stages = enumerate("weapons", "wait", "coolwait", "cool")
+    stages = enumerate({"weapons", "wait", "coolwait", "cool"})
     stage = stages.weapons
 
     flytime = 10 -- seconds of fly time

--- a/dat/missions/sirius/achack/achack04.lua
+++ b/dat/missions/sirius/achack/achack04.lua
@@ -95,7 +95,7 @@ function create()
    startplanet, startsys = planet.get("Eenerim")
    tk.msg(title1, text1:format(player.name(), startplanet:name(), startsys:name(), startplanet:name()))
 
-   stages = enumerate("start", "findHarja", "killAssociates", "fetchHarja", "finish")
+   stages = enumerate({"start", "findHarja", "killAssociates", "fetchHarja", "finish"})
    stages["__save"] = true
    stage = 1
    

--- a/dat/scripts/enum.lua
+++ b/dat/scripts/enum.lua
@@ -1,10 +1,10 @@
 -- Enumerates the arguments passed to it. Arguments are used as keys and will be assigned numbers in the order they are passed.
 -- 
--- Example usage: my_enum = enumerate("first", "second", "third")
+-- Example usage: my_enum = enumerate({"first", "second", "third"})
 -- Example usage: print(my_enum.first)
-function enumerate(...)
+function enumerate(list)
     local enum = {}
-    for i, j in ipairs(arg) do
+    for i, j in ipairs(list) do
         enum[j] = i
     end
     return enum


### PR DESCRIPTION
Using the argument "..." in a function is a lua 5.2 feature for handling a variable number of arguments. However, this feature does not exist at all in lua 5.1. Instead, providing the function a single table of strings ensures lua 5.1 compatibility without breaking compatibility with 5.2...

This is also the only function that uses this feature, so replacing it is a trivial matter.