### PR TITLE
Remove some functions from Lua blacklist

### DIFF
--- a/src/nlua.c
+++ b/src/nlua.c
@@ -265,23 +265,18 @@ int nlua_loadBasic( lua_State* L )
          "collectgarbage",
          "dofile",
          "getfenv",
-         "getmetatable",
          "load",
          "loadfile",
          "loadstring",
-         "rawequal",
-         "rawget",
-         "rawset",
          "setfenv",
-         /*"setmetatable",*/
-         "END"
+	 NULL
    };
 
 
    luaL_openlibs(L);
 
    /* replace non-safe functions */
-   for (i=0; strcmp(override[i],"END")!=0; i++) {
+   for (i=0; override[i]!=NULL; i++) {
       lua_pushnil(L);
       lua_setglobal(L, override[i]);
    }


### PR DESCRIPTION
I don't think these are an issue except with intentionally malicious code, which Naev probably doesn't protect well against anyway.

I am trying to use some Lua code (specifically https://github.com/kikito/inspect.lua) that uses getmetatable() and rawget(). If these functions are really an issue, I can probably work around it, but I don't think it's necessary to blacklist them.