### PR TITLE
Improvements to the Collective campaign, plus a couple fixes

### DIFF
--- a/dat/assets/eiroik.xml
+++ b/dat/assets/eiroik.xml
@@ -8,6 +8,11 @@
   <space>Z00.png</space>
   <exterior>methane.png</exterior>
  </GFX>
+ <presence>
+  <faction>Neutral</faction>
+  <value>0</value>
+  <range>0</range>
+ </presence>
  <general>
   <class>Z</class>
   <population>0</population>

--- a/dat/assets/eiroik.xml
+++ b/dat/assets/eiroik.xml
@@ -8,11 +8,6 @@
   <space>Z00.png</space>
   <exterior>methane.png</exterior>
  </GFX>
- <presence>
-  <faction>Independent</faction>
-  <value>0</value>
-  <range>0</range>
- </presence>
  <general>
   <class>Z</class>
   <population>0</population>

--- a/dat/assets/eiroik.xml
+++ b/dat/assets/eiroik.xml
@@ -9,7 +9,7 @@
   <exterior>methane.png</exterior>
  </GFX>
  <presence>
-  <faction>Neutral</faction>
+  <faction>Independent</faction>
   <value>0</value>
   <range>0</range>
  </presence>

--- a/dat/factions/equip/collective.lua
+++ b/dat/factions/equip/collective.lua
@@ -24,6 +24,9 @@ end
 function equip_CollectiveDrone ()
    return { "Neutron Disruptor" }
 end
+function equip_CollectiveDroneHvy ()
+   return { "Heavy Neutron Disruptor" }
+end
 function equip_CollectiveDroneHvyRanged ()
    return { "Electron Burst Cannon" }
 end
@@ -59,7 +62,7 @@ function equip_collectiveMilitary( p, shipsize )
          equip_cores(p, "Tricon Zephyr II Engine", "Milspec Orion 3701 Core System", "S&K Light Combat Plating")
 
          -- TODO: Remove assumptions about slot sizes.
-         addWeapons( equip_CollectiveDrone(), 2 )
+         addWeapons( equip_CollectiveDroneHvy(), 2 )
          addWeapons( equip_CollectiveDroneHvyRanged(), 2 )
       end
    else

--- a/dat/missions/empire/collective/ec05.lua
+++ b/dat/missions/empire/collective/ec05.lua
@@ -81,7 +81,7 @@ taunts[3] = _("My drones will make mincemeat of you!")
 function create ()
    missys = {system.get("Rockbed")}
    if not misn.claim(missys) then
-      abort()
+      misn.finish(false)
    end
  
    misn.setNPC( _("Dimitri?"), "unknown" )
@@ -122,9 +122,7 @@ function accept ()
    tk.msg( title[4], string.format(text[5], misn_target_sys:name(), misn_target_sys:name() ) )
 
    -- Escorts
-   esc_pacifier  = true
-   esc_lancelot1 = true
-   esc_lancelot2 = true
+   escorts = {}
 
    hook.jumpout("jumpout")
    hook.jumpin("jumpin")
@@ -153,16 +151,16 @@ function enter ( from_sys )
    if misn_stage == 0 then
       local sys = system.cur()
 
-      -- Escorts enter a while back
-      enter_vect = player.pos()
-      if from_sys == nil then
-         add_escorts( true )
-      else -- Just jumped
-         hook.timer( rnd.int(2000, 5000), "add_escorts" )
-      end
-
       -- Create some havoc
       if sys == misn_target_sys then
+         -- Escorts enter a while back
+         enter_vect = player.pos()
+         if from_sys == nil then
+            add_escorts( true )
+         else -- Just jumped
+            hook.timer( rnd.int(2000, 5000), "add_escorts" )
+         end
+
          -- Disable spawning and clear pilots -> makes it more epic
          pilot.clear()
          pilot.toggleSpawn(false)
@@ -195,28 +193,11 @@ function enter ( from_sys )
 end
 
 
--- Gets the empire talker
-function emp_talker ()
-   if esc_pacifier then
-      talker = paci
-   elseif esc_lancelot1 then
-      talker = lance1
-   elseif esc_lancelot2 then
-      talker = lance2
-   else
-      -- I don't like the idea of player talking, but we need the conversation
-      talker = player.pilot()
-   end
-
-   return talker
-end
-
-
 -- Little talk when ESS Trinity is encountered.
 function final_talk ()
    -- Empire talks about arresting
    if final_fight == 0 then
-      talker = emp_talker()
+      talker = paci
       talker:broadcast( talk[1] )
 
       final_fight = 1
@@ -229,7 +210,7 @@ function final_talk ()
       hook.timer(rnd.int( 3000, 4000 ), "final_talk")
    elseif final_fight == 2 then
       -- Talk
-      talker = emp_talker()
+      talker = paci
       talker:broadcast( talk[3] )
 
       -- ESS Trinity becomes collective now.
@@ -244,14 +225,10 @@ function final_talk ()
       hook.timer(rnd.int( 3000, 5000 ) , "call_drones")
       hook.timer( 3000, "trinity_check" )
       tri_checked = 0
-      if esc_pacifier then
-         paci:control(false)
-      end
-      if esc_lancelot1 then
-         lance1:control(false)
-      end
-      if esc_lancelot2 then
-         lance2:control(false)
+      for i, j in ipairs( escorts ) do
+         if j:exists() then
+            j:control(false)
+         end
       end
    end
 end
@@ -334,7 +311,7 @@ function drone_dead ()
 end
 
 
--- Adds escorts that weren't killed sometime.
+-- Adds escorts
 function add_escorts( landed )
    local param
    if landed then
@@ -342,46 +319,25 @@ function add_escorts( landed )
    else
       param = last_sys
    end
-   if esc_pacifier then
-      enter_vect:add( rnd.int(-50,50), rnd.int(-50,50) )
-      paci = pilot.add("Empire Pacifier", "escort_player", param)
-      paci = paci[1]
-      paci:setFriendly()
-      hook.pilot(paci, "death", "paci_dead")
-      if trinity ~= nil then
-         paci:control()
-         paci:goto( trinity:pos():add( 100, 0 ) )
-      end
+   
+   if escorts == nil then escorts = {} end
+   paci = pilot.add("Empire Pacifier", "escort_player", param)[1]
+   escorts[#escorts + 1] = paci
+   paci:setFriendly()
+   if trinity ~= nil then
+      paci:control()
+      paci:goto( trinity:pos() )
    end
-   if esc_lancelot1 then
-      enter_vect:add( rnd.int(-50,50), rnd.int(-50,50) )
-      lance1 = pilot.add("Empire Lancelot", "escort_player", param)
-      lance1 = lance1[1]
-      lance1:setFriendly()
-      hook.pilot(lance1, "death", "lance1_dead")
+   for i=1, 6 do
+      local lance = pilot.add("Empire Lancelot", "escort_player", param)[1]
+      escorts[#escorts + 1] = lance
+      lance:setFriendly()
       if trinity ~= nil then
-         lance1:control()
-         lance1:goto( trinity:pos():add( -100, -100 ) )
-      end
-   end
-   if esc_lancelot2 then
-      enter_vect:add( rnd.int(-50,50), rnd.int(-50,50) )
-      lance2 = pilot.add("Empire Lancelot", "escort_player", param)
-      lance2 = lance2[1]
-      lance2:setFriendly()
-      hook.pilot(lance2, "death", "lance2_dead")
-      if trinity ~= nil then
-         lance2:control()
-         lance2:goto( trinity:pos():add( 300, -100 ) )
+         lance:control()
+         lance:goto( trinity:pos() )
       end
    end
 end
-
-
--- Escort death functions -> will stop spawning
-function paci_dead () esc_pacifier = false end
-function lance1_dead () esc_lancelot1 = false end
-function lance2_dead () esc_lancelot2 = false end
 
 
 -- Handles arrival back to base

--- a/dat/outfits/launchers/electron_burst_cannon.xml
+++ b/dat/outfits/launchers/electron_burst_cannon.xml
@@ -13,6 +13,6 @@
  <specific type="launcher" secondary="1">
   <ammo>Electron Energy Cell</ammo>
   <delay>0.3</delay>
-  <amount>100</amount>
+  <amount>50</amount>
  </specific>
 </outfit>

--- a/dat/outfits/launchers/electron_energy_cell.xml
+++ b/dat/outfits/launchers/electron_energy_cell.xml
@@ -13,13 +13,13 @@
   <sound_hit>empexplode</sound_hit>
   <spfx_shield>EmpS</spfx_shield>
   <spfx_armour>EmpM</spfx_armour>
-  <duration blowup="shield">1.5</duration>
-  <thrust>1500</thrust>
-  <speed>2000</speed>
+  <duration blowup="shield">1</duration>
+  <thrust>0</thrust>
+  <speed>1500</speed>
   <damage>
-   <type>ion</type>
-   <penetrate>20</penetrate>
-   <physical>20</physical>
+   <type>shieldbreaker</type>
+   <penetrate>10</penetrate>
+   <physical>15</physical>
    <disable>5</disable>
   </damage>
   <ai>dumb</ai>

--- a/dat/ships/drone_heavy.xml
+++ b/dat/ships/drone_heavy.xml
@@ -39,5 +39,7 @@
   <thrust_mod>10</thrust_mod>
   <cargo_mod>-50</cargo_mod>
   <armour_mod>-10</armour_mod>
+  <launch_range>-50</launch_range>
+  <ammo_capacity>-50</ammo_capacity>
  </stats>
 </ship>

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -2250,7 +2250,6 @@ int pilot_refuelStart( Pilot *p )
    /* Now start the boarding to refuel. */
    pilot_setFlag(p, PILOT_REFUELBOARDING);
    p->ptimer  = PILOT_REFUEL_TIME; /* Use timer to handle refueling. */
-   p->pdata   = PILOT_REFUEL_QUANTITY;
    return 1;
 }
 
@@ -2264,7 +2263,6 @@ int pilot_refuelStart( Pilot *p )
 static void pilot_refuel( Pilot *p, double dt )
 {
    Pilot *target;
-   double amount;
 
    /* Check to see if target exists, remove flag if not. */
    target = pilot_get(p->target);
@@ -2277,20 +2275,16 @@ static void pilot_refuel( Pilot *p, double dt )
    /* Match speeds. */
    p->solid->vel = target->solid->vel;
 
-   amount = CLAMP( 0., p->pdata, PILOT_REFUEL_RATE * dt);
-   p->pdata -= amount;
-
-   /* Move fuel. */
-   p->fuel        -= amount;
-   target->fuel   += amount;
-   /* Stop refueling at max. */
-   if (target->fuel > target->fuel_max) {
-      p->ptimer      = -1.;
-      target->fuel   = target->fuel_max;
-   }
-
    /* Check to see if done. */
    if (p->ptimer < 0.) {
+      /* Move fuel. */
+      p->fuel       -= PILOT_REFUEL_QUANTITY;
+      target-> fuel += PILOT_REFUEL_QUANTITY;
+
+	  if (target->fuel > target->fuel_max) {
+	     target->fuel   = target->fuel_max;
+	  }
+
       pilot_rmFlag(p, PILOT_REFUELBOARDING);
       pilot_rmFlag(p, PILOT_REFUELING);
    }

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -36,8 +36,7 @@
 #define PILOT_TAKEOFF_DELAY      2. /**< Delay for takeoff animation. */
 /* Refueling. */
 #define PILOT_REFUEL_TIME        3. /**< Time to complete refueling. */
-#define PILOT_REFUEL_QUANTITY    101. /**< Amount transferred per refuel. */
-#define PILOT_REFUEL_RATE        PILOT_REFUEL_QUANTITY/PILOT_REFUEL_TIME /**< Fuel per second. */
+#define PILOT_REFUEL_QUANTITY    100 /**< Amount transferred per refuel. */
 /* Misc. */
 #define PILOT_SIZE_APROX         0.8   /**< approximation for pilot size */
 #define PILOT_WEAPON_SETS        10    /**< Number of weapon sets the pilot has. */


### PR DESCRIPTION
Of note in this PR:

1. I've modified both the Collective Heavy Drone and the Electron Burst Cannon to further reduce the ridiculousness of it. The Electron Burst Cannon has been reclassed as a shieldbreaker, with less damage and less ammo, and with the "thrust" removed so that it's just a constant speed. Heavy Drones also now have a -50% ammo penalty and a -50% missile range penalty. The result is much more in-line with what the Collective was like before, and yet it keeps the Electron Burst Cannon a perfectly competitive weapon choice (important since it's also used by the Za'lek). Heavy Drones have also had the regular Neutron Disruptors on them replaced with Heavy Neutron Disruptors; I don't know why they were removed in the first place.

2. Reverted the way fueling works to "all at once" like it used to be a long time ago. Simple reason: a recent change to the way fuel is handled broke the progressive fueling system. This fixes that.

3. Fixed a mistake in the Black Trinity mission (it called "abort", a non-existent function).

4. Modified Black Trinity to only warp your escorts in when you go to the target system. Avoids losing your escorts before beginning the mission, which might kind of make sense, but is annoying from a gameplay perspective.

5. You now get seven escorts in Black Trinity, not just three. It's still incredibly difficult to win the mission, but at least the number of ships makes more sense from a story perspective.