### PR TITLE
Got the traders to do convoys

### DIFF
--- a/dat/ai/personality/trader.lua
+++ b/dat/ai/personality/trader.lua
@@ -1,15 +1,28 @@
 -- Default task to run when idle
 function idle ()
-   local planet = ai.landplanet( mem.land_friendly )
-   -- planet must exist.
-   if planet == nil or mem.land_planet == false then
-      ai.settimer(0, rnd.int(1000, 3000))
-      ai.pushtask("enterdelay")
-   else
-      mem.land = planet:pos()
-      ai.pushtask("hyperspace")
-      if not mem.tookoff then
-         ai.pushtask("land")
+   if not mem.boss then -- Pilot nover had a boss
+      mem.boss = ai.getBoss()
+   end
+
+   -- If the boss exists, follow him
+   if mem.boss and mem.boss:exists() then
+         --ai.follow_accurate(mem.boss, mem)
+         mem.angle = rnd.rnd( 360 )
+         mem.radius = rnd.rnd( 70, 130 )
+         ai.pushtask("follow_accurate",mem.boss)
+   else  -- The pilot has no boss, he chooses his target
+      local planet = ai.landplanet( mem.land_friendly )
+      -- planet must exist.
+      if planet == nil or mem.land_planet == false then
+         ai.settimer(0, rnd.int(1000, 3000))
+         ai.pushtask("enterdelay")
+      else
+         mem.land = planet:pos()
+         ai.pushtask("hyperspace")
+         if not mem.tookoff then
+            ai.pushtask("land")
+         end
       end
+
    end
 end

--- a/src/ai.c
+++ b/src/ai.c
@@ -244,6 +244,7 @@ static int aiL_timeup( lua_State *L ); /* boolean timeup( number ) */
 
 /* messages */
 static int aiL_distress( lua_State *L ); /* distress( string [, bool] ) */
+static int aiL_getBoss( lua_State *L ); /* number getBoss() */
 
 /* loot */
 static int aiL_credits( lua_State *L ); /* credits( number ) */
@@ -330,6 +331,7 @@ static const luaL_reg aiL_methods[] = {
    { "timeup", aiL_timeup },
    /* messages */
    { "distress", aiL_distress },
+   { "getBoss", aiL_getBoss },
    /* loot */
    { "setcredits", aiL_credits },
    /* misc */
@@ -3246,6 +3248,26 @@ static int aiL_distress( lua_State *L )
    return 0;
 }
 
+
+/**
+ * @brief Picks a pilot that will command the current pilot.
+ *
+ *    @luatreturn Pilot|nil
+ *    @luafunc getBoss()
+ */
+static int aiL_getBoss( lua_State *L )
+{
+   unsigned int id;
+
+   id = pilot_getBoss( cur_pilot );
+
+   if (id==0) /* No boss found */
+      return 0;
+
+   lua_pushpilot(L, id);
+
+   return 1;
+}
 
 /**
  * @brief Sets the pilot_nstack credits. Only call in create().

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -404,6 +404,76 @@ unsigned int pilot_getNearestPilot( const Pilot* p )
 
 
 /**
+ * @brief Get the strongest ally in a given range.
+ *
+ *    @param p Pilot to get the boss of.
+ *    @return The boss.
+ */
+unsigned int pilot_getBoss( const Pilot* p )
+{
+   unsigned int t;
+   int i;
+   double td, dx, dy;
+   double relpower, ppower, curpower;
+   /* TODO : all the parameters should be adjustable with arguments */
+
+   t = 0;
+
+   /*Hack : the player is used as a reference (for initialization issues)*/
+   ppower = pilot_reldps(  p, pilot_stack[PLAYER_ID] )
+            * pilot_relhp(  p, pilot_stack[PLAYER_ID] );
+
+   for (i=0; i<pilot_nstack; i++) {
+
+      /* Must be in range. */
+      if (!pilot_inRangePilot( p, pilot_stack[i] ))
+         continue;
+
+      /* Must not be self. */
+      if (pilot_stack[i] == p)
+         continue;
+
+      /* Shouldn't be disabled. */
+      if (pilot_isDisabled(pilot_stack[i]))
+         continue;
+
+      /* Must be a valid target. */
+      if (!pilot_validTarget( p, pilot_stack[i] ))
+         continue;
+
+      /* Maximum distance in 2 seconds. */
+      dx = pilot_stack[i]->solid->pos.x + 2*pilot_stack[i]->solid->vel.x -
+           p->solid->pos.x - 2*p->solid->vel.x;
+      dy = pilot_stack[i]->solid->pos.y + 2*pilot_stack[i]->solid->vel.y -
+           p->solid->pos.y - 2*p->solid->vel.y;
+      td = sqrt( pow2(dx) + pow2(dy) );
+      if (td > 5000)
+         continue;
+
+      /* Must have the same faction. */
+      if (pilot_stack[i]->faction != p->faction)
+         continue;
+
+      /* Must be slower. */
+      if (pilot_stack[i]->speed > p->speed)
+         continue;
+
+      curpower = pilot_reldps(  pilot_stack[i], pilot_stack[PLAYER_ID] )
+                 * pilot_relhp(  pilot_stack[i], pilot_stack[PLAYER_ID] );
+
+      /*Should not be weaker than the current pilot*/
+      if (ppower >= curpower )
+         continue;
+
+      if (relpower < curpower ){
+         relpower = curpower;
+         t = pilot_stack[i]->id;
+      }
+   }
+   return t;
+}
+
+/**
  * @brief Get the nearest pilot to a pilot from a certain position.
  *
  *    @param p Pilot to get the nearest pilot of.

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -445,6 +445,7 @@ unsigned int pilot_getNearestEnemy_size( const Pilot* p, double target_mass_LB, 
 unsigned int pilot_getNearestEnemy_heuristic(const Pilot* p, double mass_factor, double health_factor, double damage_factor, double range_factor);
 unsigned int pilot_getNearestHostile (void); /* only for the player */
 unsigned int pilot_getNearestPilot( const Pilot* p );
+unsigned int pilot_getBoss( const Pilot* p );
 double pilot_getNearestPos( const Pilot *p, unsigned int *tp, double x, double y, int disabled );
 double pilot_getNearestAng( const Pilot *p, unsigned int *tp, double ang, int disabled );
 int pilot_getJumps( const Pilot* p );


### PR DESCRIPTION
Every trader ship that jumps in looks for a suitable boss, and follows him. As a result, small convoys are sometimes put together. For now, it's mostly cosmetic because when the pilots feel danger, the convoy disbands itself.
In my opinion, that's a cheap way to get pseudo-fleets that can maybe be transformed into a real fleet system.
If you like it, I can do the same for patrol ships.