### PR TITLE
Fixed the every-ship-warps-in-with-you bug.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1799,7 +1799,8 @@ void player_brokeHyperspace (void)
 
    /* Add persisted pilots */
    for (i=0; i<pilot_nstack; i++) {
-      if (pilot_stack[i] != player.p) {
+      if ((pilot_stack[i] != player.p) &&
+            (pilot_isFlag(pilot_stack[i], PILOT_PERSIST))) {
          space_calcJumpInPos( cur_system, sys, &pilot_stack[i]->solid->pos, &pilot_stack[i]->solid->vel, &pilot_stack[i]->solid->dir );
          ai_cleartasks(pilot_stack[i]);
       }


### PR DESCRIPTION
The code was treating every ship on the map as an escort, from the
looks of it. An additional check stops this problem from occurring.
Yay!