### PR TITLE
Fixed a mistake in Commodity Run mission.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ po/quot.sed
 po/remove-potcdate.sin  
 po/stamp-it
 po/@GETTEXT_PACKAGE@.pot
+po/*.gmo
 
 /.cproject
 /.project

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -106,7 +106,7 @@ function land ()
    local reward = amount * price
 
    if planet.cur() == misplanet and amount > 0 then
-      local txt = string.format(  cargo_land_p2[ rnd.rnd( 1, #cargo_land_p2 ) ], cargo_land_p1[ rnd.rnd( 1, #cargo_land_p1 ) ], chosen_comm, reward )
+      local txt = string.format(  cargo_land_p2[ rnd.rnd( 1, #cargo_land_p2 ) ], cargo_land_p1[ rnd.rnd( 1, #cargo_land_p1 ) ], chosen_comm, numstring( reward ) )
       tk.msg( cargo_land_title, txt )
       pilot.cargoRm( player.pilot(), chosen_comm, amount )
       player.pay( reward )


### PR DESCRIPTION
The Commodity Run mission was printing straight numbers, which gave
ugly and difficult to read results. Fixed; it now uses numstring in
that instance.

I also added "po/*.gmo" to .gitignore, because I noticed that a file
called "po/ja.gmo" was about to be committed. Hopefully that's the
right way to fix it; if not, please let me know.