### PR TITLE
Alternate system for allying with the pirates

### DIFF
--- a/dat/events/pirate_fame.lua
+++ b/dat/events/pirate_fame.lua
@@ -66,27 +66,22 @@ end
 function create()
    local fame = faction.playerStanding("Pirate")
 
-   -- If the player already has a low reputation, just stop there. 20 is the
-   -- minimum required to land on a pirate planet without having to bribe the
-   -- guy in charge of landing ships.
    local floor = var.peek("_ffloor_decay_pirate")
    if floor == nil then floor = -20 end
    if fame <= floor then
       evt.finish()
    end
 
-   local maybe
+   local amt
    if using_pirate_ship() then
-      maybe = 0.05
+      amt = 0.15 + rnd.sigma() * 0.05
    elseif using_impressive_ship() then
-      maybe = 0.10
+      amt = 0.5 + rnd.sigma() * 0.10
    else
-      maybe = 0.15
+      amt = 1 + rnd.sigma() * 0.25
    end
 
-   if rnd.rnd() < maybe then
-      faction.modPlayerSingle("Pirate",-1)
-   end
+   faction.modPlayerSingle( "Pirate", -amt )
 
    evt.finish()
 end

--- a/dat/events/pirate_fame.lua
+++ b/dat/events/pirate_fame.lua
@@ -69,7 +69,9 @@ function create()
    -- If the player already has a low reputation, just stop there. 20 is the
    -- minimum required to land on a pirate planet without having to bribe the
    -- guy in charge of landing ships.
-   if fame <= 20 then
+   local floor = var.peek("_ffloor_decay_pirate")
+   if floor == nil then floor = -20 end
+   if fame <= floor then
       evt.finish()
    end
 

--- a/dat/factions/standing/pirate.lua
+++ b/dat/factions/standing/pirate.lua
@@ -4,8 +4,8 @@ include "dat/factions/standing/skel.lua"
 
 
 _fcap_kill     = 30 -- Kill cap
-_fdelta_distress = {-1, 2} -- Maximum change constraints
-_fdelta_kill     = {-1, 2} -- Maximum change constraints
+_fdelta_distress = {-2, 0.25} -- Maximum change constraints
+_fdelta_kill     = {-5, 1} -- Maximum change constraints
 _fcap_misn     = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_pirate"
 _fthis         = faction.get("Pirate")

--- a/dat/factions/standing/pirate.lua
+++ b/dat/factions/standing/pirate.lua
@@ -4,13 +4,21 @@ include "dat/factions/standing/skel.lua"
 
 
 _fcap_kill     = 30 -- Kill cap
-_fdelta_distress = {0, 0} -- Maximum change constraints
-_fdelta_kill     = {0, 0} -- Maximum change constraints
+_fdelta_distress = {-1, 2} -- Maximum change constraints
+_fdelta_kill     = {-1, 2} -- Maximum change constraints
 _fcap_misn     = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_pirate"
 _fthis         = faction.get("Pirate")
 
+-- Secondary hit modifiers.
+_fmod_distress_enemy  = 1 -- Distress of the faction's enemies
+_fmod_distress_friend = 0 -- Distress of the faction's allies
+_fmod_kill_enemy      = 1 -- Kills of the faction's enemies
+_fmod_kill_friend     = 0 -- Kills of the faction's allies
+_fmod_misn_enemy      = 0.3 -- Missions done for the faction's enemies
+_fmod_misn_friend     = 0 -- Missions done for the faction's allies
+
 
 function faction_hit( current, amount, source, secondary )
-    return default_hit(current, amount, source, secondary)
+   return math.max( -20, default_hit( current, amount, source, secondary ) )
 end

--- a/dat/factions/standing/skel.lua
+++ b/dat/factions/standing/skel.lua
@@ -106,6 +106,7 @@ function default_hit( current, amount, source, secondary )
    local cap
    local mod = 1
    if source == "distress" then
+      cap   = _fcap_kill
       delta = clone(_fdelta_distress)
 
       -- Adjust for secondary hit

--- a/dat/missions/pirate/common.lua
+++ b/dat/missions/pirate/common.lua
@@ -21,3 +21,12 @@ function pir_getLordRandomPortrait ()
 
    return portraits[ rnd.rnd( 1, #portraits ) ]
 end
+
+
+function pir_modDecayFloor( n )
+   local floor = var.peek("_ffloor_decay_pirate")
+   if floor == nil then floor = -20 end
+   floor = math.min(floor + n, -1)
+   var.push("_ffloor_decay_pirate", floor)
+end
+

--- a/dat/missions/pirate/hitman.lua
+++ b/dat/missions/pirate/hitman.lua
@@ -8,6 +8,8 @@
 
 --]]
 
+include "dat/missions/pirate/common.lua"
+
 -- Localization, choosing a language if naev is translated for non-english-speaking locales.
 lang = naev.lang()
 if lang == "es" then
@@ -136,6 +138,7 @@ function landed()
       tk.msg(title[3], text[3])
       player.pay(45000)
       faction.modPlayerSingle("Pirate",5)
+      pir_modDecayFloor( 2 )
       misn.finish(true)
    end
 end

--- a/dat/missions/pirate/hitman2.lua
+++ b/dat/missions/pirate/hitman2.lua
@@ -8,6 +8,8 @@
 
 --]]
 
+include "dat/missions/pirate/common.lua"
+
 -- Localization, choosing a language if naev is translated for non-english-speaking locales.
 lang = naev.lang()
 if lang == "es" then
@@ -117,6 +119,7 @@ function landed()
       tk.msg(title[3], text[3])
       player.pay(100000) -- 100k
       faction.modPlayerSingle("Pirate",5)
+      pir_modDecayFloor( 3 )
       misn.finish(true)
    end
 end

--- a/dat/missions/pirate/hitman3.lua
+++ b/dat/missions/pirate/hitman3.lua
@@ -17,7 +17,7 @@ else -- Default to English
 
    -- Mission details
    misn_title  = "Pirate Hitman 3"
-   misn_reward = "Pirate landing permision"
+   misn_reward = "More easy money."
    misn_desc   = "The Empire patrol vessel known as %s must be terminated. It was last seen near the %s system."
    misn_desc2  = "Return to %s to get your rewards."
 
@@ -27,8 +27,8 @@ else -- Default to English
    title[1] = "Spaceport Bar"
    title[2] = "Mission Complete"
    text[1]  = [[As you approach, the man merely glances at you before pushing out a chair for you. "Hello. A certain trader associate of mine has recommended your services." You nod knowingly, and he continues, "A certain Empire pilot has been... consistent in refusing our bribes. We'd like to be rid of him as soon as possible. Are you up for it?]]
-   text[2]  = [["Excellent. If you're successful in removing him, I have a token that will grant you landing access to all pirate worlds." His demeanour shifts slightly before he continues, "Of course, we are not the forgiving type. If you rat us out, we will find you. If you fail, well, I suppose you'll be sent to one of the Empire's penal colonies. That said, you've performed admirably for my associate, so I trust I'll see you again soon."]]
-   text[3] = [[The businessman is waiting for you. "Ah, you've returned. I've already received the good news from my associates who monitor the Empire communications band. Here's the landing pass, you're now free to land at any pirate colony. There's always work for a competent pilot; I look forward to working with you again." With that, the man walks away, disappearing into a crowd. You wonder how much "business" this supposed businessman is involved in.]]
+   text[2]  = [["Excellent. If you're successful in removing him, you will of course be rewarded." His demeanour shifts slightly before he continues, "Of course, we are not the forgiving type. If you rat us out, we will find you. If you fail, well, I suppose you'll be sent to one of the Empire's penal colonies. That said, you've performed admirably for my associate, so I trust I'll see you again soon."]]
+   text[3] = [[The businessman is waiting for you. "Ah, you've returned. I've already received the good news from my associates who monitor the Empire communications band. Here's your pay. There's always work for a competent pilot; I look forward to working with you again." With that, the man walks away, disappearing into a crowd. You wonder how much "business" this supposed businessman is involved in.]]
 
    msg = {}
    msg[1] = "Target destroyed. Mission objective updated"
@@ -138,16 +138,10 @@ function landed ()
    if planet.cur() == misn_base then
       tk.msg(title[2], text[3])
 
-      -- Give factions
-      local f = faction.playerStanding("Pirate")
-      if f < 0 then
-            f = 0 - f
-            faction.modPlayerSingle( "Pirate", f )
-      end
-   
-      -- Give landing pass   
-      player.addOutfit("Pirate Landing Pass")
+      -- Give rewards
+      faction.modPlayerSingle( "Pirate", 5 )
       player.pay( 100000 ) -- 100k
+      pir_modDecayFloor( 5 )
 
       -- Finish mission
       misn.finish(true)


### PR DESCRIPTION
Here's a rework of the way you align yourself with the pirates. I haven't tested it much, so it could be that exact numbers should be adjusted, but I think the concept works well and it seems to me to be better than the current system, at least.

Here's how it works:

1. You can gain reputation with the pirates by killing, attacking, and all-around causing mayhem. You lose reputation by killing pirates.
2. Every time you change systems, there's a chance of losing reputation. This was already in place, but I modified it so that the floor starts at -20 and is adjusted up by missions, rather than being a static 20. It cannot rise above -1. As a result, you have to continue committing piracy to stay friendly with the pirates, no matter how many campaigns you've completed.
3. Campaigns are used to boost the mission cap (as with other factions) and, additionally, to boost the reputation floor. Currently, the Hitman campaign just adjusts the reputation floor.
4. The "Pirate Landing Pass" is no longer given to the player, though I haven't removed it outright at this point.
5. Missions (which I haven't worked on yet) should give both reputation and money.
6. It's essentially impossible to both be a pirate and be friendly with the other factions.

So in a nutshell, this system is simpler, yet more difficult. I think this is a far better system for someone who wants to commit galactic piracy.

Of course, I realize this is a pretty substantial change, so if there is disagreement on this, I am open to suggestions.