### PR TITLE
Fix pirate cargo missions requiring time travel

### DIFF
--- a/dat/missions/pirate/pir_cargo.lua
+++ b/dat/missions/pirate/pir_cargo.lua
@@ -75,7 +75,7 @@ function create()
    local routepos = origin_p:pos()
 
    -- target destination
-   destplanet, destsys, numjumps, traveldist, cargo, tier = cargo_calculateRoute()
+   destplanet, destsys, numjumps, traveldist, cargo, _, tier = cargo_calculateRoute()
    if destplanet == nil then
       misn.finish(false)
    end


### PR DESCRIPTION
Since #627 cargo_calculateRoute returns risk for the route, which is based on the presence of pirates.
Fixes #633.