### PR TITLE
Changed the way spawn position is chosen

### DIFF
--- a/dat/factions/spawn/civilian.lua
+++ b/dat/factions/spawn/civilian.lua
@@ -44,7 +44,7 @@ function spawn ( presence, max )
     end
     
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Civilian" )
     
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/collective.lua
+++ b/dat/factions/spawn/collective.lua
@@ -93,7 +93,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, Collective )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/common.lua
+++ b/dat/factions/spawn/common.lua
@@ -66,24 +66,24 @@ end
 
 
 -- @brief Actually spawns the pilots
-function scom.spawn( pilots )
+function scom.spawn( pilots, faction )
    local spawned = {}
    local leader = nil
+
+   local origin = pilot.choosePoint( faction ) -- Find a suitable spawn point
    for k,v in ipairs(pilots) do
       local p
       if type(v["pilot"])=='function' then
          p = v["pilot"]() -- Call function
       elseif not v["pilot"][1] then
-         local pos = nil
          if leader ~= nil then
-            pos = leader:pos()
             if pilots.__formation ~= nil then
                leader:memory().formation = pilots.__formation
             end
          end
-         p = pilot.add( v["pilot"], nil, pos )
+         p = pilot.add( v["pilot"], nil, origin )
       else
-         p = scom.spawnRaw( v["pilot"][1], v["pilot"][2], v["pilot"][3], v["pilot"][4], v["pilot"][5])
+         p = scom.spawnRaw( v["pilot"][1], v["pilot"][2], v["pilot"][3], v["pilot"][4], v["pilot"][5], origin )
       end
       if #p == 0 then
          error(_("No pilots added"))
@@ -105,8 +105,8 @@ end
 
 
 -- @brief spawn a pilot with addRaw
-function scom.spawnRaw( ship, name, ai, equip, faction)
-   local p = {pilot.addRaw( ship, ai, nil, equip )}
+function scom.spawnRaw( ship, name, ai, equip, faction, origin)
+   local p = {pilot.addRaw( ship, ai, origin, equip )}
    p[1]:rename(name)
    p[1]:setFaction(faction)
    return p

--- a/dat/factions/spawn/dvaered.lua
+++ b/dat/factions/spawn/dvaered.lua
@@ -112,7 +112,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Dvaered" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/empire.lua
+++ b/dat/factions/spawn/empire.lua
@@ -156,7 +156,7 @@ function spawn ( presence, max )
    end
   
    -- Actually spawn the pilots
-   pilots = scom.spawn( spawn_data )
+   pilots = scom.spawn( spawn_data, "Empire" )
 
    -- Calculate spawn data
    spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/flf.lua
+++ b/dat/factions/spawn/flf.lua
@@ -72,7 +72,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "FLF" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/frontier.lua
+++ b/dat/factions/spawn/frontier.lua
@@ -71,7 +71,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Frontier" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/goddard.lua
+++ b/dat/factions/spawn/goddard.lua
@@ -57,7 +57,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Goddard" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/independent.lua
+++ b/dat/factions/spawn/independent.lua
@@ -76,7 +76,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Independent" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/pirate.lua
+++ b/dat/factions/spawn/pirate.lua
@@ -120,7 +120,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Pirate" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/proteron.lua
+++ b/dat/factions/spawn/proteron.lua
@@ -108,7 +108,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Proteron" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/sirius.lua
+++ b/dat/factions/spawn/sirius.lua
@@ -109,7 +109,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Sirius" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/soromid.lua
+++ b/dat/factions/spawn/soromid.lua
@@ -111,7 +111,7 @@ function spawn ( presence, max )
    end
   
    -- Actually spawn the pilots
-   pilots = scom.spawn( spawn_data )
+   pilots = scom.spawn( spawn_data, "Soromid" )
 
    -- Calculate spawn data
    spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/thurion.lua
+++ b/dat/factions/spawn/thurion.lua
@@ -111,7 +111,7 @@ function spawn ( presence, max )
    end
   
    -- Actually spawn the pilots
-   pilots = scom.spawn( spawn_data )
+   pilots = scom.spawn( spawn_data, "Thurion" )
 
    -- Calculate spawn data
    spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/trader.lua
+++ b/dat/factions/spawn/trader.lua
@@ -74,7 +74,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Trader" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/zalek.lua
+++ b/dat/factions/spawn/zalek.lua
@@ -121,7 +121,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data )
+    pilots = scom.spawn( spawn_data, "Za'lek" )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -150,6 +150,7 @@ static int pilotL_leader( lua_State *L );
 static int pilotL_setLeader( lua_State *L );
 static int pilotL_followers( lua_State *L );
 static int pilotL_hookClear( lua_State *L );
+static int pilotL_choosePoint( lua_State *L );
 static const luaL_Reg pilotL_methods[] = {
    /* General. */
    { "addRaw", pilotL_addFleetRaw },
@@ -247,6 +248,7 @@ static const luaL_Reg pilotL_methods[] = {
    { "setLeader", pilotL_setLeader },
    { "followers", pilotL_followers },
    { "hookClear", pilotL_hookClear },
+   { "choosePoint", pilotL_choosePoint },
    {0,0}
 }; /**< Pilot metatable methods. */
 
@@ -370,6 +372,41 @@ int lua_ispilot( lua_State *L, int ind )
 
 
 /**
+ * @brief Returns a suitable jumpin spot for a given pilot.
+ * @usage point = pilot.choosePoint( f, i )
+ *
+ *    @luatparam Faction f Faction the pilot will belong to.
+ *    @luatparam boolean i Wether to ignore rules.
+ *    @luatreturn Planet|Vec2|Jump A randomly chosen suitable spawn point.
+ * @luafunc choosePoint( f, i )
+ */
+static int pilotL_choosePoint( lua_State *L )
+{
+   LuaFaction lf;
+   int ignore_rules, planetind, jump;
+   Vector2d vp;
+
+   lf = faction_get( luaL_checkstring(L,1) );
+
+   ignore_rules = 0;
+   if (lua_isboolean(L,2) && lua_toboolean(L,2))
+      ignore_rules = 1;
+
+   planetind = jump = -1;
+   pilot_choosePoint( &vp, &planetind, &jump, lf, ignore_rules );
+
+   if (planetind >= 0)
+      lua_pushplanet(L, planetind );
+   else if (jump >= 0)
+      lua_pushsystem(L, cur_system->jumps[jump].target->id);
+   else
+      lua_pushvector(L, vp);
+
+   return 1;
+}
+
+
+/**
  * @brief Wrapper with common code for pilotL_addFleet and pilotL_addFleetRaw.
  */
 static int pilotL_addFleetFrom( lua_State *L, int from_ship )
@@ -380,17 +417,14 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
    int i, first;
    unsigned int p;
    double a, r;
-   Vector2d vv,vp, vn;
+   Vector2d vv, vp, vn;
    FleetPilot *plt;
    LuaFaction lf;
    StarSystem *ss;
    Planet *planet;
-   JumpPoint *target;
+   int planetind;
    int jump;
    PilotFlags flags;
-   int *jumpind, njumpind;
-   int *ind, nind;
-   double chance;
    int ignore_rules;
 
    /* Default values. */
@@ -475,75 +509,25 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
       if (lua_isboolean(L,3) && lua_toboolean(L,3))
          ignore_rules = 1;
 
-      /* Build landable planet table. */
-      ind   = NULL;
-      nind  = 0;
-      if (cur_system->nplanets > 0) {
-         ind = malloc( sizeof(int) * cur_system->nplanets );
-         for (i=0; i<cur_system->nplanets; i++)
-            if (planet_hasService(cur_system->planets[i],PLANET_SERVICE_INHABITED) &&
-                  !areEnemies(lf,cur_system->planets[i]->faction))
-               ind[ nind++ ] = i;
+      /* Choose the spawn point and act in consequence.*/
+      planetind = -1;
+      pilot_choosePoint( &vp, &planetind, &jump, lf, ignore_rules );
+
+      if ( planetind >= 0 ) {
+         planet = planet_getIndex( planetind );
+         pilot_setFlagRaw( flags, PILOT_TAKEOFF );
+         a = RNGF() * 2. * M_PI;
+         r = RNGF() * planet->radius;
+         vect_cset( &vp,
+               planet->pos.x + r * cos(a),
+               planet->pos.y + r * sin(a) );
+         a = RNGF() * 2.*M_PI;
+         vectnull( &vv );
       }
-
-      /* Build jumpable jump table. */
-      jumpind  = NULL;
-      njumpind = 0;
-      if (cur_system->njumps > 0) {
-         jumpind = malloc( sizeof(int) * cur_system->njumps );
-         for (i=0; i<cur_system->njumps; i++) {
-            /* The jump into the system must not be exit-only, and unless
-             * ignore_rules is set, must also be non-hidden and have faction
-             * presence matching the pilot's on the remote side.
-             */
-            target = jump_getTarget( cur_system, cur_system->jumps[i].target );
-            if (!jp_isFlag( target, JP_EXITONLY ) && (ignore_rules ||
-                  (!jp_isFlag( &cur_system->jumps[i], JP_HIDDEN ) &&
-                  (system_getPresence( cur_system->jumps[i].target, lf ) > 0))))
-               jumpind[ njumpind++ ] = i;
-         }
+      else if ( &vp != NULL ) {
+         a = RNGF() * 2.*M_PI;
+         vectnull( &vv );
       }
-
-      /* Crazy case no landable nor presence, we'll just jump in randomly. */
-      if ((nind == 0) && (njumpind==0)) {
-         if (cur_system->njumps > 0) {
-            jumpind = malloc( sizeof(int) * cur_system->njumps );
-            for (i=0; i<cur_system->njumps; i++)
-               jumpind[ njumpind++ ] = i;
-         }
-         else {
-            WARN(_("Creating pilot in system with no jumps nor planets to take off from!"));
-            vectnull( &vp );
-            a = RNGF() * 2.*M_PI;
-            vectnull( &vv );
-         }
-      }
-
-      /* Calculate jump chance. */
-      if ((ind != NULL) || (jumpind != NULL)) {
-         chance = njumpind;
-         chance = chance / (chance + nind);
-
-         /* Random jump in. */
-         if ((ind == NULL) || ((RNGF() <= chance) && (jumpind != NULL)))
-            jump = jumpind[ RNG_SANE(0,njumpind-1) ];
-         /* Random take off. */
-         else if (ind !=NULL && nind != 0) {
-            planet = cur_system->planets[ ind[ RNG_SANE(0,nind-1) ] ];
-            pilot_setFlagRaw( flags, PILOT_TAKEOFF );
-            a = RNGF() * 2. * M_PI;
-            r = RNGF() * planet->radius;
-            vect_cset( &vp,
-                  planet->pos.x + r * cos(a),
-                  planet->pos.y + r * sin(a) );
-            a = RNGF() * 2.*M_PI;
-            vectnull( &vv );
-         }
-      }
-
-      /* Free memory allocated. */
-      free( ind );
-      free( jumpind );
    }
 
    /* Set up velocities and such. */

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -498,6 +498,7 @@ unsigned int pilot_create( Ship* ship, const char* name, int faction, const char
 Pilot* pilot_createEmpty( Ship* ship, const char* name,
       int faction, const char *ai, PilotFlags flags );
 Pilot* pilot_copy( Pilot* src );
+void pilot_choosePoint( Vector2d *vp, int *planet, int *jump, int lf, int ignore_rules );
 void pilot_delete( Pilot *p );
 
 


### PR DESCRIPTION
I propose a new implementation of the way to ensure that all the ships in a fleet spawn from the same jump/planet. I belive, this implementation is more handy as the previous one.
The only visible effect of this modification is that the escort of a capship now jumps-in in the same time as the capship.