### PR TITLE
Fixed a bug that allowed you to buy maps with no new information.

### DIFF
--- a/src/equipment.c
+++ b/src/equipment.c
@@ -2114,7 +2114,7 @@ static credits_t equipment_transportPrice( char* shipname )
 
    /* Here we also use hidden jump points, which may not be the best idea but ensures
     * that things can be reached. */
-   if ( planet_getSystem( loc ) == NULL )
+   if ( !planet_hasSystem( loc ) )
       /* Planet doesn't exist; assume a huge number of jumps. */
       jumps = 200;
    else if ( strcmp( planet_getSystem( loc ), cur_system->name ) != 0 )

--- a/src/space.c
+++ b/src/space.c
@@ -812,6 +812,24 @@ int system_index( StarSystem *sys )
 
 
 /**
+ * @brief Get whether or not a planet has a system (i.e. is on the map).
+ *
+ *    @param planetname Planet name to match.
+ *    @return 1 if the planet has a system, 0 otherwise.
+ */
+int planet_hasSystem( const char* planetname )
+{
+   int i;
+
+   for (i=0; i<spacename_nstack; i++)
+      if (strcmp(planetname_stack[i],planetname)==0)
+         return 1;
+
+   return 0;
+}
+
+
+/**
  * @brief Get the name of a system from a planetname.
  *
  *    @param planetname Planet name to match.

--- a/src/space.h
+++ b/src/space.h
@@ -52,7 +52,9 @@
 #define planet_isFlag(p,f)    ((p)->flags & (f)) /**< Checks planet flag. */
 #define planet_setFlag(p,f)   ((p)->flags |= (f)) /**< Sets a planet flag. */
 #define planet_rmFlag(p,f)    ((p)->flags &= ~(f)) /**< Removes a planet flag. */
-#define planet_isKnown(p)     planet_isFlag(p,PLANET_KNOWN) /**< Checks if planet is known. */
+#define planet_isKnown(p) \
+   (!planet_exists((p)->name) || !planet_hasSystem((p)->name) || \
+      planet_isFlag(p,PLANET_KNOWN)) /**< Checks if planet is known. */
 
 
 /**
@@ -117,7 +119,9 @@ typedef struct Planet_ {
 #define sys_isFlag(s,f)    ((s)->flags & (f)) /**< Checks system flag. */
 #define sys_setFlag(s,f)   ((s)->flags |= (f)) /**< Sets a system flag. */
 #define sys_rmFlag(s,f)    ((s)->flags &= ~(f)) /**< Removes a system flag. */
-#define sys_isKnown(s)     sys_isFlag(s,SYSTEM_KNOWN) /**< Checks if system is known. */
+#define sys_isKnown(s) \
+   (!system_exists((s)->name) || \
+      sys_isFlag(s,SYSTEM_KNOWN)) /**< Checks if system is known. */
 #define sys_isMarked(s)    sys_isFlag(s,SYSTEM_MARKED) /**< Checks if system is marked. */
 
 
@@ -318,6 +322,7 @@ void space_exit (void);
  * planet stuff
  */
 Planet *planet_new (void);
+int planet_hasSystem( const char* planetname );
 char* planet_getSystem( const char* planetname );
 Planet* planet_getAll( int *n );
 Planet* planet_get( const char* planetname );


### PR DESCRIPTION
The bug was caused when there were destroyed assets within the map.
Whether or not the asset actually existed was not being checked,
so you could always buy the map again and again, wasting your
credits. Fixed by considering any planet that either doesn't exist
or is outside of the planetname_stack to be "known". This fixes the
problem and doesn't seem to have any unintended side-effects.

Big thanks to both bobbens and BTAxis for helping me navigate the
code on this one.