### PR TITLE
Added the next FLF Empire alliance campaign mission.

### DIFF
--- a/dat/faction.xml
+++ b/dat/faction.xml
@@ -119,6 +119,7 @@
   <enemies>
    <enemy>Pirate</enemy>
    <enemy>Collective</enemy>
+   <enemy>Rogue FLF</enemy>
   </enemies>
  </faction>
  <faction name="Soromid">
@@ -169,6 +170,7 @@
   <equip>pirate</equip>
   <enemies>
    <enemy>Dvaered</enemy>
+   <enemy>Rogue FLF</enemy>
   </enemies>
  </faction>
  <faction name="Dvaered">
@@ -186,6 +188,7 @@
   <enemies>
    <enemy>Pirate</enemy>
    <enemy>FLF</enemy>
+   <enemy>Rogue FLF</enemy>
   </enemies>
  </faction>
  <faction name="Za'lek">
@@ -233,6 +236,18 @@
   </allies>
   <enemies>
    <enemy>Pirate</enemy>
+  </enemies>
+ </faction>
+ <faction name="Rogue FLF">
+  <static />
+  <invisible />
+  <player>-100</player>
+  <colour>red</colour>
+  <standing>static</standing>
+  <enemies>
+   <enemy>FLF</enemy>
+   <enemy>Dvaered</enemy>
+   <enemy>Empire</enemy>
   </enemies>
  </faction>
  <faction name="Mercenary">

--- a/dat/fleet.xml
+++ b/dat/fleet.xml
@@ -182,6 +182,20 @@
    <pilot name="FLF Lancelot" ship="Lancelot"></pilot>
   </pilots>
  </fleet>
+ <fleet name="Rogue FLF Vendetta">
+  <ai>flf</ai>
+  <faction>Rogue FLF</faction>
+  <pilots>
+   <pilot name="Rogue FLF Vendetta" ship="Vendetta"></pilot>
+  </pilots>
+ </fleet>
+ <fleet name="Rogue FLF Lancelot">
+  <ai>flf</ai>
+  <faction>Rogue FLF</faction>
+  <pilots>
+   <pilot name="Rogue FLF Lancelot" ship="Lancelot"></pilot>
+  </pilots>
+ </fleet>
  <fleet name="Pirate Hyena">
   <ai>pirate</ai>
   <faction>Pirate</faction>

--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -745,6 +745,29 @@
    <cond>faction.playerStanding("FLF") &gt;= 30 and faction.playerStanding("Empire") &gt;= 30</cond>
   </avail>
  </mission>
+ <mission name="The FLF Coup">
+  <lua>flf/empa/flf_empa04</lua>
+  <flags>
+   <unique />
+  </flags>
+  <avail>
+   <chance>60</chance>
+   <done>Raelid Outpost Rescue</done>
+   <location>Bar</location>
+   <faction>FLF</faction>
+   <cond>not diff.isApplied("flf_vs_empire")</cond>
+  </avail>
+ </mission>
+ <mission name="Rogue FLF">
+  <lua>flf/flf_rogue</lua>
+  <avail>
+   <priority>5</priority>
+   <chance>550</chance>
+   <done>The FLF Coup</done>
+   <location>Computer</location>
+   <faction>FLF</faction>
+  </avail>
+ </mission>
  <mission name="Take the Dvaered crew home">
   <lua>dvaered/dv_antiflf01</lua>
   <flags>

--- a/dat/missions/flf/empa/flf_empa04.lua
+++ b/dat/missions/flf/empa/flf_empa04.lua
@@ -1,0 +1,110 @@
+--[[
+
+   The FLF Coup
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--]]
+
+include "dat/missions/flf/flf_rogue.lua"
+
+-- localization stuff
+lang = naev.lang()
+if lang == "raishuu" then
+else -- default English
+   title = {}
+   text = {}
+
+   title[1] = "The Coup"
+   text[1] = [[Cheryl wastes no time. "%s, I'm glad I found you. We have a serious situation, and we need your help.
+    "See, as I sort of mentioned when you were assigned your last mission, some people are quite upset about our cooperation with the Empire. However, it has come to my attention that it's worse than I thought. A fleet of FLF ships has gone rogue and is trying to initiate a coup. It's not that big of a coup, but I'm having trouble riling support against it.
+    "Don't worry. It's not that they support the coup. They don't. But they're just not willing to fight against our former comrades. It just doesn't feel right to them."]]
+
+   text[2] = [[She continues. "I'm so sorry to put you in such a horrible position. I never wanted it to be this way. But if this coup succeeds, all of our operations will be thrown into chaos and our dealings with the Empire will be completely ruined. This coup must be stopped, and since the fleet refuses to respond to our hails, they have to be..." She stops mid-sentence to regain her composure. "They have to be taken out, by any means necessary." Of course, she means that they have to be killed, and this realization makes it clear why she is having so much trouble finding support. After all, FLF soldiers kill Dvaered pilots on a daily basis. But to kill fellow comrades in the FLF? It just feels... wrong.
+    Cheryl clearly sees what you are thinking in your eyes. "Again, I'm so sorry to put you in this position, %s, but I need your help. Can you join the defense against this coup?"]]
+
+   text[3] = [["Thank you, %s. I will continue to look around for more people willing to mount a defense. The rogue fleet has probably already entered the system. Good luck." She wanders off, presumably to find some more help. Well, there's no time to lose.]]
+
+   text[4] = [["I understand. I will continue looking for supporters. Hopefully we can mount some kind of defense."]]
+
+   pay_text = {}
+   pay_text[1] = [[As you return from your dreadful mission, you sense a familiar coldness, mixed in with a great deal of sadness. Cheryl looks at you apologetically, quietly hands you your pay, and leaves.]]
+
+   misn_title = "The Coup"
+   misn_desc = "A fleet of FLF soldiers has initiated a coup. For the safety and stability of the FLF, it must be destroyed."
+   misn_reward = "Securing the stability and future of the FLF"
+
+   npc_name = "Cheryl"
+   npc_desc = "Cheryl looks unusually distraught as she looks for pilots. Perhaps you should see what is the matter."
+end
+
+
+function create ()
+   missys = system.get( "Sigur" )
+   if not misn.claim( missys ) then misn.finish( false ) end
+
+   level = 3
+   ships = 4
+   flfships = 0
+   flfships = 2
+
+   credits = 100000
+
+   late_arrival = true
+   late_arrival_delay = rnd.rnd( 10000, 120000 )
+
+   misn.setNPC( npc_name, "neutral/miner2" )
+   misn.setDesc( npc_desc )
+end
+
+
+function accept ()
+   tk.msg( title[1], text[1]:format( player.name() ) )
+   if tk.yesno( title[1], text[2]:format( player.name() ) ) then
+      tk.msg( title[1], text[3]:format( player.name() ) )
+
+      misn.accept()
+
+      misn.setTitle( misn_title )
+      misn.setDesc( misn_desc )
+      misn.setReward( misn_reward )
+      marker = misn.markerAdd( missys, "high" )
+
+      osd_desc[1] = osd_desc[1]:format( missys:name() )
+      osd_desc[2] = osd_desc[2]:format( misn_level[level] )
+      misn.osdCreate( osd_title, osd_desc )
+
+      rogue_ships_left = 0
+      job_done = false
+      last_system = planet.cur()
+
+      hook.enter( "enter" )
+      hook.jumpout( "leave" )
+      hook.land( "leave" )
+   else
+      tk.msg( title[1], text[4] )
+   end
+end
+
+
+function land_flf ()
+   leave()
+   last_system = nil
+   if planet.cur():faction():name() == "FLF" then
+      tk.msg( "", pay_text[1] )
+      player.pay( credits )
+      misn.finish( true )
+   end
+end
+

--- a/dat/missions/flf/flf_common.lua
+++ b/dat/missions/flf/flf_common.lua
@@ -19,13 +19,26 @@
 --]]
 
 
+-- Get a random system with FLF presence.
+function flf_getSystem ()
+   local choices = {}
+   for i, j in ipairs( system.getAll() ) do
+      local p = j:presences()
+      if p[ "FLF" ] then
+         choices[ #choices + 1 ] = j:name()
+      end
+   end
+   return system.get( choices[ rnd.rnd( 1, #choices ) ] )
+end
+
+
 -- Get a system generally good for an FLF mission.
 -- These are systems which have both FLF and Dvaered presence.
 function flf_getTargetSystem ()
    local choices = {}
    for i, j in ipairs( system.getAll() ) do
       local p = j:presences()
-      if p[ "FLF" ] and p[ "Dvaered" ]  then
+      if p[ "FLF" ] and p[ "Dvaered" ] then
          choices[ #choices + 1 ] = j:name()
       end
    end

--- a/dat/missions/flf/flf_rogue.lua
+++ b/dat/missions/flf/flf_rogue.lua
@@ -1,0 +1,225 @@
+--[[
+
+   Rogue FLF Elimination Mission
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--]]
+
+include "numstring.lua"
+include "fleethelper.lua"
+include "dat/missions/flf/flf_common.lua"
+
+-- localization stuff, translators would work here
+lang = naev.lang()
+if lang == "utau koto suki hae" then
+else -- default english
+   misn_title  = "FLF: Rogue %s in %s"
+   misn_reward = "%s credits"
+
+   text = {}
+   text[1] = "The officer is clearly not happy with the loss, but mumbles a thank-you and hands you your pay."
+   text[2] = "As you enter the station, you detect a feeling of dread. You silently collect your pay, avoiding eye contact with the other soldiers."
+   text[3] = "A soldier gives you a dirty look as you move to collect your pay."
+   text[4] = "An FLF soldier, while upset about the infighting, thanks you for your service and buys you a drink."
+   text[5] = "You are silently handed your pay by an officer who looks utterly depressed."
+   text[6] = "An FLF officer forces out a smile as you collect your pay. It's unfortunate, but the job had to be done."
+
+   misn_desc = {}
+   misn_desc[1] = "There is a squadron of rogue FLF ships with %d ships in the %s system. Eliminate this squadron."
+   misn_desc[2] = "There is a rogue FLF ship in the %s system. Eliminate this ship."
+   misn_desc[3] = " You will be accompanied by %d other FLF pilots for this mission."
+
+   misn_level = {}
+   misn_level[1] = "Pilot"
+   misn_level[2] = "Squadron"
+   misn_level[3] = "Squadron"
+   misn_level[4] = "Fleet"
+
+   osd_title   = "Rogue FLF"
+   osd_desc    = {}
+   osd_desc[1] = "Fly to the %s system"
+   osd_desc[2] = "Eliminate the rogue FLF %s"
+   osd_desc[3] = "Return to FLF base"
+   osd_desc["__save"] = true
+end
+
+
+function create ()
+   missys = flf_getSystem()
+   if not misn.claim( missys ) then misn.finish( false ) end
+
+   level = rnd.rnd( 1, #misn_level )
+   ships = 0
+   flfships = 0
+   if level == 1 then
+      ships = 1
+   elseif level == 2 then
+      ships = rnd.rnd( 2, 3 )
+   elseif level == 3 then
+      ships = 4
+      if rnd.rnd() < 0.5 then
+         flfships = 2
+      end
+   elseif level == 4 then
+      ships = 7
+      flfships = rnd.rnd( 2, 4 )
+   end
+
+   credits = ships * 30000 - flfships * 1000
+   credits = credits * system.cur():jumpDist( missys ) / 3
+   credits = credits + rnd.sigma() * 8000
+
+   local desc
+   if ships == 1 then
+      desc = misn_desc[2]:format( missys:name() )
+   else
+      desc = misn_desc[1]:format( ships, missys:name() )
+   end
+   if flfships > 0 then
+      desc = desc .. misn_desc[3]:format( flfships )
+   end
+
+   late_arrival = rnd.rnd() < 0.75
+   late_arrival_delay = rnd.rnd( 10000, 120000 )
+
+   -- Set mission details
+   misn.setTitle( misn_title:format( misn_level[level], missys:name() ) )
+   misn.setDesc( desc )
+   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   marker = misn.markerAdd( missys, "computer" )
+end
+
+
+function accept ()
+   misn.accept()
+
+   osd_desc[1] = osd_desc[1]:format( missys:name() )
+   osd_desc[2] = osd_desc[2]:format( misn_level[level] )
+   misn.osdCreate( osd_title, osd_desc )
+
+   rogue_ships_left = 0
+   job_done = false
+   last_system = planet.cur()
+
+   hook.enter( "enter" )
+   hook.jumpout( "leave" )
+   hook.land( "leave" )
+end
+
+
+function enter ()
+   if not job_done then
+      if system.cur() == missys then
+         misn.osdActive( 2 )
+         rogue_spawnRogue( ships )
+         if flfships > 0 then
+            if not late_arrival then
+               rogue_spawnFLF( flfships, last_system )
+            else
+               hook.timer( late_arrival_delay, "timer_lateFLF" )
+            end
+         end
+      else
+         misn.osdActive( 1 )
+      end
+   end
+end
+
+
+function leave ()
+   if spawner ~= nil then hook.rm( spawner ) end
+   rogue_ships_left = 0
+   last_system = system.cur()
+end
+
+
+function timer_lateFLF ()
+   local systems = system.cur():adjacentSystems()
+   local source = systems[ rnd.rnd( 1, #systems ) ]
+   rogue_spawnFLF( flfships, source )
+end
+
+
+function pilot_death_rogue ()
+   rogue_ships_left = rogue_ships_left - 1
+   if rogue_ships_left <= 0 then
+      job_done = true
+      misn.osdActive( 3 )
+      misn.markerRm( marker )
+      hook.land( "land_flf" )
+      pilot.toggleSpawn( true )
+      if fleetFLF ~= nil then
+         for i, j in ipairs( fleetFLF ) do
+            if j:exists() then
+               j:changeAI( "flf" )
+            end
+         end
+      end
+   end
+end
+
+
+function land_flf ()
+   leave()
+   last_system = nil
+   if planet.cur():faction():name() == "FLF" then
+      tk.msg( "", text[ rnd.rnd( 1, #text ) ] )
+      player.pay( credits )
+      misn.finish( true )
+   end
+end
+
+
+-- Spawn a rogue FLF squad with n ships.
+function rogue_spawnRogue( n )
+   pilot.clear()
+   pilot.toggleSpawn( false )
+   player.pilot():setVisible( true )
+   if rnd.rnd() < 0.05 then n = n + 1 end
+   local r = system.cur():radius()
+   fleetRogue = {}
+   for i = 1, n do
+      local x = rnd.rnd( -r, r )
+      local y = rnd.rnd( -r, r )
+      local shipname
+      local shipnames = { "Rogue FLF Vendetta", "Rogue FLF Lancelot" }
+      shipname = shipnames[ rnd.rnd( 1, #shipnames ) ]
+      local pstk = pilot.add( shipname, "flf_norun", vec2.new( x, y ) )
+      local p = pstk[1]
+      hook.pilot( p, "death", "pilot_death_rogue" )
+      p:setHostile()
+      p:setVisible( true )
+      p:setHilight( true )
+      fleetRogue[i] = p
+      rogue_ships_left = rogue_ships_left + 1
+   end
+end
+
+
+-- Spawn n FLF ships at/from the location param.
+function rogue_spawnFLF( n, param )
+   if rnd.rnd() < 0.25 then n = n - 1 end
+   local lancelots = rnd.rnd( n )
+   fleetFLF = addShips( "FLF Lancelot", "flf_norun", param, lancelots )
+   local vendetta_fleet = addShips( "FLF Vendetta", "flf_norun", param, n - lancelots )
+   for i, j in ipairs( vendetta_fleet ) do
+      fleetFLF[ #fleetFLF + 1 ] = j
+   end
+   for i, j in ipairs( fleetFLF ) do
+      j:setFriendly()
+      j:setVisible( true )
+   end
+end
+


### PR DESCRIPTION
This is where the campaign goes sour. Tense feelings from a minority
of FLF pilots causes some of them to go rogue and attempt to initiate
a coup. The player is then tasked with stopping this coup. Of course,
this is just the beginning.

This mission also unlocks missions similar to the Dvaered patrol
missions, but targeting rogue FLF pilots instead. Unlike the Dvaered
patrol missions, these missions do not give you a reputation boost,
only money, and completion is met with coldness.