### PR TITLE
Fix sillyness in sensor array description

### DIFF
--- a/dat/outfits/modifiers/sensor_array.xml
+++ b/dat/outfits/modifiers/sensor_array.xml
@@ -5,7 +5,7 @@
   <size>small</size>
   <mass>2</mass>
   <price>250000</price>
-  <description>To detect other ships despite heavy ambient radiation the Thurion have developed powerful sensor arrays. By installing these additional sensors, the distance at which ships can be detected is reduced.</description>
+  <description>To detect other ships despite heavy ambient radiation the Thurion have developed powerful sensor arrays. By installing these additional sensors, the distance at which ships can be detected is increased.</description>
   <gfx_store>jammer0</gfx_store>
   <cpu>-8</cpu>
  </general>


### PR DESCRIPTION
More powerful sensors should be able to detect ships further way, thus increasing the distance at which ships can be detected.

Discovered while looking through #800