### PR TITLE
Fix ldoc build

### DIFF
--- a/docs/lua/config.ld
+++ b/docs/lua/config.ld
@@ -1,6 +1,7 @@
 dir = "../html"
 style = "./"
 template = "./"
+not_luadoc = true
 title = "Naev Lua API"
 project = "Naev Lua API"
 description = "Naev Lua API"

--- a/docs/luadoc.sh
+++ b/docs/luadoc.sh
@@ -14,8 +14,8 @@ for F in ../src/nlua_*.c ../src/ai.c; do
 # Lines after @luafunc & @luamod will be ignored by Luadoc
 # Doxygen comments that do not contain any of these tags have no impact on
 # the Luadoc output.
-         s|^ *\* *@luafunc\(.*\)|function\1\nend|p
 # Rename some tags:
+         s|^ *\* *@luafunc|-- @function|p
          s|^ *\* *@brief|--|p
          s|^ *\* *@luasee|-- @see|p
          s|^ *\* *@luaparam|-- @param|p
@@ -47,18 +47,12 @@ for F in ../src/nlua_*.c ../src/ai.c; do
 # Delete everything else, just in case:
          d
          ' $F | awk '
-         # This awk script removes all lines before @module, so LDoc will not
-         # implicitly declare the module and then produce an error when it is
-         # defined again by the @module command.
+	 # Skips all comment blocks without an @ tag
          BEGIN {
             RS="\n\n"
          }
-         /\n-- @module/ {
-            a=1
-         }
-         {
-            if (a==1)
-               print $0, "\n"
+         /@/ {
+            print $0, "\n"
          }' > lua/"$(basename $F)".luadoc
 done
 

--- a/docs/luadoc.sh
+++ b/docs/luadoc.sh
@@ -57,8 +57,8 @@ for F in ../src/nlua_*.c ../src/ai.c; do
 done
 
 # Run Luadoc, put HTML files into html/ dir
-(
-   cd lua
-   ldoc .
-   rm *.luadoc
-)
+cd lua
+ldoc .
+error=$?
+rm *.luadoc
+exit $error


### PR DESCRIPTION
The sed/awk conversion is a hack and ideally would be eliminated, since ldoc (unlike luadoc) supports [documenting c code](http://stevedonovan.github.io/ldoc/manual/doc.md.html#Extension_modules_written_in_C). Unfortunately naev also uses doxygen comments to document the code, and those would confuse ldoc. I'm not sure how that could be dealt with...

As I've mentioned before, I'd also like to set up automatic building of the API documentation. Travis-CI might be the easiest way to do that.