### PR TITLE
changed the way pirates and FLF spawn

### DIFF
--- a/dat/factions/spawn/common.lua
+++ b/dat/factions/spawn/common.lua
@@ -66,11 +66,11 @@ end
 
 
 -- @brief Actually spawns the pilots
-function scom.spawn( pilots, faction )
+function scom.spawn( pilots, faction, guerilla )
    local spawned = {}
    local leader = nil
 
-   local origin = pilot.choosePoint( faction ) -- Find a suitable spawn point
+   local origin = pilot.choosePoint( faction, false, guerilla ) -- Find a suitable spawn point
    for k,v in ipairs(pilots) do
       local p
       if type(v["pilot"])=='function' then

--- a/dat/factions/spawn/flf.lua
+++ b/dat/factions/spawn/flf.lua
@@ -72,7 +72,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data, "FLF" )
+    pilots = scom.spawn( spawn_data, "FLF", true )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/dat/factions/spawn/pirate.lua
+++ b/dat/factions/spawn/pirate.lua
@@ -120,7 +120,7 @@ function spawn ( presence, max )
     end
   
     -- Actually spawn the pilots
-    pilots = scom.spawn( spawn_data, "Pirate" )
+    pilots = scom.spawn( spawn_data, "Pirate", true )
 
     -- Calculate spawn data
     spawn_data = scom.choose( spawn_table )

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -373,17 +373,18 @@ int lua_ispilot( lua_State *L, int ind )
 
 /**
  * @brief Returns a suitable jumpin spot for a given pilot.
- * @usage point = pilot.choosePoint( f, i )
+ * @usage point = pilot.choosePoint( f, i, g )
  *
  *    @luatparam Faction f Faction the pilot will belong to.
  *    @luatparam boolean i Wether to ignore rules.
+ *    @luatparam boolean g Wether to behave as guerilla (spawn in deep space)
  *    @luatreturn Planet|Vec2|Jump A randomly chosen suitable spawn point.
  * @luafunc choosePoint( f, i )
  */
 static int pilotL_choosePoint( lua_State *L )
 {
    LuaFaction lf;
-   int ignore_rules, planetind, jump;
+   int ignore_rules, guerilla, planetind, jump;
    Vector2d vp;
 
    lf = faction_get( luaL_checkstring(L,1) );
@@ -392,8 +393,12 @@ static int pilotL_choosePoint( lua_State *L )
    if (lua_isboolean(L,2) && lua_toboolean(L,2))
       ignore_rules = 1;
 
+   guerilla = 0;
+   if (lua_isboolean(L,3) && lua_toboolean(L,3))
+      guerilla = 1;
+
    planetind = jump = -1;
-   pilot_choosePoint( &vp, &planetind, &jump, lf, ignore_rules );
+   pilot_choosePoint( &vp, &planetind, &jump, lf, ignore_rules, guerilla );
 
    if (planetind >= 0)
       lua_pushplanet(L, planetind );
@@ -425,7 +430,7 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
    int planetind;
    int jump;
    PilotFlags flags;
-   int ignore_rules;
+   int ignore_rules, guerilla;
 
    /* Default values. */
    pilot_clearFlagsRaw( flags );
@@ -511,7 +516,7 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
 
       /* Choose the spawn point and act in consequence.*/
       planetind = -1;
-      pilot_choosePoint( &vp, &planetind, &jump, lf, ignore_rules );
+      pilot_choosePoint( &vp, &planetind, &jump, lf, ignore_rules, 0 );
 
       if ( planetind >= 0 ) {
          planet = planet_getIndex( planetind );

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -501,7 +501,7 @@ unsigned int pilot_create( Ship* ship, const char* name, int faction, const char
 Pilot* pilot_createEmpty( Ship* ship, const char* name,
       int faction, const char *ai, PilotFlags flags );
 Pilot* pilot_copy( Pilot* src );
-void pilot_choosePoint( Vector2d *vp, int *planet, int *jump, int lf, int ignore_rules );
+void pilot_choosePoint( Vector2d *vp, int *planet, int *jump, int lf, int ignore_rules, int guerilla );
 void pilot_delete( Pilot *p );
 
 


### PR DESCRIPTION
This proposal is quite simple technically speaking, but has an impact on gameplay : the pirates and FLF don't use jumps if they are in minority in the system on the other side. To compensate this lack of spawn points, they spawn form hidden JP, and can spawn from nothing very far away (at 1.5 X radius of the system).

The goal is to avoid situation like in Cygnus where the life expectation around the JP approaches 0 while the pirate presence in the system and on the other side of the jump is not so high.
This also avoids the annoyance when you're doing a patrol mission and you're stuck at a jump because pirates don't stop to jump in.

I've tested it a bit and didn't detect annoyances caused by this commit, but I didn't test all the systems...