### PR TITLE
correction of a bug I caused in spawn

### DIFF
--- a/src/pilot.c
+++ b/src/pilot.c
@@ -2750,7 +2750,7 @@ void pilot_choosePoint( Vector2d *vp, int *planet, int *jump, int lf, int ignore
    }
 
    /* Calculate jump chance. */
-   if ((ind != NULL) || (jumpind != NULL)) {
+   if ((nind != 0) || (njumpind != 0)) {
       chance = njumpind;
       chance = chance / (chance + nind);
 


### PR DESCRIPTION
In some systems, the code for spawn point choosing resulted in trying to get an element in an empty, but not null array... Sorry about that.