### PR TITLE
macOS fixes

### DIFF
--- a/extras/macos/Info.plist.in
+++ b/extras/macos/Info.plist.in
@@ -7,7 +7,7 @@
 	<key>CFBundleIconFile</key>
 	<string>naev.icns</string>
 	<key>CFBundleIdentifier</key>
-  <string>org.naev.naev</string>
+	<string>org.naev.Naev</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/extras/macos/bundle.sh
+++ b/extras/macos/bundle.sh
@@ -79,4 +79,7 @@ for dep in Naev.app/Contents/Frameworks/*.dylib; do
     $dep
 done
 
+# Strip headers, especially from the SDL2 framework.
+find Naev.app -name Headers -prune | xargs rm -r
+
 echo "Successfully created Naev.app"

--- a/extras/macos/bundle.sh
+++ b/extras/macos/bundle.sh
@@ -24,7 +24,7 @@ cp extras/macos/naev.icns Naev.app/Contents/Resources/
 cp src/naev Naev.app/Contents/MacOS/
 
 # Bundle the SDL2 framework.
-cp -r ~/Library/Frameworks/SDL2.framework \
+cp -R ~/Library/Frameworks/SDL2.framework \
   Naev.app/Contents/Frameworks/SDL2.framework
 
 # Find all Homebrew dependencies (from /usr/local),

--- a/extras/macos/codesign.sh
+++ b/extras/macos/codesign.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# After building Naev.app, use this script to sign the bundle. Requires a
+# single argument: the signing identity. This should be a code-signing
+# certificate present in the default keychain.
+
+# Official Naev builds are currently not yet signed, so this script is right
+# now just an example.
+
+exec codesign --verbose --force --deep --sign "$1" \
+  --entitlements extras/macos/entitlements.plist \
+  Naev.app

--- a/extras/macos/entitlements.plist
+++ b/extras/macos/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Some macOS build fixes, and also app sandbox preparation.

While Naev now works in the app sandbox, it means ndata must be inside the app bundle. Outside of the bundle, you can drag ndata to Naev and it'll work, but this creates a temporary sandbox exception that is forgotten when Naev closes. (So you'll get `insert ndata` on every launch.)

So we'd have to either instruct users to place ndata inside the bundle, or (better) distribute Naev with ndata already in place. (Better, because I believe we can then also sign the entire bundle including ndata.)

The other thing is that app sandbox involves a manual migration of config and save games. Apps running in the sandbox get a private home directory. We can't really help the user, because the old locations are all outside the grasp of the sandboxed app.

So yeah, I've left that off for now, but it's there if we want to. Biggest benefit is that we could eventually get a $99/year developer cert from apple, and launch on the App Store. :)