### PR TITLE
[Docs] Replace '=' with '=='

### DIFF
--- a/src/nlua_faction.c
+++ b/src/nlua_faction.c
@@ -199,7 +199,7 @@ int lua_isfaction( lua_State *L, int ind )
 /**
  * @brief __eq (equality) metamethod for factions.
  *
- * You can use the '=' operator within Lua to compare factions with this.
+ * You can use the '==' operator within Lua to compare factions with this.
  *
  * @usage if f == faction.get( "Dvaered" ) then
  *

--- a/src/nlua_jump.c
+++ b/src/nlua_jump.c
@@ -278,7 +278,7 @@ static int jumpL_get( lua_State *L )
 
 
 /**
- * @brief You can use the '=' operator within Lua to compare jumps with this.
+ * @brief You can use the '==' operator within Lua to compare jumps with this.
  *
  * @usage if j:__eq( jump.get( "Rhu", "Ruttwi" ) ) then -- Do something
  *    @luatparam Jump j Jump comparing.

--- a/src/nlua_news.c
+++ b/src/nlua_news.c
@@ -381,7 +381,7 @@ int newsL_get( lua_State *L )
 /**
  * @brief Check articles for equality.
  *
- * Allows you to use the '=' operator in Lua with articles.
+ * Allows you to use the '==' operator in Lua with articles.
  *
  *    @luatparam Article a1 article 1
  *    @luatparam Article a2 article 2

--- a/src/nlua_planet.c
+++ b/src/nlua_planet.c
@@ -439,7 +439,7 @@ static int planetL_system( lua_State *L )
 }
 
 /**
- * @brief You can use the '=' operator within Lua to compare planets with this.
+ * @brief You can use the '==' operator within Lua to compare planets with this.
  *
  * @usage if p.__eq( planet.get( "Anecu" ) ) then -- Do something
  * @usage if p == planet.get( "Anecu" ) then -- Do something

--- a/src/nlua_system.c
+++ b/src/nlua_system.c
@@ -278,7 +278,7 @@ static int systemL_getAll( lua_State *L )
 /**
  * @brief Check systems for equality.
  *
- * Allows you to use the '=' operator in Lua with systems.
+ * Allows you to use the '==' operator in Lua with systems.
  *
  * @usage if sys == system.get( "Draygar" ) then -- Do something
  *


### PR DESCRIPTION
Comparison is done with the latter, not the former.