### PR TITLE
Added reputation cap boosts when first completing assassination jobs.

### DIFF
--- a/dat/missions/pirate/empbounty_dead.lua
+++ b/dat/missions/pirate/empbounty_dead.lua
@@ -30,7 +30,7 @@
 
 include "numstring.lua"
 include "jumpdist.lua"
-include "pilot/empire.lua"
+include "dat/missions/pirate/common.lua"
 
 
 -- Mission details
@@ -277,6 +277,32 @@ end
 function succeed ()
    player.msg( "\ag" .. msg[4] .. "\a0" )
    player.pay( credits )
+
+   -- Pirate rep cap increase
+   local bounty_done = var.peek( "pir_bounty_done" )
+   var.push( "pir_bounty_done", true )
+   if bounty_done ~= true then
+      var.push( "_fcap_pirate", var.peek( "_fcap_pirate" ) + 5 )
+   end
+
+   if level >= 5 then
+      local bounty_dangerous_done = var.peek( "pir_bounty_dangerous_done" )
+      var.push( "pir_bounty_dangerous_done", true )
+      if bounty_dangerous_done ~= true then
+         var.push( "_fcap_pirate", var.peek( "_fcap_pirate" ) + 5 )
+         pir_modDecayFloor( 5 )
+      end
+
+      if level >= 6 then
+         local bounty_highly_dangerous_done = var.peek( "pir_bounty_highly_dangerous_done" )
+         var.push( "pir_bounty_highly_dangerous_done", true )
+         if bounty_highly_dangerous_done ~= true then
+            var.push( "_fcap_pirate", var.peek( "_fcap_pirate" ) + 5 )
+            pir_modDecayFloor( 5 )
+         end
+      end
+   end
+
    paying_faction:modPlayerSingle( reputation )
    misn.finish( true )
 end

--- a/dat/missions/pirate/hitman.lua
+++ b/dat/missions/pirate/hitman.lua
@@ -131,7 +131,7 @@ end
 function landed()
    if planet.cur() == misn_base then
       tk.msg(title[3], text[3])
-      player.pay(45000)
+      player.pay(150000)
       faction.modPlayerSingle("Pirate",5)
       pir_modDecayFloor( 2 )
       misn.finish(true)

--- a/dat/missions/pirate/hitman2.lua
+++ b/dat/missions/pirate/hitman2.lua
@@ -112,7 +112,7 @@ end
 function landed()
    if planet.cur() == misn_base then
       tk.msg(title[3], text[3])
-      player.pay(100000) -- 100k
+      player.pay(500000) -- 500k
       faction.modPlayerSingle("Pirate",5)
       pir_modDecayFloor( 3 )
       misn.finish(true)


### PR DESCRIPTION
On the first assassination job, first dangerous assassination job,
and first highly dangerous assassination job, your reputation cap
for the pirates now increases.

The hitman missions have also had their pay increased substantially. This is a regular problem in Naev: unique missions are usually not rewarding enough to justify their increased complexity.