### PR TITLE
Increased simulation time on warp-in from 15 seconds to 5 minutes.

### DIFF
--- a/src/space.h
+++ b/src/space.h
@@ -18,7 +18,7 @@
 #include "explosion.h"
 
 
-#define SYSTEM_SIMULATE_TIME  15. /**< Time to simulate system before player is added. */
+#define SYSTEM_SIMULATE_TIME  300. /**< Time to simulate system before player is added. */
 
 #define MAX_HYPERSPACE_VEL    25 /**< Speed to brake to before jumping. */
 

--- a/src/space.h
+++ b/src/space.h
@@ -18,7 +18,7 @@
 #include "explosion.h"
 
 
-#define SYSTEM_SIMULATE_TIME  300. /**< Time to simulate system before player is added. */
+#define SYSTEM_SIMULATE_TIME  120. /**< Time to simulate system before player is added. */
 
 #define MAX_HYPERSPACE_VEL    25 /**< Speed to brake to before jumping. */
 


### PR DESCRIPTION
This makes it so that you're not effectively guaranteed to warp into
the middle of a battle zone, which can be a problem if you're
in hostile territory.