### PR TITLE
Adjust .travis.yml to build against sdl2, and to build lua api documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ compiler:
    - clang
 before_install:
    - sudo apt-get update -qq
-   - sudo apt-get install -y libsdl2-2.0-0 libsdl2-image-2.0-0 libgl1-mesa-dri libxml2 libfreetype6 libpng12-0 libopenal1 libvorbis0a libzip2 build-essential automake libsdl2-dev libsdl2-image-dev libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev libvorbis-dev binutils-dev libzip-dev libiberty-dev libluajit-5.1-dev
-script: ./autogen.sh && ./configure && make
+   - sudo apt-get install -y libsdl2-2.0-0 libsdl2-image-2.0-0 libgl1-mesa-dri libxml2 libfreetype6 libpng12-0 libopenal1 libvorbis0a libzip2 build-essential automake libsdl2-dev libsdl2-image-dev libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev libvorbis-dev binutils-dev libzip-dev libiberty-dev libluajit-5.1-dev luarocks
+   - sudo luarocks install ldoc
+script:
+   - "./autogen.sh && ./configure && make"
+   - cd docs && ./luadoc.sh && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
    - clang
 before_install:
    - sudo apt-get update -qq
-   - sudo apt-get install -y libsdl2-2.0-0 libsdl2-image-2.0-0 libgl1-mesa-dri libxml2 libfreetype6 libpng12-0 libopenal1 libvorbis0a libzip2 build-essential automake libsdl2-dev libsdl2-image-dev libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev libvorbis-dev binutils-dev libzip-dev libiberty-dev libluajit-5.1-dev luarocks
+   - sudo apt-get install -y build-essential automake libsdl2-dev libsdl2-image-dev libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev libvorbis-dev binutils-dev libzip-dev libiberty-dev libluajit-5.1-dev luarocks
    - sudo luarocks install ldoc
 script:
    - "./autogen.sh && ./configure && make"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: c
+sudo: required
+dist: trusty
 compiler:
    - gcc
    - clang
 before_install:
-   # Travis uses Ubuntu 12.04, which is far too old for SDL2, so build with
-   # SDL 1.2.
    - sudo apt-get update -qq
-   - sudo apt-get install -y build-essential automake libsdl-image1.2-dev libsdl-mixer1.2-dev libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev libvorbis-dev binutils-dev libzip-dev
+   - sudo apt-get install -y libsdl2-2.0-0 libsdl2-image-2.0-0 libgl1-mesa-dri libxml2 libfreetype6 libpng12-0 libopenal1 libvorbis0a libzip2 build-essential automake libsdl2-dev libsdl2-image-dev libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev libvorbis-dev binutils-dev libzip-dev libiberty-dev libluajit-5.1-dev
 script: ./autogen.sh && ./configure && make


### PR DESCRIPTION
This does not implement deployment (#687) of the api docs to http://api.naev.org, but is a step toward that. Travis also has the usual advantages of continuous integration; verifying if PR's build properly, verifying that the lua documentation builds properly (perhaps more important, since that is not usually tested each commit), etc.

I have successfully implemented and tested a Travis setup for deploying via rsync to my own server, but that is not included in this PR because it will need additional configuration for naev's server.

Travis will also need to be activated for the naev/naev repository by an admin at https://travis-ci.org.
