### PR TITLE
Update libpng dependency in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ Install compile-time dependencies on Ubuntu 16.04 (and hopefully later) with:
 
 ```bash
 apt-get install build-essential automake libsdl2-dev libsdl2-image-dev \
-libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng12-dev libopenal-dev \
+libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng-dev libopenal-dev \
 libvorbis-dev binutils-dev libzip-dev libiberty-dev autopoint intltool
 ```
 


### PR DESCRIPTION
`libpng12-dev` has been superceded by `libpng-dev` in recent Ubuntu and Debian.