### PR TITLE
Fixed a couple things.

### DIFF
--- a/dat/missions/neutral/diy-nerds.lua
+++ b/dat/missions/neutral/diy-nerds.lua
@@ -116,7 +116,7 @@ textosd[1] = _("Bring the nerds and their box to %s before %s")
 textosd[2] = _("You have %s remaining.")
 textosd[3] = _("You're late. Mia has started verbally abusing you and your ship. Better land to get rid of the nerds and their box.")
 -- stage 2
-textosd[4] = _("You are to wait several STP until hailed by the nerds for their return trip.")
+textosd[4] = _("You are to wait several periods until hailed by the nerds for their return trip.")
 textosd[5] = _("Pick up the nerds on %s for their return trip to %s.")
 textosd[6] = _("The nerds are getting impatient.")
 textosd[7] = _("You didn't pick up the nerds in time.")

--- a/dat/outfits/launchers/electron_energy_cell.xml
+++ b/dat/outfits/launchers/electron_energy_cell.xml
@@ -13,7 +13,7 @@
   <sound_hit>empexplode</sound_hit>
   <spfx_shield>EmpS</spfx_shield>
   <spfx_armour>EmpM</spfx_armour>
-  <duration blowup="shield">5</duration>
+  <duration blowup="shield">1.5</duration>
   <thrust>1500</thrust>
   <speed>2000</speed>
   <damage>


### PR DESCRIPTION
1. Fixed a remaining "STP" string in diy-nerds.
2. Reverted a change from a couple years back that increased the range, dramatically, of the Electron Energy Cell. This is a weapon used by the Collective Heavy Drone, and it's such a huge range (something like half of the system) that it causes these drones to be pretty much a death sentence. Reverting it to what it was before (about 1/3 of what it was changed to) still keeps it a very powerful weapon, but makes surviving it much more realistic.