### PR TITLE
Added variation to passage of time between ships.

### DIFF
--- a/dat/events/neutral/npc.lua
+++ b/dat/events/neutral/npc.lua
@@ -205,6 +205,8 @@ msg_tip =                  {_("I heard you can set your weapons to only fire whe
                               _("If you're having trouble with overheating weapons or outfits, you can press " .. tutGetKey("autobrake") .. " twice to put your ship into Active Cooldown. Careful though, your energy and shields won't recharge while you do it!"),
                               _("If you're having trouble shooting other ships face on, try outfitting with turrets or use an afterburner to avoid them entirely!"),
                               _("You know how time speeds up when Autonav is on, but then goes back to normal when enemies are around? Turns out you can't disable the return to normal speed entirely, but you can control what amount of danger triggers it. Really handy if you want to ignore enemies that aren't actually hitting you."),
+                              _("Flying bigger ships is awesome, but it's a bit tougher than flying smaller ships. There's so much more you have to do for the same actions, time just seems to fly by faster. I guess the upside of that is that you don't notice how slow your ship is as much."),
+                              _("I know it can be tempting to fly the big and powerful ships, but don't underestimate smaller ones! Given their simpler designs and lesser crew size, you have a lot more time to react with a smaller vessel. Some are even so simple to pilot that time seems to slow down all around you!"),
                            }
 
 -- Jump point messages.
@@ -360,7 +362,7 @@ function getJmpMessage(fac)
          table.insert(mytargets, j)
       end
    end
-   
+
    if #mytargets == 0 then -- The player already knows all jumps in this system.
       return getLoreMessage(fac), nil
    end
@@ -410,7 +412,7 @@ function getMissionLikeMessage(fac)
             msg_combined[#msg_combined + 1] = j[2]
          end
       end
-   
+
       -- After-care.
       -- After-care messages are only valid if the relevant mission has been completed.
       for i, j in pairs(msg_mdone) do

--- a/dat/ships/admonisher.xml
+++ b/dat/ships/admonisher.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>600000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>A very versatile combat ship. Nexus defines the Admonisher as a compromise between the ruggedness of the Pacifier and the agility of the Lancelot. Overall a very solid fighter.</description>

--- a/dat/ships/ancestor.xml
+++ b/dat/ships/ancestor.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>500000</price>
+ <time_mod>1</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Light Combat Vessel License</license>
  <description>Commonly referred to as the little Goddard, the Ancestor also has its roots in the primitive flying machines used by men many ages ago. Unlike the Goddard though, the electronics are done by House Dvaered, making it considerably inferior in that area.</description>

--- a/dat/ships/byakko.xml
+++ b/dat/ships/byakko.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>5700000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>This is one of the Four Winds flagships. It's tough.</description>
  <mission/>

--- a/dat/ships/diplomatic_vessel.xml
+++ b/dat/ships/diplomatic_vessel.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Scout</class>
  <price>180000</price>
+ <time_mod>1</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <description>This is a diplomatic vessel. Not to be used by the player or the normal AIs.</description>
  <mission/>

--- a/dat/ships/drone.xml
+++ b/dat/ships/drone.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Drone</class>
  <price>300000</price>
+ <time_mod>0.75</time_mod>
  <fabricator>Robosys</fabricator>
  <description>This is a modified version of the robotic drone that includes a life support system for humans.</description>
  <health>

--- a/dat/ships/drone_heavy.xml
+++ b/dat/ships/drone_heavy.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Heavy Drone</class>
  <price>750000</price>
+ <time_mod>1</time_mod>
  <fabricator>Robosys</fabricator>
  <description>This Collective heavy drone has been modified by engineers to support a human pilot.</description>
  <health>

--- a/dat/ships/dvaered_ancestor.xml
+++ b/dat/ships/dvaered_ancestor.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>600000</price>
+ <time_mod>1</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Light Combat Vessel License</license>
  <description>This military grade version of the Ancestor is equipped with slightly more armour than its standard counterpart, which improves the integrity of its hull at the cost of slightly increased base mass.</description>

--- a/dat/ships/dvaered_goddard.xml
+++ b/dat/ships/dvaered_goddard.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>7000000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>House Goddard</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>Once, the Goddard Battlecruiser was commissioned by the Empire for military service. However, during the Dvaered Revolts most Goddard captains sided with the insurgents, and after the establishment of House Dvaered the Empire ceded the license for the aging vessel to them. Today, House Dvaered is House Goddard's biggest client, and this military grade version has been developed which features better armour and weapon damage at the cost of increased mass and energy consumption.</description>

--- a/dat/ships/dvaered_phalanx.xml
+++ b/dat/ships/dvaered_phalanx.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>650000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>This military grade version of the Phalanx has slightly stronger armour compared to its standard counterpart, and it also features a special cooling chamber for its forward-mounted weapons that doubles as additional cargo space.</description>

--- a/dat/ships/dvaered_vendetta.xml
+++ b/dat/ships/dvaered_vendetta.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>400000</price>
+ <time_mod>1</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Light Combat Vessel License</license>
  <description>This military grade version of the Vendetta has stronger armour and better weapon cooling facilities than the standard Vendetta, but its turning thrusters are less optimally placed than its standard counterpart to make space for the improved weapon cooling facilities, reducing the ship's turning rate slightly.</description>

--- a/dat/ships/dvaered_vigilance.xml
+++ b/dat/ships/dvaered_vigilance.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>900000</price>
+ <time_mod>2</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>This military grade version of the Vigilance has stronger armour and diverts more of its energy to its forward-mounted weapons than its standard counterpart, resulting in increased damage at the cost of slightly increased power consumption and heat production.</description>

--- a/dat/ships/empire_admonisher.xml
+++ b/dat/ships/empire_admonisher.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>700000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>This military grade version of the Admonisher is mostly identical in function to a standard Admonisher, but with slightly better armour, shields, and heat dissipation.</description>

--- a/dat/ships/empire_hawking.xml
+++ b/dat/ships/empire_hawking.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>5500000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>This military grade version of the Hawking is mostly identical in function to a standard Hawking, but with slightly better armour, shields, and heat dissipation.</description>

--- a/dat/ships/empire_lancelot.xml
+++ b/dat/ships/empire_lancelot.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>500000</price>
+ <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>This military grade version of the Lancelot is mostly identical in function to a standard Lancelot, but with slightly better armour, shields, and heat dissipation.</description>

--- a/dat/ships/empire_pacifier.xml
+++ b/dat/ships/empire_pacifier.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>1100000</price>
+ <time_mod>2</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>This military grade version of the Pacifier is mostly identical in function to a standard Pacifier, but with slightly better armour, shields, and heat dissipation.</description>

--- a/dat/ships/empire_peacemaker.xml
+++ b/dat/ships/empire_peacemaker.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Carrier</class>
  <price>8000000</price>
+ <time_mod>3</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>Built under contract for the Empire by Nexus Shipyards, the Peacemaker is one of the grandest vessels in the galaxy, dwarfing even the mighty Goddard. Peacemakers typically function as flag ships in Imperial fleets, and can provide the fighter and bomber squadrons with much needed resupplies. Like most capital ships, however, it is vulnerable to attack from enemy bombers.</description>

--- a/dat/ships/empire_shark.xml
+++ b/dat/ships/empire_shark.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>380000</price>
+ <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Empire military grade version of the Shark is mostly identical in function to a standard Shark, but with slightly better armour, shields, and heat dissipation. The military-grade materials used also result in the ship being slightly lighter than its generic counterpart.</description>

--- a/dat/ships/flf_lancelot.xml
+++ b/dat/ships/flf_lancelot.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>400000</price>
+ <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <description>The Lancelot is commonly used by FLF pilots both because of its widespread availability and its general well-roundedness.</description>
  <health>

--- a/dat/ships/flf_pacifier.xml
+++ b/dat/ships/flf_pacifier.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>1000000</price>
+ <time_mod>2</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>While not especially popular among their ranks, some FLF pilots use the Pacifier as a heavy assault ship.</description>

--- a/dat/ships/flf_vendetta.xml
+++ b/dat/ships/flf_vendetta.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>400000</price>
+ <time_mod>1</time_mod>
  <fabricator>House Dvaered</fabricator>
  <description>It's something of an irony that one of the most popular ships in use by FLF pilots comes from House Dvaered. Still, the Vendetta has been proven to be a great choice for dealing a lot of damage in a short amount of time, which is vital when going up against ships more than twice your size.</description>
  <health>

--- a/dat/ships/gawain.xml
+++ b/dat/ships/gawain.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Luxury Yacht</class>
  <price>500000</price>
+ <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <description>The Gawain is a very high-end ship, outpacing nearly all other production vessels. It relies heavily on technology first implemented on the Lancelot, and is widely used as a sporting vessel as it is extremely manoeuvrable, though they rarely see combat due to their meager weapons space and relative fragility.</description>
  <health>

--- a/dat/ships/genbu.xml
+++ b/dat/ships/genbu.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>5700000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>This is one of the Four Winds flagships. It's tough.</description>
  <mission/>

--- a/dat/ships/goddard.xml
+++ b/dat/ships/goddard.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>6000000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>House Goddard</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>Designed by eccentric genius Eduard Manuel Goddard, the Goddard Battlecruiser is what skyrocketed House Goddard to fame and fortune. Production is entirely done on Zhiru in the Goddard system by House Goddard. Over time, specialization and improvements on the original design have kept it very competitive in the market. It's a classic of space.</description>

--- a/dat/ships/hawking.xml
+++ b/dat/ships/hawking.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>4500000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The Hawking is the flagship vessel of Nexus Shipyards. A large cruiser designed for extended engagements, it is widely used by the Empire to exert control over their territories. In terms of raw firepower, the Hawking is second only to the flagship of House Goddard, though its narrower frame allows it to present a smaller target to the enemy.</description>

--- a/dat/ships/hyena.xml
+++ b/dat/ships/hyena.xml
@@ -6,8 +6,9 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>180000</price>
+ <time_mod>0.75</time_mod>
  <fabricator>Aerosys</fabricator>
- <description>The star product of Aerosys, the Hyena quickly has become a favorite of pirates far and wide. Not much of a fighter, nor does it pack too much of a punch, but in groups they can overcome nearly any vessel. While Aerosys claim that their ships are only sold to reputable pilots, it's suspected that they sell to anyone willing to pay, as it seems there are countless Hyenas among the pirate ranks.</description>
+ <description>The star product of Aerosys, the Hyena quickly has become a favorite of pirates far and wide. Not much of a fighter, nor does it pack too much of a punch, but in groups they can overcome nearly any vessel, and it's so simple to pilot that reaction time is vastly improved. While Aerosys claim that their ships are only sold to reputable pilots, it's suspected that they sell to anyone willing to pay, as it seems there are countless Hyenas among the pirate ranks.</description>
  <health>
   <absorb>0</absorb>
   <armour>25</armour>

--- a/dat/ships/hyena.xml
+++ b/dat/ships/hyena.xml
@@ -32,8 +32,8 @@
  </slots>
  <stats>
   <speed_mod>10</speed_mod>
-  <turn_mod>10</turn_mod>
-  <thrust_mod>10</thrust_mod>
+  <turn_mod>25</turn_mod>
+  <thrust_mod>100</thrust_mod>
   <armour_mod>-20</armour_mod>
  </stats>
 </ship>

--- a/dat/ships/kestrel.xml
+++ b/dat/ships/kestrel.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>3000000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Krain Industries</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The ship that single-handedly put Krain Industries on the map, the Kestrel was designed to be a sleek heavy assault cruiser. Generally more fragile than other cruisers, it manages to combine excellent manoeuvrability and firepower with state-of-the-art electronics, making for a truly fearsome ship in the hands of an able captain.</description>

--- a/dat/ships/koala.xml
+++ b/dat/ships/koala.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Courier</class>
  <price>260000</price>
+ <time_mod>1</time_mod>
  <fabricator>Melendez Corp.</fabricator>
  <description>The Koala is your standard cargo vessel. It's a small ship with little weapon space but a decent amount of cargo space. Good for the entrepreneur working his way to a vast space trade empire.</description>
  <health>

--- a/dat/ships/lancelot.xml
+++ b/dat/ships/lancelot.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>400000</price>
+ <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>One of the prize heavy fighters of Nexus Shipyards. The Lancelot was originally a classified design for the Empire military, but its existence was revealed during an aborted test flight. Now a modified version is available for civilians, though it doesn't quite match the original specifications. It is used by security agencies all over the universe for its reliability and availability.</description>

--- a/dat/ships/llama.xml
+++ b/dat/ships/llama.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Yacht</class>
  <price>120000</price>
+ <time_mod>1</time_mod>
  <fabricator>Melendez Corp.</fabricator>
  <description>One of the most widely used ships in the galaxy. Renowned for its stability and stubbornness. The design hasn't been modified much since its creation many many years ago. It was one of the first civilian use spacecrafts, first used by aristocracy and now used by everyone who cannot afford better.</description>
  <characteristics>

--- a/dat/ships/mule.xml
+++ b/dat/ships/mule.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Freighter</class>
  <price>900000</price>
+ <time_mod>2</time_mod>
  <fabricator>Melendez Corp.</fabricator>
  <license>Large Civilian Vessel License</license>
  <description>A heavy freighter specialized in transporting cargo throughout the galaxy. Also has sufficient accommodations for passengers depending on the model, allowing for enjoyable cruises. The Mule was a favorite target of pirates until they added defensive capabilities to the new models which have proved highly effective against ill-prepared pirates.</description>

--- a/dat/ships/pacifier.xml
+++ b/dat/ships/pacifier.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>1000000</price>
+ <time_mod>2</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Pacifier is one of the older and trustier designs of Nexus Shipyards. It was designed primarily as a border-patrol vessel, and as such it is able to withstand heavy punishment from raiding parties. The Pacifier features high fuel capacity to facilitate lengthy patrol routes.</description>

--- a/dat/ships/phalanx.xml
+++ b/dat/ships/phalanx.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>450000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>While somewhat technologically antiquated, the Phalanx's large energy capacity and heavy armour allow it to remain an effective combat vessel.</description>

--- a/dat/ships/pirate_admonisher.xml
+++ b/dat/ships/pirate_admonisher.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>700000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>The stock Admonisher is a powerful vessel, especially for its size. Through the usual Skull and Bones refit the Pirate Admonisher features improved manoeuvrability, more weapons space, and slightly improved defenses, at a cost of cargo capacity and armor regeneration rates.</description>
  <health>

--- a/dat/ships/pirate_ancestor.xml
+++ b/dat/ships/pirate_ancestor.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>550000</price>
+ <time_mod>1</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>Ancestors were one of the first ships to be fancied by pirates. The big intimidating wings and good top speeds would usually get ships to surrender without firing a shot. As better ships came out in the market, their use has fallen due to their archaic electronics and targeting systems.</description>
  <health>

--- a/dat/ships/pirate_kestrel.xml
+++ b/dat/ships/pirate_kestrel.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>2700000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>The Kestrel is the best ship offered by the Skull and Bones. It is extremely agile for a cruiser yet doesn't lack the firepower necessary to question the authority of the Empire. A very strong ship for those pirates who can afford it.</description>
  <health>

--- a/dat/ships/pirate_phalanx.xml
+++ b/dat/ships/pirate_phalanx.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>650000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>Building upon the already-capable Phalanx chassis, the Skull and Bones engineers have substantially improved the ship's performance, while only minorly sacrificing protection.</description>
  <health>

--- a/dat/ships/pirate_rhino.xml
+++ b/dat/ships/pirate_rhino.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Armoured Transport</class>
  <price>1500000</price>
+ <time_mod>2</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>The traditional Skull and Bones refit has left the Rhino substantially more manoeuvrable, though somewhat less armoured. Exploiting its large cargo bay and durability, the Rhino has become an excellent scavenger ship.</description>
  <health>

--- a/dat/ships/pirate_shark.xml
+++ b/dat/ships/pirate_shark.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>280000</price>
+ <time_mod>1</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>The nimble Nexus Shipyards Shark has proved an excellent canvas for the Skull and Bones technicians. Fitted with an additional weapon mount, its handling suffers minimally while it's able to bring substantially more firepower to bear.</description>
  <health>

--- a/dat/ships/pirate_vendetta.xml
+++ b/dat/ships/pirate_vendetta.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>450000</price>
+ <time_mod>1</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>The Pirate Vendetta is even more intimidating than its regular counterpart. It's been heavily tweaked to be more adjusted to the pirate style of flying. Some of the armour has been removed to make more room for loot, while the reactor has been jacked up by a dubious technician. The ship ends up being substantially better than the original, but every so often the reactor goes nova destroying the ship. You hope it won't happen to you if you get in one.</description>
  <health>

--- a/dat/ships/proteron_archimedes.xml
+++ b/dat/ships/proteron_archimedes.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>3250000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Proteron</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The Archimedes is the backbone of the Proteron fleet. Offering heavy firepower and high durability, it can always be found in the heat of battle.</description>

--- a/dat/ships/proteron_derivative.xml
+++ b/dat/ships/proteron_derivative.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>290000</price>
+ <time_mod>0.75</time_mod>
  <fabricator>Proteron</fabricator>
  <license>Light Combat Vessel License</license>
  <description>While smaller and less intimidating than it's bigger brothers in the Proteron arsenal, a pack of Derivatives is still a foe to be reckoned with. True to its name, it's the latest in a long line of largely carrier-based fighters. Packing relatively little firepower, they're ill-suited to duelling, but a carrier group unleashing several squadrons has been known to turn the tide of battle on many occasions.</description>

--- a/dat/ships/proteron_kahan.xml
+++ b/dat/ships/proteron_kahan.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>1400000</price>
+ <time_mod>2</time_mod>
  <fabricator>Proteron</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Kahan is a cutting-edge vessel. Its design was completed shortly before the Incident, and it was on track to become the Proteron military's primary combat vessel. While possessing fewer weapon mounts than the Pacifier, it makes up for it with its ability to mount higher-tech weapons.</description>

--- a/dat/ships/proteron_watson.xml
+++ b/dat/ships/proteron_watson.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Carrier</class>
  <price>9000000</price>
+ <time_mod>3</time_mod>
  <fabricator>Proteron</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The heart of the Proteron battle fleet is formed by the Watsons. Acting as a mobile launch base as well as a command and control unit, this vessel coordinates the others in the fight for dominance over the galaxy.</description>

--- a/dat/ships/quicksilver.xml
+++ b/dat/ships/quicksilver.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Courier</class>
  <price>400000</price>
+ <time_mod>1</time_mod>
  <fabricator>Melendez Corp.</fabricator>
  <description>While still a cargo hauler, the Quicksilver is quite different from Melendez's other offerings. Featuring a streamlined frame and oversized engines, it's the prime choice for expedient shipping.</description>
  <health>

--- a/dat/ships/raelid_outpost.xml
+++ b/dat/ships/raelid_outpost.xml
@@ -7,6 +7,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>1</price>
+ <time_mod>1</time_mod>
  <fabricator>N/A</fabricator>
  <description>This is a base. It's for AI use only. Don't buy it. Seriously.</description>
  <mission/>

--- a/dat/ships/raglan_outpost.xml
+++ b/dat/ships/raglan_outpost.xml
@@ -7,6 +7,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>1</price>
+ <time_mod>1</time_mod>
  <fabricator>N/A</fabricator>
  <description>This is a base. It's for AI use only. Don't buy it. Seriously.</description>
  <mission/>

--- a/dat/ships/rhino.xml
+++ b/dat/ships/rhino.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Armoured Transport</class>
  <price>1100000</price>
+ <time_mod>2</time_mod>
  <fabricator>Melendez Corp.</fabricator>
  <license>Large Civilian Vessel License</license>
  <description>A particularly durable Melendez design, the Rhino is well-suited to transporting high-value, high-risk freight. While it has much lower cargo density than dedicated freighters, it protects itself extremely effectively. Its modular bays allow it to function as a personnel transport, a fact not lost on modern militaries.</description>

--- a/dat/ships/schroedinger.xml
+++ b/dat/ships/schroedinger.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Scout</class>
  <price>180000</price>
+ <time_mod>1</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <description>The Schroedinger is primarily used as a reconnaissance vessel. It requires a skeleton crew due to its advanced automation subsystems, and its proprietary fuel tanks allow it to have range much greater than most ships. The downside is that the ship is extremely vulnerable to attack due to its light armour and low amount of weapons space. It is also equipped with a pair of Eraedon engines, making it highly manoeuvrable.</description>
  <health>

--- a/dat/ships/seiryuu.xml
+++ b/dat/ships/seiryuu.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>5700000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>This is one of the Four Winds flagships. It's tough.</description>
  <mission/>

--- a/dat/ships/shark.xml
+++ b/dat/ships/shark.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>280000</price>
+ <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>A newer Nexus Shipyards design, the Shark is an agile light fighter designed for in-system patrolling. While it's not as capable as its larger relative, the Lancelot, it's still an effective addition to any fleet.</description>

--- a/dat/ships/sindbad.xml
+++ b/dat/ships/sindbad.xml
@@ -7,6 +7,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>1</price>
+ <time_mod>1</time_mod>
  <fabricator>N/A</fabricator>
  <description>This is a base. It's for AI use only. Don't buy it. Seriously.</description>
  <mission/>

--- a/dat/ships/sirius_divinity.xml
+++ b/dat/ships/sirius_divinity.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Carrier</class>
  <price>7200000</price>
+ <time_mod>3</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>Whilst the Dogma is said to form the core of any Sirian fleet, few combat pilots would dismiss the significance of the Divinity. Though not exceptionally formidable in direct combat, the Divinity's ability to field a multitude of fighters gives it unparalleled flexibility in combat, serving as a key logistical vessel in any sizable fleet.</description>

--- a/dat/ships/sirius_dogma.xml
+++ b/dat/ships/sirius_dogma.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>5300000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The backbone of the House Sirius fleet, the Dogma is a sight to behold. Trimmed in gold and silver and fielding a large array of weapons, the Dogma is seldom surpassed in either prestige or military might.</description>

--- a/dat/ships/sirius_fidelity.xml
+++ b/dat/ships/sirius_fidelity.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>350000</price>
+ <time_mod>1</time_mod>
  <license>Light Combat Vessel License</license>
  <fabricator>Sirius Systems</fabricator>
  <description>The Fidelity is the light fighter of House Sirius. While not particularly competent alone, it's often employed as a forward scout, bringing with it far deadlier allies.</description>

--- a/dat/ships/sirius_preacher.xml
+++ b/dat/ships/sirius_preacher.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>550000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Preacher, as its name implies, is the primary vessel by which House Sirius projects its message and will. Fielding a large array of weaponry, the Preacher is adept at making converts out of unbelievers.</description>

--- a/dat/ships/sirius_reverence.xml
+++ b/dat/ships/sirius_reverence.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>720000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>A modified version of the more common Preacher, the Reverence is only available to the purest of the pure, those who carry a fraction of the Sirichana's will within themselves. Protected by the best shields money can buy, the Reverence is nevertheless weak in offense.</description>

--- a/dat/ships/sirius_shaman.xml
+++ b/dat/ships/sirius_shaman.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>525000</price>
+ <time_mod>1</time_mod>
  <fabricator>Sirius Systems</fabricator>
  <license>Light Combat Vessel License</license>
  <description>Though its relatively sleek form may cause it to be mistaken for a light fighter from a distance, the Shaman is anything but. A purpose-built light missile platform, few enemies escape the reach of the Shaman.</description>

--- a/dat/ships/soromid_arx.xml
+++ b/dat/ships/soromid_arx.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Carrier</class>
  <price>7200000</price>
+ <time_mod>3</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The Soromid Arx usually features in Soromid fleets as a command vessel and fighter carrier. It provides small craft with refuel and rearm services and has excellent durability. It is, however, lacking in both the speed and mobility areas.</description>

--- a/dat/ships/soromid_brigand.xml
+++ b/dat/ships/soromid_brigand.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>280000</price>
+ <time_mod>1</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Brigand is a fast, maneuverable bioship that the Soromid use for system patrols and police duties. The ship is lighly armoured and fairly fragile, but it makes up for this by being fast to grow and therefore relatively expendable.</description>

--- a/dat/ships/soromid_ira.xml
+++ b/dat/ships/soromid_ira.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>4500000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The Ira is the heaviest conventional combat vessel in Soromid service. Though lumbering and vulnerable when caught without escorts, it can deliver terrible punishment on enemy spaceships.</description>

--- a/dat/ships/soromid_marauder.xml
+++ b/dat/ships/soromid_marauder.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>600000</price>
+ <time_mod>1</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Marauder was developed from the same base as the Brigand, but the two ships are quite different. The Marauder was developed to fill a bomber role, which calls for increased durability and ammunition chambers. This makes it quite a bit slower than its distant cousin.</description>

--- a/dat/ships/soromid_nyx.xml
+++ b/dat/ships/soromid_nyx.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>1000000</price>
+ <time_mod>2</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Nyx is the symbol of the Soromid's military might. Able to provide heavy firepower in heated battles and agile enough to withdraw when needed, this ship usually forms the backbone of any sizable Soromid fleet.</description>

--- a/dat/ships/soromid_odium.xml
+++ b/dat/ships/soromid_odium.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>600000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Odium offers a good balance between shields and armour, as well as an impressive amount of system hardpoints for a ship its size. It can often be found dominating smaller military engagements.</description>

--- a/dat/ships/soromid_reaver.xml
+++ b/dat/ships/soromid_reaver.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>500000</price>
+ <time_mod>1</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Light Combat Vessel License</license>
  <description>Reavers are often found at the forefront of Soromid military engagements. Their good speed and maneuverability are compounded by their durability, making the Reaver one of the most effective heavy fighters in the galaxy.</description>

--- a/dat/ships/soromid_vox.xml
+++ b/dat/ships/soromid_vox.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>9000000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Soromid</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The Vox is the biggest vessel the Soromid field hands down. This dreadnought serves as the core of any given Soromid war fleet and only called upon in notable engagements.</description>

--- a/dat/ships/suzaku.xml
+++ b/dat/ships/suzaku.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>5700000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Skull and Bones</fabricator>
  <description>This is one of the Four Winds flagships. It's tough.</description>
  <mission/>

--- a/dat/ships/thurion_ingenuity.xml
+++ b/dat/ships/thurion_ingenuity.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>650000</price>
+ <time_mod>1</time_mod>
  <fabricator>Thurion shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Thurion Ingenuity is a fighter built for survival, like all Thurian ships, it puts defensive capabilities first, and offensive capabilities second. However, by no means is the Ingenuity a poor combat craft. It is capable of staying in combat and slugging it out, and when things get too hot, it can quickly retreat to recharge and regenerate. Also, like every Thurian ship, the electronics are well above average.</description>

--- a/dat/ships/thurion_perspicacity.xml
+++ b/dat/ships/thurion_perspicacity.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>350000</price>
+ <time_mod>1</time_mod>
  <fabricator>Thurion shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Thurion Perspicacity is a fast fighter with great defensive capabilities, but armed with only a low ammount of weapons. These ships are therefor often used as scouts.</description>

--- a/dat/ships/thurion_scintillation.xml
+++ b/dat/ships/thurion_scintillation.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>950000</price>
+ <time_mod>1</time_mod>
  <fabricator>Thurion shipyards</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Thurion Scintillation is a bomber designed to attack from a large distance. It is better armed than any other Thurion ship of compareable size, but has still a lower ammount of weapon hard points than other bomber class ships.</description>

--- a/dat/ships/thurion_taciturnity.xml
+++ b/dat/ships/thurion_taciturnity.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Armoured Transport</class>
  <price>1600000</price>
+ <time_mod>2</time_mod>
  <fabricator>Thurion shipyards</fabricator>
  <license>Large Civilian Vessel License</license>
  <description>The Thurion Taciturnity is a armoured and stealthy freighter that is well-suited to transport valuable freight.</description>

--- a/dat/ships/thurion_virtuosity.xml
+++ b/dat/ships/thurion_virtuosity.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>1100000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Thurion shipyards</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>For a ship of its size the Thurion Virtuosity has an impressive ammount of utility slots. Offensive capabilities are neglected though.</description>

--- a/dat/ships/vendetta.xml
+++ b/dat/ships/vendetta.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Fighter</class>
  <price>400000</price>
+ <time_mod>1</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Light Combat Vessel License</license>
  <description>The Vendetta displays the House Dvaered philosophy very well. Give a ship many intimidating guns, layer it with heavy armour, and neglect the electronics. Due to the obsolete electronics used in the Vendetta, it is better suited to skirmishes than extended battles, as it possesses inferior shield and energy regeneration compared to other ships of its class, though it can unleash a truly fearsome barrage.</description>

--- a/dat/ships/vigilance.xml
+++ b/dat/ships/vigilance.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>900000</price>
+ <time_mod>2</time_mod>
  <fabricator>House Dvaered</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Vigilance is the embodiment of Dvaered philosophy. Featuring immense energy reserves and six weapon hardpoints, it's designed to hit as hard as possible. Given its Dvaered origins, it possesses inferior technology relative to its counterparts.</description>

--- a/dat/ships/zalek_demon.xml
+++ b/dat/ships/zalek_demon.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Destroyer</class>
  <price>2400000</price>
+ <time_mod>2</time_mod>
  <fabricator>Za'lek Fabricators</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>House Za'lek's ferociously-named destroyer has earned the moniker with disproportionatly powerful shields and energy management, as well as size. Its handling suffers, and has poor armor like all Za'lek ships, but this comes as poor consolation to the Za'lek's enemies.</description>

--- a/dat/ships/zalek_diablo.xml
+++ b/dat/ships/zalek_diablo.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Carrier</class>
  <price>7000000</price>
+ <time_mod>3</time_mod>
  <fabricator>Za'lek Fabricators</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>This carrier is the archetypical Za'lek warship. Virtually unarmored and equipped with heavy shields, they are meant to serve as a platform for devastating drone swarms, not frontline combat.</description>

--- a/dat/ships/zalek_drone_bomber.xml
+++ b/dat/ships/zalek_drone_bomber.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Bomber</class>
  <price>500000</price>
+ <time_mod>1</time_mod>
  <fabricator>Za'lek Robotics</fabricator>
  <description>This is the Za'lek Bomber Drone. Built for attacking heavy ships. Not to be flown by the player.</description>
  <health>

--- a/dat/ships/zalek_drone_heavy.xml
+++ b/dat/ships/zalek_drone_heavy.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Heavy Drone</class>
  <price>190000</price>
+ <time_mod>1</time_mod>
  <fabricator>Za'lek Robotics</fabricator>
  <description>This is the Za'lek Heavy Drone. Fewer and not as crap. Not to be flown by the player.</description>
  <health>

--- a/dat/ships/zalek_drone_light.xml
+++ b/dat/ships/zalek_drone_light.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Drone</class>
  <price>120000</price>
+ <time_mod>1</time_mod>
  <fabricator>Za'lek Robotics</fabricator>
  <description>This is the Za'lek Light Drone. Very weak, cheap and numerous. Not to be flown by the player.</description>
  <health>

--- a/dat/ships/zalek_drone_scout.xml
+++ b/dat/ships/zalek_drone_scout.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Scout</class>
  <price>180000</price>
+ <time_mod>1</time_mod>
  <fabricator>Za'lek Robotics</fabricator>
  <description>This is the Za'lek Scout Drone. Built for scouting, not for battle. Not to be flown by the player.</description>
  <health>

--- a/dat/ships/zalek_hephaestus.xml
+++ b/dat/ships/zalek_hephaestus.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Carrier</class>
  <price>10000000</price>
+ <time_mod>3</time_mod>
  <fabricator>Za'lek Fabricators</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>The crown of the House Za'lek Defense Fleet, these proud buttresses of the Za'lek's ideals frequently serve as the nerve center of a Za'lek battle fleet, thanks to their superior sensor suite. The Hephaestus is rarely-seen, but commands respect.</description>

--- a/dat/ships/zalek_imp.xml
+++ b/dat/ships/zalek_imp.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>650000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Za'lek Fabricators</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Za'lek Imp is a lightweight corvette that features a cutting-edge sensor suite, even relative to most other Za'lek vessels. While it lacks the firepower of heavier corvettes, the information advantage it confers to fleets should not be dismissed.</description>

--- a/dat/ships/zalek_mephisto.xml
+++ b/dat/ships/zalek_mephisto.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>7000000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Za'lek Fabricators</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>A mighty ship, the Mephisto has grand energy and shielding management, and its shields allow it to shrug off a lot of abuse. A core of these ships can reduce even powerful fleets to slag in short order.</description>

--- a/dat/ships/zalek_prototype.xml
+++ b/dat/ships/zalek_prototype.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>8000000</price>
+ <time_mod>2.5</time_mod>
  <fabricator>Za'lek Research Team</fabricator>
  <license>Heavy Combat Vessel License</license>
  <description>This is an experimental type of cruiser developed by Za'lek engineers. Little is known about it outside of the development team, but it is rumoured to have powerful upgrades and enhancements over much of the competition.</description>

--- a/dat/ships/zalek_sting.xml
+++ b/dat/ships/zalek_sting.xml
@@ -6,6 +6,7 @@
  <sound>engine</sound>
  <class>Corvette</class>
  <price>770000</price>
+ <time_mod>1.5</time_mod>
  <fabricator>Za'lek Fabricators</fabricator>
  <license>Medium Combat Vessel License</license>
  <description>The Sting Corvette is rather large for its size, but its advanced sensor suite, impressive weapons loadout, and tough shields makes it a good backbone to the fleet of House Za'lek.</description>

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -304,6 +304,7 @@ void equipment_open( unsigned int wid )
       "Thrust:\n"
       "Speed:\n"
       "Turn:\n"
+      "Time Rate:\n"
       "\n"
       "Absorption:\n"
       "Shield:\n"
@@ -1698,6 +1699,7 @@ void equipment_updateShips( unsigned int wid, char* str )
          "\a%c%.0f\a0 kN/tonne\n"
          "\a%c%.0f\a0 m/s (max \a%c%.0f\a0 m/s)\n"
          "\a%c%.0f\a0 deg/s\n"
+         "\a%c%.0f%%\n"
          "\n"
          "\a%c%.0f%%\n"
          "\a%c%.0f\a0 MJ (\a%c%.1f\a0 MW)\n"
@@ -1722,6 +1724,7 @@ void equipment_updateShips( unsigned int wid, char* str )
       EQ_COMP( solid_maxspeed( ship->solid, ship->speed, ship->thrust ),
             solid_maxspeed( ship->solid, ship->ship->speed, ship->ship->thrust), 0 ),
       EQ_COMP( ship->turn*180./M_PI, ship->ship->turn*180./M_PI, 0 ),
+      EQ_COMP( ship->ship->dt_default * 100, ship->ship->dt_default * 100, 0 ),
       /* Health. */
       EQ_COMP( ship->dmg_absorb * 100, ship->ship->dmg_absorb * 100, 0 ),
       EQ_COMP( ship->shield_max, ship->ship->shield, 0 ),

--- a/src/info.c
+++ b/src/info.c
@@ -388,6 +388,7 @@ static void info_openShip( unsigned int wid )
          "Thrust:\n"
          "Speed:\n"
          "Turn:\n"
+         "Time Rate:\n"
          "\n"
          "Absorption:\n"
          "Shield:\n"
@@ -433,6 +434,7 @@ static void ship_update( unsigned int wid )
          "%.0f kN/tonne\n"
          "%.0f m/s (max %.0f m/s)\n"
          "%.0f deg/s\n"
+         "%.0f%%\n" /* Time Rate (dt_default) */
          "\n"
          "%.0f%%\n" /* Absorbption */
          "%.0f / %.0f MJ (%.1f MW)\n" /* Shield */
@@ -453,6 +455,7 @@ static void ship_update( unsigned int wid )
          player.p->thrust / player.p->solid->mass,
          player.p->speed, solid_maxspeed( player.p->solid, player.p->speed, player.p->thrust ),
          player.p->turn*180./M_PI,
+         player.p->ship->dt_default * 100.,
          /* Health. */
          player.p->dmg_absorb * 100.,
          player.p->shield, player.p->shield_max, player.p->shield_regen,

--- a/src/input.c
+++ b/src/input.c
@@ -1024,11 +1024,11 @@ static void input_key( int keynum, double value, double kabs, int repeat )
       if ((value==KEY_PRESS) && (!player_isFlag( PLAYER_CINEMATICS_2X ))) {
          if (player_isFlag(PLAYER_DOUBLESPEED)) {
             if (!player_isFlag(PLAYER_AUTONAV))
-               pause_setSpeed(1.);
+               pause_setSpeed( player.p->ship->dt_default );
             player_rmFlag(PLAYER_DOUBLESPEED);
          } else {
             if (!player_isFlag(PLAYER_AUTONAV))
-               pause_setSpeed(2.);
+               pause_setSpeed( 2. * player.p->ship->dt_default );
             player_setFlag(PLAYER_DOUBLESPEED);
          }
       }

--- a/src/input.c
+++ b/src/input.c
@@ -1023,12 +1023,16 @@ static void input_key( int keynum, double value, double kabs, int repeat )
    } else if (KEY("speed") && !repeat) {
       if ((value==KEY_PRESS) && (!player_isFlag( PLAYER_CINEMATICS_2X ))) {
          if (player_isFlag(PLAYER_DOUBLESPEED)) {
-            if (!player_isFlag(PLAYER_AUTONAV))
+            if (!player_isFlag(PLAYER_AUTONAV)) {
                pause_setSpeed( player.p->ship->dt_default );
+               sound_setSpeed( 1. );
+            }
             player_rmFlag(PLAYER_DOUBLESPEED);
          } else {
-            if (!player_isFlag(PLAYER_AUTONAV))
+            if (!player_isFlag(PLAYER_AUTONAV)) {
                pause_setSpeed( 2. * player.p->ship->dt_default );
+               sound_setSpeed( 2. );
+            }
             player_setFlag(PLAYER_DOUBLESPEED);
          }
       }

--- a/src/land.c
+++ b/src/land.c
@@ -26,6 +26,7 @@
 #include "toolkit.h"
 #include "dialogue.h"
 #include "player.h"
+#include "player_autonav.h"
 #include "rng.h"
 #include "music.h"
 #include "economy.h"
@@ -1355,6 +1356,9 @@ void takeoff( int delay )
    pilot_setFlag( player.p, PILOT_TAKEOFF );
    pilot_setThrust( player.p, 0. );
    pilot_setTurn( player.p, 0. );
+
+   /* Reset speed */
+   player_autonavResetSpeed();
    }
 
 

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -120,6 +120,7 @@ void shipyard_open( unsigned int wid )
          "Thrust:\n"
          "Speed:\n"
          "Turn:\n"
+         "Time Rate:\n"
          "\n"
          "Absorption:\n"
          "Shield:\n"
@@ -200,6 +201,7 @@ void shipyard_update( unsigned int wid, char* str )
             "NA\n"
             "NA\n"
             "NA\n"
+            "NA\n"
             "\n"
             "NA\n"
             "NA\n"
@@ -253,6 +255,7 @@ void shipyard_update( unsigned int wid, char* str )
          "%.0f kN/ton\n"
          "%.0f m/s\n"
          "%.0f deg/s\n"
+         "%.0f%%\n"
          "\n"
          "%.0f%% damage\n"
          "%.0f MJ (%.1f MW)\n"
@@ -274,6 +277,7 @@ void shipyard_update( unsigned int wid, char* str )
          ship->thrust,
          ship->speed,
          ship->turn*180/M_PI,
+         ship->dt_default*100.,
          /* Misc */
          ship->dmg_absorb*100.,
          ship->shield, ship->shield_regen,

--- a/src/menu.c
+++ b/src/menu.c
@@ -139,6 +139,7 @@ static int menu_main_bkg_system (void)
    cam_setTargetPos( cx, cy, 0 );
    cam_setZoom( conf.zoom_far );
    pause_setSpeed( 1. );
+   sound_setSpeed( 1. );
 
    return 0;
 }

--- a/src/naev.c
+++ b/src/naev.c
@@ -1104,6 +1104,7 @@ static double fps_cur = 0.; /**< FPS accumulator to trigger change. */
 static void display_fps( const double dt )
 {
    double x,y;
+   double dt_mod_base = 1.;
 
    fps_dt  += dt;
    fps_cur += 1.;
@@ -1118,8 +1119,13 @@ static void display_fps( const double dt )
       gl_print( NULL, x, y, NULL, "%3.2f", fps );
       y -= gl_defFont.h + 5.;
    }
-   if (dt_mod != 1.)
-      gl_print( NULL, x, y, NULL, "%3.1fx", dt_mod);
+
+   if ((player.p != NULL) && !player_isFlag(PLAYER_DESTROYED) &&
+         !player_isFlag(PLAYER_CREATING)) {
+      dt_mod_base = player.p->ship->dt_default;
+   }
+   if (dt_mod != dt_mod_base)
+      gl_print( NULL, x, y, NULL, "%3.1fx", dt_mod / dt_mod_base);
 
    if (!paused || !player_paused || !conf.pause_show)
       return;

--- a/src/nlua_player.c
+++ b/src/nlua_player.c
@@ -566,6 +566,7 @@ static int playerL_cinematics( lua_State *L )
    if (player_isFlag( PLAYER_DOUBLESPEED )) {
       player_rmFlag( PLAYER_DOUBLESPEED );
       pause_setSpeed( player.p->ship->dt_default );
+      sound_setSpeed( 1. );
    }
 
    if (b) {
@@ -574,6 +575,7 @@ static int playerL_cinematics( lua_State *L )
       player_rmFlag( PLAYER_DOUBLESPEED );
       ovr_setOpen(0);
       pause_setSpeed( player.p->ship->dt_default );
+      sound_setSpeed( 1. );
 
       if (!f_gui)
          player_setFlag( PLAYER_CINEMATICS_GUI );

--- a/src/nlua_player.c
+++ b/src/nlua_player.c
@@ -565,7 +565,7 @@ static int playerL_cinematics( lua_State *L )
    /* Remove doublespeed. */
    if (player_isFlag( PLAYER_DOUBLESPEED )) {
       player_rmFlag( PLAYER_DOUBLESPEED );
-      pause_setSpeed(1.);
+      pause_setSpeed( player.p->ship->dt_default );
    }
 
    if (b) {
@@ -573,7 +573,7 @@ static int playerL_cinematics( lua_State *L )
       player_autonavAbort( abort_msg );
       player_rmFlag( PLAYER_DOUBLESPEED );
       ovr_setOpen(0);
-      pause_setSpeed(1.);
+      pause_setSpeed( player.p->ship->dt_default );
 
       if (!f_gui)
          player_setFlag( PLAYER_CINEMATICS_GUI );

--- a/src/pause.c
+++ b/src/pause.c
@@ -69,8 +69,6 @@ void unpause_game (void)
 void pause_setSpeed( double mod )
 {
    dt_mod = mod;
-   /* FIXME: sound_setSpeed causes sound to go silent above 2. Capped for now */
-   sound_setSpeed( MIN(mod, 2) );
 }
 
 

--- a/src/pause.c
+++ b/src/pause.c
@@ -69,7 +69,8 @@ void unpause_game (void)
 void pause_setSpeed( double mod )
 {
    dt_mod = mod;
-   sound_setSpeed( mod );
+   /* FIXME: sound_setSpeed causes sound to go silent above 2. Capped for now */
+   sound_setSpeed( MIN(mod, 2) );
 }
 
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -1478,7 +1478,9 @@ void pilot_updateDisable( Pilot* p, const unsigned int shooter )
 
       /* This is sort of a hack to make sure it gets reset... */
       if (p->id==PLAYER_ID)
-         pause_setSpeed( player_isFlag(PLAYER_DOUBLESPEED) ? 2. : 1. );
+         pause_setSpeed(
+            player.p->ship->dt_default *
+            (player_isFlag(PLAYER_DOUBLESPEED) ? 2. : 1.) );
    }
 }
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -31,6 +31,7 @@
 #include "escort.h"
 #include "music.h"
 #include "player.h"
+#include "player_autonav.h"
 #include "gui.h"
 #include "board.h"
 #include "debris.h"
@@ -1478,9 +1479,7 @@ void pilot_updateDisable( Pilot* p, const unsigned int shooter )
 
       /* This is sort of a hack to make sure it gets reset... */
       if (p->id==PLAYER_ID)
-         pause_setSpeed(
-            player.p->ship->dt_default *
-            (player_isFlag(PLAYER_DOUBLESPEED) ? 2. : 1.) );
+         player_autonavResetSpeed();
    }
 }
 

--- a/src/player.c
+++ b/src/player.c
@@ -802,6 +802,7 @@ void player_cleanup (void)
 
    /* Reset time compression. */
    pause_setSpeed( 1.0 );
+   sound_setSpeed( 1.0 );
 
    /* Clean up. */
    memset( &player, 0, sizeof(Player_t) );
@@ -2267,6 +2268,7 @@ void player_dead (void)
 {
    /* Explode at normal speed. */
    pause_setSpeed(1.);
+   sound_setSpeed(1.);
 
    gui_cleanup();
 
@@ -2297,6 +2299,7 @@ void player_destroyed (void)
 
    /* Reset time compression when player dies. */
    pause_setSpeed( 1. );
+   sound_setSpeed( 1. );
 }
 
 

--- a/src/player_autonav.c
+++ b/src/player_autonav.c
@@ -19,6 +19,7 @@
 #include "pilot.h"
 #include "pilot_ew.h"
 #include "space.h"
+#include "sound.h"
 #include "conf.h"
 #include <time.h>
 
@@ -50,9 +51,11 @@ void player_autonavResetSpeed (void)
    if (player_isFlag(PLAYER_DOUBLESPEED)) {
       tc_mod         = 2. * player.p->ship->dt_default;
       pause_setSpeed( tc_mod );
+      sound_setSpeed( 2 );
    } else {
       tc_mod         = player.p->ship->dt_default;
       pause_setSpeed( tc_mod );
+      sound_setSpeed( 1 );
    }
    tc_rampdown = 0;
 }
@@ -131,6 +134,7 @@ static int player_autonavSetup (void)
    /* Set flag and tc_mod just in case. */
    player_setFlag(PLAYER_AUTONAV);
    pause_setSpeed( tc_mod );
+   sound_setSpeed( tc_mod / player.p->ship->dt_default );
 
    /* Make sure time acceleration starts immediately. */
    player.autonav_timer = 0.;
@@ -566,6 +570,7 @@ void player_updateAutonav( double dt )
             tc_mod = MIN( dis_max, tc_mod + dis_mod*dt );
       }
       pause_setSpeed( tc_mod );
+      sound_setSpeed( tc_mod / player.p->ship->dt_default );
       return;
    }
 
@@ -578,6 +583,7 @@ void player_updateAutonav( double dt )
       if (tc_mod != tc_base) {
          tc_mod = MAX( tc_base, tc_mod-tc_down*dt );
          pause_setSpeed( tc_mod );
+         sound_setSpeed( tc_mod / player.p->ship->dt_default );
       }
       return;
    }
@@ -591,6 +597,7 @@ void player_updateAutonav( double dt )
    if (tc_mod > player.tc_max)
       tc_mod = player.tc_max;
    pause_setSpeed( tc_mod );
+   sound_setSpeed( tc_mod / player.p->ship->dt_default );
 }
 
 

--- a/src/player_autonav.c
+++ b/src/player_autonav.c
@@ -48,11 +48,11 @@ static int player_autonavBrake (void);
 void player_autonavResetSpeed (void)
 {
    if (player_isFlag(PLAYER_DOUBLESPEED)) {
-     tc_mod         = 2.;
-     pause_setSpeed( 2. );
+      tc_mod         = 2. * player.p->ship->dt_default;
+      pause_setSpeed( tc_mod );
    } else {
-     tc_mod         = 1.;
-     pause_setSpeed( 1. );
+      tc_mod         = player.p->ship->dt_default;
+      pause_setSpeed( tc_mod );
    }
    tc_rampdown = 0;
 }
@@ -110,7 +110,7 @@ static int player_autonavSetup (void)
    player_message(_("\apAutonav initialized."));
    if (!player_isFlag(PLAYER_AUTONAV)) {
 
-      tc_base   = player_isFlag(PLAYER_DOUBLESPEED) ? 2. : 1.;
+      tc_base   = player.p->ship->dt_default * (player_isFlag(PLAYER_DOUBLESPEED) ? 2. : 1.);
       tc_mod    = tc_base;
       if (conf.compression_mult >= 1.)
          player.tc_max = MIN( conf.compression_velocity / solid_maxspeed(player.p->solid, player.p->speed, player.p->thrust), conf.compression_mult );

--- a/src/ship.c
+++ b/src/ship.c
@@ -849,6 +849,7 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
          /* Already preemptively loaded, avoids warning. */
          continue;
       }
+      xmlr_float(node,"time_mod",temp->dt_default);
       xmlr_long(node,"price",temp->price);
       xmlr_strd(node,"license",temp->license);
       xmlr_strd(node,"fabricator",temp->fabricator);
@@ -985,6 +986,7 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    MELEMENT((temp->gfx_space==NULL) || (temp->gfx_comm==NULL),"GFX");
    MELEMENT(temp->gui==NULL,"GUI");
    MELEMENT(temp->class==SHIP_CLASS_NULL,"class");
+   MELEMENT(temp->dt_default==0,"time_mod");
    MELEMENT(temp->price==0,"price");
    MELEMENT(temp->fabricator==NULL,"fabricator");
    MELEMENT(temp->description==NULL,"description");

--- a/src/ship.c
+++ b/src/ship.c
@@ -987,6 +987,7 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    MELEMENT(temp->gui==NULL,"GUI");
    MELEMENT(temp->class==SHIP_CLASS_NULL,"class");
    MELEMENT(temp->price==0,"price");
+   MELEMENT(temp->dt_default==0.,"time_mod");
    MELEMENT(temp->fabricator==NULL,"fabricator");
    MELEMENT(temp->description==NULL,"description");
    MELEMENT(temp->armour==0.,"armour");
@@ -1004,17 +1005,6 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    /*MELEMENT(temp->cap_cargo==0,"cargo");
    MELEMENT(temp->cpu==0.,"cpu");*/
 #undef MELEMENT
-
-   /* Set default time_mod (dt_default) value. */
-   if (temp->dt_default == 0.) {
-      if (temp->crew != 0) {
-         temp->dt_default = cbrt(temp->crew) * 0.75;
-      } else {
-         WARN( _("Ship '%s' missing both 'time_mod' and 'crew' element; cannot calculate 'time_mod', defaulting to 1"), temp->name );
-         temp->dt_default = 1.;
-      }
-         
-   }
 
    return 0;
 }

--- a/src/ship.c
+++ b/src/ship.c
@@ -986,7 +986,6 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    MELEMENT((temp->gfx_space==NULL) || (temp->gfx_comm==NULL),"GFX");
    MELEMENT(temp->gui==NULL,"GUI");
    MELEMENT(temp->class==SHIP_CLASS_NULL,"class");
-   MELEMENT(temp->dt_default==0,"time_mod");
    MELEMENT(temp->price==0,"price");
    MELEMENT(temp->fabricator==NULL,"fabricator");
    MELEMENT(temp->description==NULL,"description");
@@ -1005,6 +1004,17 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    /*MELEMENT(temp->cap_cargo==0,"cargo");
    MELEMENT(temp->cpu==0.,"cpu");*/
 #undef MELEMENT
+
+   /* Set default time_mod (dt_default) value. */
+   if (temp->dt_default == 0.) {
+      if (temp->crew != 0) {
+         temp->dt_default = cbrt(temp->crew) * 0.75;
+      } else {
+         WARN( _("Ship '%s' missing both 'time_mod' and 'crew' element; cannot calculate 'time_mod', defaulting to 1"), temp->name );
+         temp->dt_default = 1.;
+      }
+         
+   }
 
    return 0;
 }

--- a/src/ship.h
+++ b/src/ship.h
@@ -104,6 +104,7 @@ typedef struct Ship_ {
    int fuel;                /**< How much fuel by default. */
    int fuel_consumption; /**< Fuel consumption by engine. */
    double cap_cargo;        /**< Cargo capacity (in volume). */
+   double dt_default;      /**< Default/minimum time delta. */
 
    /* health */
    double armour;    /**< Maximum base armour in MJ. */

--- a/src/sound.c
+++ b/src/sound.c
@@ -668,9 +668,6 @@ void sound_setSpeed( double s )
    if (sound_disabled)
       return;
 
-   /* FIXME: Sound goes silent above speed of 2. Capped for now. */
-   s = MIN(s, 2);
-
    /* We implement the brown noise here. */
    playing = (snd_compression_gain > 0.);
    if (player.tc_max > 2.)

--- a/src/sound.c
+++ b/src/sound.c
@@ -668,6 +668,9 @@ void sound_setSpeed( double s )
    if (sound_disabled)
       return;
 
+   /* FIXME: Sound goes silent above speed of 2. Capped for now. */
+   s = MIN(s, 2);
+
    /* We implement the brown noise here. */
    playing = (snd_compression_gain > 0.);
    if (player.tc_max > 2.)


### PR DESCRIPTION
I briefly mentioned this idea I had on IRC yesterday, and thinking it over, I decided to implement it. I'm very happy with the results.

This is a pretty simple idea: heavier classes of ships have time pass at a faster rate than lighter classes. In effect, this simulates the phenomenon where larger animals "feel" time passing faster than smaller animals, and it has two effects:

1. Lighter ships now have an inherent advantage over larger ships in that they enable better reaction time.
2. Heavier ships feel much less slow, making piloting them feel a lot nicer.

I decided to make Corvettes go at 1.5x, Destroyers and medium transports go at 2x, Cruisers go at 2.5x, and carriers go at 3x. Fighters, couriers, and yachts go at 1x, as before.

Additionally, I made the Hyena a special case that goes at 0.75x, along with the regular Collective Drone. I also buffed up the Hyena's maneuverability so that players can better take advantage of the slower time passage. It works very well, and it makes the Hyena much more competitive. This also has the nice side-effect of making pirates a bit more threatening. (Note: the Collective Drone did *not* have such a buff applied to it; it's the same as before, just with slower time passage.)

While I was doing this, I also noticed that the feature that speeds sound up would completely silence sound at above 2x or so, so I capped it to that for now, until someone can come up with a more complete solution.