### PR TITLE
Correct calls to glTexImage2D

### DIFF
--- a/src/opengl_tex.c
+++ b/src/opengl_tex.c
@@ -346,12 +346,12 @@ static GLuint gl_loadSurface( SDL_Surface* surface, int *rw, int *rh, unsigned i
    /* now lead the texture data up */
    SDL_LockSurface( surface );
    if (gl_texHasCompress()) {
-      glTexImage2D( GL_TEXTURE_2D, 0, surface->format->BytesPerPixel,
+      glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA,
             surface->w, surface->h, 0, GL_COMPRESSED_RGBA,
             GL_UNSIGNED_BYTE, surface->pixels );
    }
    else {
-      glTexImage2D( GL_TEXTURE_2D, 0, surface->format->BytesPerPixel,
+      glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA,
             surface->w, surface->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surface->pixels );
    }
    SDL_UnlockSurface( surface );

--- a/src/opengl_tex.c
+++ b/src/opengl_tex.c
@@ -346,8 +346,8 @@ static GLuint gl_loadSurface( SDL_Surface* surface, int *rw, int *rh, unsigned i
    /* now lead the texture data up */
    SDL_LockSurface( surface );
    if (gl_texHasCompress()) {
-      glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA,
-            surface->w, surface->h, 0, GL_COMPRESSED_RGBA,
+      glTexImage2D( GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA,
+            surface->w, surface->h, 0, GL_RGBA,
             GL_UNSIGNED_BYTE, surface->pixels );
    }
    else {


### PR DESCRIPTION
I think this is correct. I noticed the issue while trying to port naev
to emscripten. Under emscripten, this made texture rendering work.