### PR TITLE
Thurion Space Improvements

### DIFF
--- a/dat/assets/anya.xml
+++ b/dat/assets/anya.xml
@@ -20,8 +20,14 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
+   <commodity/>
   </services>
-  <commodities/>
+  <commodities>
+   <commodity>Ore</commodity>
+  </commodities>
   <description>Anya is the twin planet to Sabe, orbiting around their shared center of gravity in tandem. Anya is shrouded in a permanent cloud cover of ash and snow however, as a result of geological activity. A small number of Thurions live on the surface of Anya but no large scale colonization effort has commenced as of yet, despite the planet's proximity to Sabe, the Thurian capital world. This is due, at least in part, to the geological instabilities of the planet.</description>
+  <bar>The bar on Anya is small and quaint, populated by locals who live here. As is usual for Thurion bars, no alcohol or other substances deemed to be damaging to the brain are served.</bar>
  </general>
 </asset>

--- a/dat/assets/hs224.xml
+++ b/dat/assets/hs224.xml
@@ -20,11 +20,14 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
    <commodity/>
   </services>
   <commodities>
    <commodity>Food</commodity>
   </commodities>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
+  <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>
 </asset>

--- a/dat/assets/hs232.xml
+++ b/dat/assets/hs232.xml
@@ -20,11 +20,14 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
    <commodity/>
   </services>
   <commodities>
    <commodity>Food</commodity>
   </commodities>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
+  <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>
 </asset>

--- a/dat/assets/hs24.xml
+++ b/dat/assets/hs24.xml
@@ -20,11 +20,14 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
    <commodity/>
   </services>
   <commodities>
    <commodity>Food</commodity>
   </commodities>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
+  <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>
 </asset>

--- a/dat/assets/hs37.xml
+++ b/dat/assets/hs37.xml
@@ -20,11 +20,14 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
    <commodity/>
   </services>
   <commodities>
    <commodity>Food</commodity>
   </commodities>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
+  <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>
 </asset>

--- a/dat/assets/hs54.xml
+++ b/dat/assets/hs54.xml
@@ -20,11 +20,14 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
    <commodity/>
   </services>
   <commodities>
    <commodity>Food</commodity>
   </commodities>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
+  <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>
 </asset>

--- a/dat/assets/ns1.xml
+++ b/dat/assets/ns1.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <missions/>
   </services>
   <commodities/>
   <description>This hulking Node Station is one of the places of habitation for the uploaded Thurion.</description>

--- a/dat/assets/ns144.xml
+++ b/dat/assets/ns144.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <missions/>
   </services>
   <commodities/>
   <description>This hulking Node Station is one of the places of habitation for the uploaded Thurion.</description>

--- a/dat/assets/ns27.xml
+++ b/dat/assets/ns27.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <missions/>
   </services>
   <commodities/>
   <description>This hulking Node Station is one of the places of habitation for the uploaded Thurion.</description>

--- a/dat/assets/ns42.xml
+++ b/dat/assets/ns42.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <missions/>
   </services>
   <commodities/>
   <description>This hulking Node Station is one of the places of habitation for the uploaded Thurion.</description>

--- a/dat/assets/ns63.xml
+++ b/dat/assets/ns63.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <missions/>
   </services>
   <commodities/>
   <description>This hulking Node Station is one of the places of habitation for the uploaded Thurion.</description>

--- a/dat/assets/sabe.xml
+++ b/dat/assets/sabe.xml
@@ -20,12 +20,43 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
+   <outfits/>
    <shipyard/>
+   <commodity/>
   </services>
-  <commodities/>
+  <commodities>
+   <commodity>Food</commodity>
+   <commodity>Industrial Goods</commodity>
+   <commodity>Medicine</commodity>
+   <commodity>Luxury Goods</commodity>
+  </commodities>
   <description>Sabe and Anya are a pair of planets tidally locked to each other, rotating around their shared center of gravity. Sabe is the center of the Thurian government, housing the largest population of both uploaded and biological Thurions, acting as the de-facto capital. The majority of the planet's surface is untouched, as virtually all its inhabitants reside in the multitude of arcologies spread across its surface.</description>
+  <bar>The bar here is extremely active, with many biological and uploaded Thurions alike. Of course, as is the custom, biological Thurions do not eat or drink any substances that could harm the brain, meaning that the bar doesn't even offer alcoholic drinks on the menu.</bar>
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
+  <item>Star Maps</item>
+  <item>__Heavy Weapon License</item>
+  <item>__Heavy Combat Vessel License</item>
  </tech>
 </asset>

--- a/dat/assets/sevlow.xml
+++ b/dat/assets/sevlow.xml
@@ -20,8 +20,16 @@
   <services>
    <land/>
    <refuel/>
+   <bar/>
+   <missions/>
+   <commodity/>
   </services>
-  <commodities/>
+  <commodities>
+   <commodity>Food</commodity>
+   <commodity>Medicine</commodity>
+   <commodity>Luxury Goods</commodity>
+  </commodities>
   <description>Sevlow is one of the few truly inhabited Thurian worlds. Sevlow is an uneventful planet, as it serves primarily as an agricultural world producing algae, and as a living place for biological Thurions.</description>
+  <bar>This bar is crowded with biological Thurions socializing and drinking non-alcoholic beverages. Just like every other Thurion bar, no alcohol is sold as that is believed to damage the brain.</bar>
  </general>
 </asset>

--- a/dat/assets/sy1025.xml
+++ b/dat/assets/sy1025.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy1025.xml
+++ b/dat/assets/sy1025.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy1206.xml
+++ b/dat/assets/sy1206.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy1206.xml
+++ b/dat/assets/sy1206.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy159.xml
+++ b/dat/assets/sy159.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy159.xml
+++ b/dat/assets/sy159.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy19.xml
+++ b/dat/assets/sy19.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy19.xml
+++ b/dat/assets/sy19.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy237.xml
+++ b/dat/assets/sy237.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy237.xml
+++ b/dat/assets/sy237.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -28,5 +29,10 @@
  <tech>
   <item>Thurion Military Ships</item>
   <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy256.xml
+++ b/dat/assets/sy256.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy256.xml
+++ b/dat/assets/sy256.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy314.xml
+++ b/dat/assets/sy314.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy314.xml
+++ b/dat/assets/sy314.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy413.xml
+++ b/dat/assets/sy413.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy413.xml
+++ b/dat/assets/sy413.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy612.xml
+++ b/dat/assets/sy612.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy612.xml
+++ b/dat/assets/sy612.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy894.xml
+++ b/dat/assets/sy894.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy894.xml
+++ b/dat/assets/sy894.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy920.xml
+++ b/dat/assets/sy920.xml
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <outfits/>
    <shipyard/>
   </services>
   <commodities/>
@@ -27,5 +28,11 @@
  </general>
  <tech>
   <item>Thurion Military Ships</item>
+  <item>Thurion Outfits</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/assets/sy920.xml
+++ b/dat/assets/sy920.xml
@@ -31,8 +31,21 @@
   <item>Thurion Outfits</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
+  <item>Heavy Weapons 1</item>
+  <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
   <item>Star Maps</item>
  </tech>
 </asset>

--- a/dat/events/flf/flf_catastrophe.lua
+++ b/dat/events/flf/flf_catastrophe.lua
@@ -197,6 +197,10 @@ function pilot_death_sindbad( pilot, attacker, arg )
    faction.get("FLF"):setPlayerStanding( 100 )
    player.addOutfit( "Map: Inner Nebula Secret Jump" )
 
+   if diff.isApplied( "flf_pirate_ally" ) then
+      diff.remove( "flf_pirate_ally" )
+   end
+
    for i, j in ipairs( emp_ships ) do
       if j:exists() then
          j:control( false )

--- a/dat/events/neutral/npc.lua
+++ b/dat/events/neutral/npc.lua
@@ -6,6 +6,12 @@
 
 include "dat/events/tutorial/tutorial-common.lua"
 
+-- Factions which will NOT get generic texts if possible.  Factions
+-- listed here not spawn generic civilian NPCs or get aftercare texts.
+-- Meant for factions which are either criminal (FLF, Pirate) or unaware
+-- of the main universe (Thurion, Proteron).
+nongeneric_factions = { "Pirate", "FLF", "Thurion", "Proteron" }
+
 -- Portraits.
 -- When adding portraits, make sure to add them to the table of the faction they belong to.
 -- Does your faction not have a table? Then just add it. The script will find and use it if it exists.
@@ -249,10 +255,22 @@ function spawnNPC()
       factions[#factions + 1] = i
    end
 
+   local nongeneric = false
+
+   local planfaction = planet.cur():faction():name()
    local fac = "general"
    local select = rnd.rnd()
-   if select >= (0.5) and planet.cur():faction() ~= nil then
-      fac = planet.cur():faction():name()
+   if planfaction ~= nil then
+      for i, j in ipairs(nongeneric_factions) do
+         if j == planfaction then
+            nongeneric = true
+            break
+         end
+      end
+
+      if nongeneric or select >= (0.5) then
+         fac = planfaction
+      end
    end
 
    -- Append the faction to the civilian name, unless there is no faction.
@@ -280,7 +298,11 @@ function spawnNPC()
       msg = getTipMessage()
    else
       -- Mission hint message.
-      msg = getMissionLikeMessage()
+      if not nongeneric then
+         msg = getMissionLikeMessage()
+      else
+         msg = getLoreMessage(fac)
+      end
    end
 
    local npcdata = {name = npcname, msg = msg, func = func}

--- a/dat/events/neutral/npc.lua
+++ b/dat/events/neutral/npc.lua
@@ -128,7 +128,28 @@ msg_lore["Za'lek"] =       {_("It's not easy, dancing to those scientists' tunes
                               _("I don't understand why we bother sending our research results to the Empire. These simpletons can't understand the simplest formulas!"),
                               }
 
-msg_lore["Proteron"] =     {_("Hello, traveler. Welcome to Proteron space. We are an evil, power hungry dystopia on a quest for dominance over the galaxy. Would you like a brochure?"),
+msg_lore["Thurion"] =      {_("Did you know that even the slightest bit of brain damage can lead to death during the upload process? That's why we're very careful to not allow our brains to be damaged, even a little."),
+                              _("My father unfortunately hit his head when he was young, so he couldn't be safely uploaded. It's okay, though; he had a long and fulfilling life, for a non-uploaded human, that is."),
+                              _("One great thing once you're uploaded is that you can choose to forget things you don't want to remember. My great-grandfather had a movie spoiled for him before he could watch it, so once he got uploaded, he deleted that memory and watched it with a fresh perspective. Cool, huh?"),
+                              _("The best part of our lives is after we're uploaded, but that doesn't mean we lead boring lives before then. We have quite easy and satisfying biological lives before uploading."),
+                              _("Being uploaded allows you to live forever, but that doesn't mean you're forced to. Any uploaded Thurion can choose to end their own life if they want, though few have chosen to do so."),
+                              _("Uploading is a choice in our society. No one is forced to do it. It's just that, well, what kind of person would turn down the chance to live a second life on the network?"),
+                              _("We were lucky to not get touched by the Incident. In fact, we kind of benefited from it. The nebula that resulted gave us a great cover and sealed off the Empire from us. It also got rid of those lunatics, the Proterons."),
+                              _("We don't desire galactic dominance. That being said, we do want to spread our way of life to the rest of the galaxy, so that everyone can experience the joy of being uploaded."),
+                              _("I think you're from the outside, aren't you? That's awesome! I've never met a foreigner before. What's it like outside the nebula?"),
+                              _("We actually make occasional trips outside of the nebula, though only rarely, and we always make sure to not get discovered by the Empire."),
+                              _("The Soromid have a rough history. Have you read up on it? First the Empire confined them to a deadly planet and doomed them to extinction. Then, when they overcame those odds, the Incident blew up their homeworld. The fact that they're still thriving now despite that is phenomenal, I must say."),
+                           }
+
+msg_lore["Proteron"] =     {_("Our system of government is clearly superior to all others. Nothing could be more obvious."),
+                              _("The Incident really set back our plan for galactic dominance, but that was only temporary."),
+                              _("We don't have time for fun and games. The whole reason we're so great is because we're more productive than any other society."),
+                              _("We are superior, so of course we deserve control over the galaxy. It's our destiny."),
+                              _("The Empire is weak, obsolete. That is why we must replace them."),
+                              _("Slaves? Of course we're not slaves. Slaves are beaten and starved. We are in top shape so we can serve our country better."),
+                              _("I can't believe the Empire continues to allow families. So primitive. Obviously, all this does is make them less productive."),
+                              _("The exact cause of the Incident is a tightly-kept secret, but the government says it was caused by the Empire's stupidity. I would expect nothing less."),
+                              _("I came across some heathen a few months back who claimed, get this, that we Proterons were the cause of the Incident! What slanderous nonsense. Being the perfect society we are, of course we would never cause such a massive catastrophe."),
                            }
 
 msg_lore["Frontier"] =     {_("We value our autonomy. We don't want to be ruled by those megalomanic Dvaered Warlords! Can't they just shoot at each other instead of threatening us? If it wasn't for the Liberation Front..."),
@@ -292,14 +313,14 @@ function spawnNPC()
       msg = getLoreMessage(fac)
    elseif select <= 0.55 then
       -- Jump point message.
-      msg, func = getJmpMessage()
+      msg, func = getJmpMessage(fac)
    elseif select <= 0.8 then
       -- Gameplay tip message.
-      msg = getTipMessage()
+      msg = getTipMessage(fac)
    else
       -- Mission hint message.
       if not nongeneric then
-         msg = getMissionLikeMessage()
+         msg = getMissionLikeMessage(fac)
       else
          msg = getLoreMessage(fac)
       end
@@ -330,7 +351,7 @@ function getLoreMessage(fac)
 end
 
 -- Returns a jump point message and updates jump point known status accordingly. If all jumps are known by the player, defaults to a lore message.
-function getJmpMessage()
+function getJmpMessage(fac)
    -- Collect a table of jump points in the system the player does NOT know.
    local mytargets = {}
    seltargets = seltargets or {} -- We need to keep track of jump points NPCs will tell the player about so there are no duplicates.
@@ -341,12 +362,12 @@ function getJmpMessage()
    end
    
    if #mytargets == 0 then -- The player already knows all jumps in this system.
-      return getLoreMessage(), nil
+      return getLoreMessage(fac), nil
    end
 
    -- All jump messages are valid always.
    if #msg_jmp == 0 then
-      return getLoreMessage(), nil
+      return getLoreMessage(fac), nil
    end
    local retmsg =  msg_jmp[rnd.rnd(1, #msg_jmp)]
    local sel = rnd.rnd(1, #mytargets)
@@ -361,10 +382,10 @@ function getJmpMessage()
 end
 
 -- Returns a tip message.
-function getTipMessage()
+function getTipMessage(fac)
    -- All tip messages are valid always.
    if #msg_tip == 0 then
-      return getLoreMessage()
+      return getLoreMessage(fac)
    end
    local sel = rnd.rnd(1, #msg_tip)
    local pick = msg_tip[sel]
@@ -373,7 +394,7 @@ function getTipMessage()
 end
 
 -- Returns a mission hint message, a mission after-care message, OR a lore message if no missionlikes are left.
-function getMissionLikeMessage()
+function getMissionLikeMessage(fac)
    if not msg_combined then
       msg_combined = {}
 
@@ -405,7 +426,7 @@ function getMissionLikeMessage()
    end
 
    if #msg_combined == 0 then
-      return getLoreMessage()
+      return getLoreMessage(fac)
    else
       -- Select a string, then remove it from the list of valid strings. This ensures all NPCs have something different to say.
       local sel = rnd.rnd(1, #msg_combined)

--- a/dat/factions/spawn/proteron.lua
+++ b/dat/factions/spawn/proteron.lua
@@ -49,9 +49,9 @@ end
 
 -- @brief Spawns a capship with escorts.
 function spawn_capship ()
-    pilots.__fleet = true
     local pilots = {}
     local r = rnd.rnd()
+    pilots.__fleet = true
 
     -- Generate the capship
     scom.addPilot( pilots, "Proteron Archimedes", 140 )

--- a/dat/factions/spawn/thurion.lua
+++ b/dat/factions/spawn/thurion.lua
@@ -55,11 +55,9 @@ function spawn_capship ()
    local r = rnd.rnd()
 
    -- Generate the capship
-   if r < 0.7 then
-      scom.addPilot( pilots, "Empire Hawking", 140 )
-   else
-      scom.addPilot( pilots, "Empire Peacemaker", 165 )
-   end
+   -- XXX: "Thurion Goddard" ship is a placeholder until proper Thurion
+   -- capships are made. (Used to be Empire Peacemaker or Empire Hawking.)
+   scom.addPilot( pilots, "Thurion Goddard", 140 )
 
    -- Generate the escorts
    r = rnd.rnd()

--- a/dat/fleet.xml
+++ b/dat/fleet.xml
@@ -1047,6 +1047,13 @@
    <pilot name="Thurion Taciturnity" ship="Thurion Taciturnity"></pilot>
   </pilots>
  </fleet>
+ <fleet name="Thurion Goddard">
+  <ai>thurion</ai>
+  <faction>Thurion</faction>
+  <pilots>
+   <pilot name="Thurion Goddard" ship="Goddard"></pilot>
+  </pilots>
+ </fleet>
  <fleet name="Sirius Recon Force">
   <ai>sirius</ai>
   <faction>Sirius</faction>

--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -22,8 +22,9 @@
    <faction>Independent</faction>
    <faction>Sirius</faction>
    <faction>Soromid</faction>
-   <faction>Za'lek</faction>
+   <faction>Thurion</faction>
    <faction>Trader</faction>
+   <faction>Za'lek</faction>
   </avail>
  </mission>
  <mission name="Empire Rehabilitation">
@@ -87,8 +88,9 @@
    <faction>Independent</faction>
    <faction>Sirius</faction>
    <faction>Soromid</faction>
-   <faction>Za'lek</faction>
+   <faction>Thurion</faction>
    <faction>Trader</faction>
+   <faction>Za'lek</faction>
   </avail>
  </mission>
  <mission name="Commodity Run">
@@ -143,8 +145,9 @@
    <faction>Independent</faction>
    <faction>Sirius</faction>
    <faction>Soromid</faction>
-   <faction>Za'lek</faction>
+   <faction>Thurion</faction>
    <faction>Trader</faction>
+   <faction>Za'lek</faction>
   </avail>
  </mission>
  <mission name="Dead Or Alive Bounty">
@@ -194,6 +197,7 @@
    <faction>Independent</faction>
    <faction>Sirius</faction>
    <faction>Soromid</faction>
+   <faction>Thurion</faction>
    <faction>Za'lek</faction>
   </avail>
  </mission>

--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -107,8 +107,9 @@
    <faction>Independent</faction>
    <faction>Sirius</faction>
    <faction>Soromid</faction>
-   <faction>Za'lek</faction>
+   <faction>Thurion</faction>
    <faction>Trader</faction>
+   <faction>Za'lek</faction>
   </avail>
  </mission>
  <mission name="FLF Commodity Run">

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -19,7 +19,7 @@ include "dat/scripts/numstring.lua"
 --Mission Details
 misn_title = _("%s Delivery")
 misn_reward = _("%s credits per ton")
-misn_desc = _("There is an insufficient supply %s on this planet to satisfy the current demand. Go to any planet which sells this commodity and bring as much of it back as possible.")
+misn_desc = _("There is an insufficient supply of %s on this planet to satisfy the current demand. Go to any planet which sells this commodity and bring as much of it back as possible.")
 
 cargo_land_title = _("Delivery success!")
 

--- a/dat/outfits/modifiers/nebula_shielding0.xml
+++ b/dat/outfits/modifiers/nebula_shielding0.xml
@@ -5,8 +5,8 @@
   <slot>structure</slot>
   <size>small</size>
   <mass>15</mass>
-  <price>0</price>
-  <description>A modification to the ship's shields that allow them to resist nebular volatility.</description>
+  <price>10000</price>
+  <description>A modification to the ship's shields that allows them to resist nebular volatility.</description>
   <gfx_store>capacitor</gfx_store>
  </general>
  <specific type="modification">

--- a/dat/outfits/modifiers/sensor_array.xml
+++ b/dat/outfits/modifiers/sensor_array.xml
@@ -5,7 +5,7 @@
   <size>small</size>
   <mass>2</mass>
   <price>250000</price>
-  <description>To detect other ships despite heavy ambient radiation the Thurion have developed powerfull sensor arrays. By installing these additional sensors the distance a wich ships can be detected is reduced at cost of CPU usage.</description>
+  <description>To detect other ships despite heavy ambient radiation the Thurion have developed powerful sensor arrays. By installing these additional sensors, the distance at which ships can be detected is reduced.</description>
   <gfx_store>jammer0</gfx_store>
   <cpu>-8</cpu>
  </general>


### PR DESCRIPTION
Changes include:

* Modified several Thurion assets to include bars, mission computers, and outfitters (in a manner consistent with the way Thurion space was constructed previously).
* Added the possibility of doing cargo missions for the Thurions (and also patrol missions, but you don't actually get to do those since there's no enemy presence). Woohoo, something to do!
* Added faction lore for both the Thurions and the Proterons (removing the existing joke lore the Proterons had as well). Lore for both was based on what the wiki says about these factions.
* Made it so that Proteron, Thurion, FLF, and Pirate assets do not produce generic civilians or say generic lore text or mission aftercare text (if possible). This is meant to prevent weirdness with these factions, like the Proterons talking about things they should be unaware of on the other side of the universe, the Thurions talking about Nebula ghost stories, the Pirates expressing disdain for theft and advising against going to Alteris, and the FLF caring about anything other than the Dvaereds.
* Fixed some typos.
* This isn't directly related to the Thurions or Thurion space, but I also put in a modification to the FLF death event that removes the FLF-Pirate alliance diff. This is just so that you don't accidentally become enemies with the remaining FLF ships when you inevitably become enemies with the pirates again.