### PR TITLE
 Added a delay to the creation of commodity runs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ po/quot.sed
 po/remove-potcdate.sin  
 po/stamp-it
 po/@GETTEXT_PACKAGE@.pot
+po/*.gmo
 
 /.cproject
 /.project

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ core
 ABOUT-NLS                         
 po/POTFILES
 po/Makefile.in.in                 
+po/Makefile.in.in~
 po/Makevars.template              
 po/Rules-quot                     
 po/boldquot.sed                   

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -106,7 +106,7 @@ function land ()
    local reward = amount * price
 
    if planet.cur() == misplanet and amount > 0 then
-      local txt = string.format(  cargo_land_p2[ rnd.rnd( 1, #cargo_land_p2 ) ], cargo_land_p1[ rnd.rnd( 1, #cargo_land_p1 ) ], chosen_comm, reward )
+      local txt = string.format(  cargo_land_p2[ rnd.rnd( 1, #cargo_land_p2 ) ], cargo_land_p1[ rnd.rnd( 1, #cargo_land_p1 ) ], chosen_comm, numstring( reward ) )
       tk.msg( cargo_land_title, txt )
       pilot.cargoRm( player.pilot(), chosen_comm, amount )
       player.pay( reward )

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -49,6 +49,11 @@ function update_active_runs( change )
    local current_runs = var.peek( "commodity_runs_active" )
    if current_runs == nil then current_runs = 0 end
    var.push( "commodity_runs_active", math.max( 0, current_runs + change ) )
+
+   -- Note: This causes a delay (defined in create()) after accepting,
+   -- completing, or aborting a commodity run mission.  This is
+   -- intentional.
+   var.push( "last_commodity_run", time.tonumber( time.get() ) )
 end
 
 
@@ -61,6 +66,14 @@ function create ()
    chosen_comm = commchoices[ rnd.rnd( 1, #commchoices ) ]
    local mult = rnd.rnd( 1, 3 ) + math.abs( rnd.threesigma() * 2 )
    price = commodity.price( chosen_comm ) * mult
+
+   local last_run = var.peek( "last_commodity_run" )
+   if last_run ~= nil then
+      local delay = time.create( 0, 7, 0 )
+      if time.get() < time.fromnumber( last_run ) + delay then
+         misn.finish(false)
+      end
+   end
 
    for i, j in ipairs( missys:planets() ) do
       for k, v in pairs( j:commoditiesSold() ) do


### PR DESCRIPTION
I found that with commodity runs constantly appearing on certain
planets, I felt compelled to keep doing commodity runs for the same
planet over and over again. That's fine in and of itself, but the
problem is that this is not a very fun way to play; players should
be encouraged to explore, not just visit the same planet over and
over again. To address this, I've added a 7 day delay
between the acceptance, completion, or cancellation of a commodity
run and when a new commodity run is allowed to be created. This is
such an amount that it doesn't limit the number of commodity runs
you can do realistically, but it keeps you waiting just long enough
to discourage you from doing a run for the same planet over and over.

Also added "po/Makefile.in.in~" to .gitignore, since when I committed
this it added that file as well.