### PR TITLE
Fixed Za'lek Test continued being slow after completion.

### DIFF
--- a/dat/missions/zalek/zlk_test.lua
+++ b/dat/missions/zalek/zlk_test.lua
@@ -176,6 +176,11 @@ end
 
 function land()
 
+   if isSlow then   --The player is still slow and will recover normal velocity
+      player.pilot():setSpeedLimit(0)
+      isSlow = false
+   end
+
    if planet.cur() == destplanet and stage == 0 then
       tk.msg( msg_title[3], msg_msg[3])
       player.pay(reward)
@@ -190,10 +195,6 @@ function land()
    if planet.cur() ~= curplanet and stage == 1 then  --Lands elsewhere without the engine
       tk.msg( misst, miss)
       abort()
-   end
-
-   if isSlow then   --The player is still slow and will recover normal velocity
-      player.pilot():setSpeedLimit(0)
    end
 
    curplanet = planet.cur()


### PR DESCRIPTION
When during the Za'lek Test Engine mission the engine looses power,
and the engine doesn't recover its speed after a while
and the player lands on the final detsination planet without landing
on any other planet after loosing power to the test engine,
then the player stayed slow (the player did not recover its speed).