### PR TITLE
Added two new independent stations between Teller and other Pirate stongholds.

### DIFF
--- a/dat/assets/alleyway.xml
+++ b/dat/assets/alleyway.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Alleyway">
+ <pos>
+  <x>7683.061332</x>
+  <y>4794.949483</y>
+ </pos>
+ <GFX>
+  <space>002.png</space>
+  <exterior>traderoom.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Independent</faction>
+  <value>50.000000</value>
+  <range>0</range>
+ </presence>
+ <general>
+  <class>0</class>
+  <population>1000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <missions/>
+  </services>
+  <commodities/>
+  <description>Originally intended to be a trading hub and refueling stop for merchants, this station has effectively turned into a hub for both pirates and bounty hunters. Authorities have long ago given up any hope of controlling the chaos, so everyone knows to be armed and remain vigilant at all times.</description>
+  <bar>The bar is a mix of mostly pirates and bounty hunters, with a handful of merchants and gamblers. Fights often break out and it's hard to tell who to trust, so most people keep to themselves and avoid eye contact with others.</bar>
+ </general>
+</asset>

--- a/dat/assets/sabe.xml
+++ b/dat/assets/sabe.xml
@@ -22,9 +22,9 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
   <commodities>
    <commodity>Food</commodity>

--- a/dat/assets/secundus_station.xml
+++ b/dat/assets/secundus_station.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Secundus Station">
+ <pos>
+  <x>-5198.478537</x>
+  <y>-9255.152333</y>
+ </pos>
+ <GFX>
+  <space>003.png</space>
+  <exterior>station05.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Independent</faction>
+  <value>5.000000</value>
+  <range>0</range>
+ </presence>
+ <general>
+  <class>0</class>
+  <population>100</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+  </services>
+  <commodities/>
+  <description>This old, rusty station has been mostly abandoned, but a handful of dedicated individuals continue to keep it running. It has been rumored that the maintainers of the station have connections to pirates, but no such connection has been proven and the local Dvaered officials don't seem to care anyway.</description>
+ </general>
+</asset>

--- a/dat/outfits/maps/map_pirate_strongholds.xml
+++ b/dat/outfits/maps/map_pirate_strongholds.xml
@@ -71,13 +71,20 @@
   </sys>
   <!-- Stations where a few “interesting” quests are available -->
   <sys name="Suna">
-     <asset>The Wringer</asset>
+   <asset>The Wringer</asset>
   </sys>
   <sys name="Alteris">
-     <asset>Darkshed</asset>
+   <asset>Darkshed</asset>
   </sys>
+  <!-- And stations that help you to get around -->
   <sys name="Eridani">
-     <asset>The Crucible</asset>
+   <asset>The Crucible</asset>
+  </sys>
+  <sys name="Doranthex">
+   <asset>Secundus Station</asset>
+  </sys>
+  <sys name="Brimstone">
+   <asset>Alleyway</asset>
   </sys>
  </specific>
 </outfit>

--- a/dat/outfits/maps/map_the_frontier.xml
+++ b/dat/outfits/maps/map_the_frontier.xml
@@ -31,6 +31,7 @@
   <sys name="Brimstone">
    <jump>Shickhaw</jump>
    <jump>Triap</jump>
+   <asset>Alleyway</asset>
    <asset>Brimstone I</asset>
    <asset>Brimstone II</asset>
    <asset>Brimstone III</asset>

--- a/dat/ssys/brimstone.xml
+++ b/dat/ssys/brimstone.xml
@@ -11,6 +11,7 @@
   <y>-337.000000</y>
  </pos>
  <assets>
+  <asset>Alleyway</asset>
   <asset>Brimstone I</asset>
   <asset>Brimstone II</asset>
   <asset>Brimstone III</asset>

--- a/dat/ssys/doranthex.xml
+++ b/dat/ssys/doranthex.xml
@@ -15,6 +15,7 @@
   <asset>Doranthex Secundus</asset>
   <asset>Secundus Alpha</asset>
   <asset>Secundus Beta</asset>
+  <asset>Secundus Station</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Frontier Unpresence</asset>
   <asset>Virtual Trader Area</asset>


### PR DESCRIPTION
These stations are designed to mainly be refueling stops for pirate
aligned players, since without them the journey to Teller is nearly
insurmountable. Incidentally, they're marginally useful for non-pirate
players too, since they're located closer to the centers of their
respective systems.