### PR TITLE
Upped the rewards on most unique missions, plus other minor improvements.

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -1160,18 +1160,17 @@
     <unique />
   </flags>
   <avail>
-    <cond>player.pilot():ship():class() == "Yacht"</cond>
-   <chance>5</chance>
+    <cond>player.pilot():ship():class() == "Yacht" or player.pilot():ship():class() == "Luxury Yacht"</cond>
+   <chance>10</chance>
    <location>Bar</location>
   </avail>
  </mission>
  <mission name="Racing Skills 2">
   <lua>neutral/race2</lua>
-  <flags>
-  </flags>
   <avail>
-    <cond>player.pilot():ship():class() == "Yacht" and player.misnDone("Racing Skills 1")</cond>
-   <chance>5</chance>
+   <cond>player.pilot():ship():class() == "Yacht" or player.pilot():ship():class() == "Luxury Yacht"</cond>
+   <done>Racing Skills 1</done>
+   <chance>20</chance>
    <location>Bar</location>
   </avail>
  </mission>

--- a/dat/missions/dvaered/assault_on_unicorn.lua
+++ b/dat/missions/dvaered/assault_on_unicorn.lua
@@ -25,7 +25,7 @@ osd_msg3 = _("You have reached your maximum payment. Return to %s.")
 function create ()
    rep = faction.playerStanding("Dvaered")
    -- Round the payment to the nearest thousand.
-   max_payment = math.floor( (10000 * math.sqrt(rep) * rep/10 / 1e3) + .5 ) * 1e3
+   max_payment = rep * 50000
    misn_desc = misn_desc:format( numstring(max_payment) )
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
@@ -69,14 +69,14 @@ end
 function death(pilot,killer)
    if pilot:faction() == faction.get("Pirate") and killer == player.pilot() then
       reward_table = {
-         ["Hyena"]             =  1000,
-         ["Pirate Shark"]      =  2000,
-         ["Pirate Vendetta"]   =  4000,
-         ["Pirate Ancestor"]   =  5000,
-         ["Pirate Rhino"]      = 10000,
-         ["Pirate Phalanx"]    = 11000,
-         ["Pirate Admonisher"] = 12000,
-         ["Pirate Kestrel"]    = 24000
+         ["Hyena"]             =  10000,
+         ["Pirate Shark"]      =  30000,
+         ["Pirate Vendetta"]   =  80000,
+         ["Pirate Ancestor"]   = 100000,
+         ["Pirate Rhino"]      = 120000,
+         ["Pirate Phalanx"]    = 140000,
+         ["Pirate Admonisher"] = 150000,
+         ["Pirate Kestrel"]    = 600000
       }
 
       killed_ship = pilot:ship():name()

--- a/dat/missions/dvaered/championship.lua
+++ b/dat/missions/dvaered/championship.lua
@@ -42,13 +42,13 @@ title[3] = _("You won this round")
 text[3] = _([["Congratulations", the staff says to you. Come back when you are ready for the next round!]])
 
 title[4] = _("You are the new champion")
-text[4] = _([[Congratulations! The staff pays you %s k credits.]])
+text[4] = _([[Congratulations! The staff pays you %s credits.]])
 
 title[5] = _("You are the vice-champion")
-text[5] = _([[Congratulations! The staff pays you %s k credits.]])
+text[5] = _([[Congratulations! The staff pays you %s credits.]])
 
 title[6] = _("Thanks for playing")
-text[6] = _([[The staff pays you %s k credits.]])
+text[6] = _([[The staff pays you %s credits.]])
 
 comptitle[1] = _("I am here to win the championship")
 comptext[1] = _([["Hello," the pilot says, "I came to become the new champion of this cycle! I prepared myself since the first day I piloted a ship. Trust me, I'm nearly invincible, and my Vendetta is indestructible.
@@ -68,11 +68,11 @@ comptext[5] = _([["Hi, I'm... err... I'm an independant pilot. I'm here to take 
 
 comptitle[6] = _("I am here to win the championship")
 comptext[6] = _([["Hello," the pilot says, "I came to become the new champion of this cycle! I prepared myself since the first day I piloted a ship. Trust me, I'm nearly invincible, and my Vendetta is indestructible.
-   Do you know who I am? I am the famous independant pilot who helped Dvaered High Command to destroy the FLF base in the nebula. I managed to defeat lots of FLF fighters with my ship! An other day, I will tell you my adventures, but now, I need to concentrate myself."]])
+   Do you know who I am? I am the famous independant pilot who helped Dvaered High Command to destroy the FLF base in the nebula. I managed to defeat lots of FLF fighters with my ship! Another day, I will tell you my adventures, but now, I need to concentrate myself."]])
    
 -- Mission details
 misn_title = _("The Dvaered Championship")
-misn_reward = _("From 5k to 160k credits, depending on your rank")
+misn_reward = _("From 50k to 1.6m credits, depending on your rank")
 misn_desc = _("You take part to a fight contest. Try to do your best!")
 
 -- NPC
@@ -165,7 +165,7 @@ end
 function accept()
    
    level = 0
-   reward = 5000
+   reward = 50000
    
    if tk.yesno(title[1], text[1]) then
 
@@ -182,7 +182,7 @@ function accept()
 
       beginbattle()
 
-      else
+   else
       tk.msg(refusetitle, refusetext)
       misn.finish(false)
    end
@@ -364,10 +364,10 @@ function enter()
       mark = system.mrkAdd( mark_name, start_pos )
       prox = hook.timer(500, "proximity", {location = start_pos, radius = 300, funcname = "assault"})
 
-      elseif haslauncher == true then
+   elseif haslauncher == true then
       tk.msg(dismisstitle, missiletext)
       misn.finish(false)
-      elseif playerclass ~= "Fighter" then
+   elseif playerclass ~= "Fighter" then
       tk.msg(dismisstitle, fightertext)
       misn.finish(false)
    end
@@ -415,11 +415,11 @@ function land()
       elseif stage == 3 and planet.cur() == mispla then  --player will be payed
 
       if level == 5 then  --you are the champion
-         tk.msg(title[4], text[4]:format(numstring(reward/1000 * 2^level)))
-         elseif level == 4 then
-         tk.msg(title[5], text[5]:format(numstring(reward/1000 * 2^level)))
-         else
-         tk.msg(title[6], text[6]:format(numstring(reward/1000 * 2^level)))
+         tk.msg(title[4], text[4]:format(numstring(reward * 2^level)))
+      elseif level == 4 then
+         tk.msg(title[5], text[5]:format(numstring(reward * 2^level)))
+      else
+         tk.msg(title[6], text[6]:format(numstring(reward * 2^level)))
       end
 
       player.pay(reward * 2^level)

--- a/dat/missions/dvaered/dv_antiflf01.lua
+++ b/dat/missions/dvaered/dv_antiflf01.lua
@@ -33,6 +33,7 @@ misn_title = _("Take the Dvaered crew home")
 osd_desc = {_("Take the Dvaered crew on board your ship to any Dvaered controlled world or station")}
 
 misn_desc = _("Take the Dvaered crew on board your ship to any Dvaered controlled world or station.")
+misn_reward = _("A chance to aid in the effort against the FLF")
 
 function create()
     -- Note: this mission makes no system claims.
@@ -43,6 +44,7 @@ function create()
     misn.osdCreate(misn_title, osd_desc)
     misn.setDesc(misn_desc)
     misn.setTitle(misn_title)
+    misn.setReward(misn_reward)
     
     DVcrew = misn.cargoAdd("Dvaered ship crew", 0)
     
@@ -53,7 +55,7 @@ function land()
     if planet.cur():faction():name() == "Dvaered" then
         if var.peek("flfbase_flfshipkilled") then
             tk.msg(title[2], text[2] .. text[3] .. text[5])
-            player.pay(10000) -- 10K
+            player.pay(100000) -- 100K
         else
             tk.msg(title[2], text[2] .. text[4] .. text[5])
         end

--- a/dat/missions/dvaered/dv_antiflf02.lua
+++ b/dat/missions/dvaered/dv_antiflf02.lua
@@ -71,6 +71,7 @@ osd_desc[4] = _("Disable and board at least one FLF ship")
 osd_desc[5] = _("Return to any Dvaered world")
 
 misn_desc = _("You have been recruited to act as a red herring in a military operation of Dvaered design. Your chief purpose is to goad the FLF into showing themselves, then disabling and boarding one of their ships. You will fail this mission if you disable or destroy any Dvaered ship, or if you leave the system before the operation is complete.")
+misn_reward = _("Serving alongside real Dvaered warlords")
 
 comm_msg["enter"] = _("Here come the FLF! All units, switch to EMPs and disable the terrorist ships!")
 comm_msg["victory"] = _("All targets neutralized. Download the flight log and let's get out of here!")
@@ -98,6 +99,7 @@ function accept()
         misn.osdCreate(misn_title, osd_desc)
         misn.setDesc(misn_desc)
         misn.setTitle(misn_title)
+        misn.setReward(misn_reward)
         marker = misn.markerAdd( system.get(destsysname), "low" )
         
         missionstarted = false
@@ -138,7 +140,7 @@ function land()
         tk.msg(title[6], text[6])
         var.push("flfbase_intro", 3)
         faction.get("Dvaered"):modPlayerSingle(5)
-        player.pay(70000) -- 70K
+        player.pay(700000) -- 700K
         misn.finish(true)
     end
 end

--- a/dat/missions/dvaered/dv_antiflf03.lua
+++ b/dat/missions/dvaered/dv_antiflf03.lua
@@ -81,6 +81,7 @@ osd_desc[3] = _("Destroy the FLF base")
 osd_desc[4] = _("Return to %s in the %s system")
 
 misn_desc = _("The Dvaered are poised to launch an all-out attack on the secret FLF base. You have chosen to join this battle for wealth and glory.")
+misn_reward = _("Wealth and glory")
 
 function create()
     missys = {system.get(var.peek("flfbase_sysname"))}
@@ -113,7 +114,7 @@ function accept()
         osd_desc[4] = string.format(osd_desc[4], DVplanet, DVsys)
         misn.osdCreate(misn_title, osd_desc)
         misn.setDesc(misn_desc)
-        misn.setReward("Wealth, glory")
+        misn.setReward(misn_reward)
         misn.setTitle(misn_title)
         mission_marker = misn.markerAdd( system.get(destsysname), "high" )
         
@@ -189,7 +190,7 @@ function land()
         tk.msg(title[3], text[6])
         dv_modReputation( 5 )
         faction.get("Dvaered"):modPlayerSingle(10)
-        player.pay(100000) -- 100K
+        player.pay(1000000) -- 1M
         var.pop("flfbase_intro")
         var.pop("flfbase_sysname")
         diff.apply("FLF_base")

--- a/dat/missions/dvaered/dv_diversion.lua
+++ b/dat/missions/dvaered/dv_diversion.lua
@@ -34,7 +34,7 @@ text[3] = _([["That is where you come in. You will jump into %s and find the Haw
 text[4] = _([["We will jump in approximately 80 hectoseconds after you jump into %s, so the fighters must be far enough away by then not to come back and attack us."]])
 
 refusetitle = _("Nuts")
-refusetext = _([["I see. In that case, I'm going to have to ask you to leave. My job is to recruit a civilian, but you're clearly not the man I'm looking for. You may excuse yourself, citizen."]])
+refusetext = _([["I see. In that case, I'm going to have to ask you to leave. My job is to recruit a civilian, but you're clearly not the one I'm looking for. You may excuse yourself, citizen."]])
 
 failtitle[1] = _("You ran away!")
 failtext[1] = _("You have left the system without first completing your mission. The operation ended in failure.")
@@ -48,7 +48,7 @@ failtitle[4] = _("The Hawk is safe.")
 failtext[4] = _("The Hawk was able to fend off the attackers and destroy their flagship. You have failed your mission.")
 
 passtitle[1] = _("The Dvaered official sent you a message.")
-passtext[1] = _([["Thanks for the distraction. I've sent you a picture of all the medals I was awarded. Oh, and I also deposited 80000 credits in your account."]])
+passtext[1] = _([["Thanks for the distraction. I've sent you a picture of all the medals I was awarded. Oh, and I also deposited 800,000 credits in your account."]])
 
 npc_desc = _("A high ranking Dvaered officer. It looks like he might have a job offer for you.")
 
@@ -56,9 +56,10 @@ misn_title = _("A Small Distraction")
 osd_desc[1] = _("Fly to the %s system")
 osd_desc[2] = _("Fire on the Hawk and flee from the fighter escorts until the Dvaered fleet jumps in and destroys the Hawk")  
 misn_desc = _("You have been recruited to distract the Dvaered fighter escorts and lead them away from the jump gate and the capital ship Hawk. The Dvaered task force will jump in and attempt to destroy the Hawk before the escort ships can return. The mission will fail if the Hawk survives or the Dvaered task force is eliminated.")
+misn_reward = _("Some good money, hopefully")
 
 chatter[0] = _("All right men, this will be Hawk's maiden jump. Continue on course to the %s jump gate.")
-chatter[1] = _("How dare he attack me! Get him!")
+chatter[1] = _("How dare he attack me! Get them!")
 chatter[2] = _("You heard Warlord Khan, blow him to pieces!")
 chatter[3] = _("He's attacking us, blow him to pieces!")
 chatter[4] = _("Arrgh!")
@@ -359,7 +360,7 @@ function complete()
    cleanup()
    tk.msg(passtitle[1], passtext[1])
    camera.set(player.pilot())
-   player.pay(80000)
+   player.pay(800000)
    jump_fleet[6]:broadcast(string.format(chatter[13], destplanetname))
    jump_fleet[6]:setNoDeath(false)
    misn.finish(true)

--- a/dat/missions/empire/collective/ec00.lua
+++ b/dat/missions/empire/collective/ec00.lua
@@ -12,10 +12,11 @@
 ]]--
 
 include "proximity.lua"
+include "numstring.lua"
 
 bar_desc = _("You see an Empire Lt. Commander who seems to be motioning you over to the counter.")
 misn_title = _("Collective Scout")
-misn_reward = _("None")
+misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Find a scout last seen in the %s system.")
 misn_desc[2] = _("Travel back to %s in %s.")
@@ -68,10 +69,11 @@ function accept ()
 
    misn_stage = 0
    misn_marker = misn.markerAdd( misn_target, "low" )
+   credits = 500000
 
    -- Mission details
    misn.setTitle(misn_title)
-   misn.setReward( misn_reward )
+   misn.setReward( misn_reward:format( numstring( credits ) ) )
    misn.setDesc( string.format(misn_desc[1],misn_nearby:name()))
 
    -- Flavour text and mini-briefing
@@ -123,6 +125,7 @@ function land()
    if misn_stage == 1 and  pnt == misn_base then
       tk.msg( title[3], string.format(text[4],misn_target:name()) )
       faction.modPlayerSingle("Empire",5)
+      player.pay(credits)
       misn.finish(true)
    end
 end

--- a/dat/missions/empire/collective/ec01.lua
+++ b/dat/missions/empire/collective/ec01.lua
@@ -11,9 +11,11 @@
 
 ]]--
 
+include "numstring.lua"
+
 bar_desc = _("You notice Lt. Commander Dimitri motioning for you to come over to him.")
 misn_title = _("Collective Espionage")
-misn_reward = _("None")
+misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Scan the Collective systems for wireless communications.")
 misn_desc[2] = _("Travel back to %s in %s.")
@@ -51,6 +53,8 @@ function accept ()
    -- Accept mission
    misn.accept()
 
+   credits = 600000
+
    misn_stage = 0
    systems_visited = 0 -- Number of Collective systems visited
    misn_base,misn_base_sys = planet.get("Omega Station")
@@ -60,7 +64,7 @@ function accept ()
    -- Mission details
    misn_desc[2] = misn_desc[2]:format(misn_base:name(), misn_base_sys:name())
    misn.setTitle(misn_title)
-   misn.setReward( misn_reward )
+   misn.setReward( misn_reward:format( numstring( credits ) ) )
    misn.setDesc(misn_desc[1])
    misn_marker1 = misn.markerAdd(targsys1, "low")
    misn_marker2 = misn.markerAdd(targsys2, "low")
@@ -117,6 +121,7 @@ end
 function land()
    if planet.cur() == misn_base and sysdone1 and sysdone2 then
       tk.msg( title[3], text[3] )
+      player.pay(credits)
       faction.modPlayerSingle("Empire",5)
       misn.finish(true)
    end

--- a/dat/missions/empire/collective/ec02.lua
+++ b/dat/missions/empire/collective/ec02.lua
@@ -13,7 +13,7 @@
 
 bar_desc = _("You notice Lt. Commander Dimitri at one of the booths.")
 misn_title = _("Collective Espionage")
-misn_reward = _("None")
+misn_reward = _("700,000 credits")
 misn_desc = {}
 misn_desc[1] = _("Land on %s in the %s system to monitor Collective communications.")
 misn_desc[2] = _("Travel back to %s in %s.")
@@ -30,7 +30,7 @@ text[3] = _([["The plan is to have you infiltrate Collective space alone to not 
 text[4] = _([[You quickly land on %s and hide in its deep dense methane atmosphere. Your monitoring gear flickers into action, hopefully catching something of some use. With some luck there won't be too many Collective drones when you take off.]])
 text[5] = _([[That should be enough. Time to report your findings.]])
 text[6] = _([[As your ship touches ground, you see Lt. Commander Dimitri come out to greet you.
-    "How was the weather?" he asks jokingly. "Glad to see you're still in one piece. We'll get right on analysing the data acquired. Those robots have to be up to something. Meet me in the bar later. Meanwhile give yourself a treat; you've earned it. We've made a 100k credit deposit in your bank account. Enjoy it."]])
+    "How was the weather?" he asks jokingly. "Glad to see you're still in one piece. We'll get right on analysing the data acquired. Those robots have to be up to something. Meet me in the bar later. Meanwhile give yourself a treat; you've earned it. We've made a 700k credit deposit in your bank account. Enjoy it."]])
 
 osd_msg = {}
 osd_msg[1] = _("Fly to %s and land on %s")
@@ -90,7 +90,7 @@ function land()
 
       -- Rewards
       faction.modPlayerSingle("Empire",5)
-      player.pay( 100000 )
+      player.pay( 700000 )
 
       misn.finish(true)
    end

--- a/dat/missions/empire/collective/ec03.lua
+++ b/dat/missions/empire/collective/ec03.lua
@@ -12,9 +12,11 @@
 
 ]]--
 
+include "numstring.lua"
+
 bar_desc = _("You see Lt. Commander Dimitri at the bar as usual.")
 misn_title = _("Collective Distraction")
-misn_reward = _("None")
+misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Go to draw the Collective's attention in the %s system.")
 misn_desc[2] = _("Travel back to %s in %s.")
@@ -50,6 +52,7 @@ end
 function accept ()
 
    commando_planet = "Eiroik"
+   credits = 1000000
 
    -- Intro text
    if tk.yesno( title[1], string.format(text[1], commando_planet) )
@@ -65,7 +68,7 @@ function accept ()
 
       -- Mission details
       misn.setTitle(misn_title)
-      misn.setReward( misn_reward )
+      misn.setReward( misn_reward:format( numstring( credits ) ) )
       misn.setDesc( string.format(misn_desc[1], misn_target_sys:name() ))
 
       tk.msg( title[1], string.format(text[2], commando_planet, commando_planet ) )
@@ -113,6 +116,7 @@ function land()
       var.push( "emp_commando", time.tonumber(time.get() + time.create( 0, 10, 0 )) )
 
       -- Rewards
+      player.pay(credits)
       faction.modPlayerSingle("Empire",5)
 
       misn.finish(true)

--- a/dat/missions/empire/collective/ec04.lua
+++ b/dat/missions/empire/collective/ec04.lua
@@ -14,9 +14,10 @@
 
 include "dat/scripts/nextjump.lua"
 include "proximity.lua"
+include "numstring.lua"
 
 misn_title = _("Collective Extraction")
-misn_reward = _("None")
+misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Check for survivors on %s in %s.")
 misn_desc[2] = _("Travel back to %s in %s.")
@@ -59,13 +60,15 @@ function create ()
    if tk.yesno( title[1], string.format(text[1], misn_target:name()) ) then
       misn.accept()
 
+      credits = 1000000
+
       misn_stage = 0
       misn_base, misn_base_sys = planet.get("Omega Station")
       misn_marker = misn.markerAdd( misn_target_sys, "low" )
 
       -- Mission details
       misn.setTitle(misn_title)
-      misn.setReward( misn_reward )
+      misn.setReward( misn_reward:format( numstring( credits ) ) )
       misn.setDesc( string.format(misn_desc[1], misn_target:name(), misn_target_sys:name() ))
       tk.msg( title[1], string.format(text[2], misn_target_sys:name(), misn_target:name()) )
       osd_msg[1] = osd_msg[1]:format(misn_target_sys:name())
@@ -234,6 +237,7 @@ function land ()
       var.pop("emp_commando")
 
       -- Rewards
+      player.pay(credits)
       faction.modPlayerSingle("Empire",5)
 
       misn.finish(true)

--- a/dat/missions/empire/collective/ec05.lua
+++ b/dat/missions/empire/collective/ec05.lua
@@ -27,9 +27,11 @@
 
 ]]--
 
+include "numstring.lua"
+
 bar_desc = _("Dimitri should be around here, but you can't see him. You should probably look for him.")
 misn_title = _("Operation Black Trinity")
-misn_reward = _("None")
+misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Arrest the ESS Trinity in %s.")
 misn_desc[2] = _("Return to base at %s in %s.")
@@ -86,6 +88,7 @@ function create ()
  
    misn.setNPC( _("Dimitri?"), "unknown" )
    misn.setDesc( bar_desc )
+   credits = 2000000
 end
 
 
@@ -111,7 +114,7 @@ function accept ()
 
    -- Mission details
    misn.setTitle(misn_title)
-   misn.setReward( misn_reward )
+   misn.setReward( misn_reward:format( numstring( credits ) ) )
    misn.setDesc( string.format(misn_desc[1], misn_target_sys:name() ))
    osd_msg[1] = osd_msg[1]:format(misn_target_sys:name())
    osd_msg[3] = osd_msg[3]:format(misn_base:name())
@@ -351,6 +354,7 @@ function land ()
          -- Failure to kill
          tk.msg( title[5], text[7] )
          var.push("trinity", true)
+         credits = credits / 2
       else
          -- Successfully killed
          tk.msg( title[4], string.format(text[6], player.name()) )
@@ -358,6 +362,7 @@ function land ()
       end
 
       -- Rewards
+      player.pay(credits)
       faction.modPlayerSingle("Empire",5)
 
       misn.finish(true)

--- a/dat/missions/empire/collective/ec06.lua
+++ b/dat/missions/empire/collective/ec06.lua
@@ -238,7 +238,7 @@ function land ()
       -- This was the last mission in the minor campaign, so bump the reputation cap.
       emp_modReputation( 10 )
       faction.modPlayerSingle("Empire",5)
-      player.pay( 500000 ) -- 500k
+      player.pay( 5000000 ) -- 5m
 
       tk.msg( title[3], text[4] )
 

--- a/dat/missions/empire/emp_cargo00.lua
+++ b/dat/missions/empire/emp_cargo00.lua
@@ -64,7 +64,7 @@ function accept ()
    misn.accept()
 
    -- Mission details
-   reward = 3000
+   reward = 30000
    misn.setTitle(misn_title)
    misn.setReward( string.format(misn_reward, numstring(reward)) )
    misn.setDesc( string.format(misn_desc,dest:name(),sys:name()))

--- a/dat/missions/empire/emp_hcvl.lua
+++ b/dat/missions/empire/emp_hcvl.lua
@@ -54,7 +54,7 @@ function accept ()
    near_sys = get_pir_system( system.cur() )
 
    -- Get credits
-   credits  = rnd.rnd(5,10) * 10000
+   credits  = rnd.rnd(5,10) * 100000
 
    -- Mission details:
    if tk.yesno( title[1], string.format( text[1], player.name(),

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua
@@ -11,7 +11,7 @@ include "dat/scripts/jumpdist.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Aramda Shipping Division is sitting at the bar.")
 misn_title = _("Soromid Long Distance Recruitment")
-misn_reward = _("50000 credits")
+misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Soromid Customs Central in the Oberon system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -52,7 +52,7 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo2.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo2.lua
@@ -11,7 +11,7 @@ include "dat/scripts/jumpdist.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Dvaered Long Distance Recruitment")
-misn_reward = _("50000 credits")
+misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Praxis in the Ogat system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -52,7 +52,7 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo3.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo3.lua
@@ -11,7 +11,7 @@ include "dat/scripts/jumpdist.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Aramda Shipping Division is sitting at the bar.")
 misn_title = _("Za'lek Long Distance Recruitment")
-misn_reward = _("50000 credits")
+misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Gerhart Station in the Ganth system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -52,7 +52,7 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo4.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo4.lua
@@ -11,7 +11,7 @@ include "dat/scripts/jumpdist.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Aramda Shipping Division is sitting at the bar.")
 misn_title = _("Frontier Long Distance Recruitment")
-misn_reward = _("50000 credits")
+misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to The Frontier Council in Gilligan's Light system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -52,7 +52,7 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo5.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo5.lua
@@ -11,7 +11,7 @@ include "dat/scripts/jumpdist.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Aramda Shipping Division is sitting at the bar.")
 misn_title = _("Sirius Long Distance Recruitment")
-misn_reward = _("50000 credits")
+misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Madria in the Esker system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -52,7 +52,7 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo6.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo6.lua
@@ -11,7 +11,7 @@ include "dat/scripts/jumpdist.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Aramda Shipping Division is sitting at the bar.")
 misn_title = _("Empire Long Distance Recruitment")
-misn_reward = _("5000 credits")
+misn_reward = _("50,000 credits")
 misn_desc = _("Deliver Lieutenant Czesc to Halir in the Gamma Polaris system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -55,7 +55,7 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 5000
+   reward = 50000
    misn.setTitle(misn_title)
    misn.setReward(misn_reward)
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )

--- a/dat/missions/empire/shipping/es00.lua
+++ b/dat/missions/empire/shipping/es00.lua
@@ -64,7 +64,7 @@ function accept ()
 
    -- Mission details
    misn_stage = 0
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward( string.format(misn_reward, numstring(reward)) )
    misn.setDesc( string.format(misn_desc[1], dest:name(), destsys:name()))

--- a/dat/missions/empire/shipping/es01.lua
+++ b/dat/missions/empire/shipping/es01.lua
@@ -70,7 +70,7 @@ function accept ()
 
    -- Mission details
    misn_stage = 0
-   reward = 50000
+   reward = 500000
    misn.setTitle(misn_title)
    misn.setReward( string.format(misn_reward, numstring(reward)) )
    misn.setDesc( string.format(misn_desc[1], pickup:name(), pickupsys:name()))

--- a/dat/missions/empire/shipping/es02.lua
+++ b/dat/missions/empire/shipping/es02.lua
@@ -81,7 +81,7 @@ function accept ()
 
    -- Mission details
    misn_stage = 0
-   reward = 75000
+   reward = 750000
    misn.setTitle(misn_title)
    misn.setReward( string.format(misn_reward, numstring(reward)) )
    misn.setDesc( string.format(misn_desc[1], destsys:name() ))

--- a/dat/missions/flf/flf_pre01.lua
+++ b/dat/missions/flf/flf_pre01.lua
@@ -66,6 +66,7 @@ osd_desc[2] = _("Alternatively, turn Gregar in to the nearest Dvaered base")
 osd_adddesc = _("Follow the FLF ships to their secret base. Do not lose them!")
 
 misn_desc = _("You have taken onboard a member of the FLF. You must either take him where he wants to go, or turn him in to the Dvaered.")
+misn_reward = _("A chance to learn more about the FLF")
 
 function create()
     missys = {system.get(var.peek("flfbase_sysname"))}
@@ -86,6 +87,7 @@ function create()
     misn.osdCreate(misn_title, {osd_desc[1]:format(destsysname), osd_desc[2]})
     misn.setDesc(misn_desc)
     misn.setTitle(misn_title)
+    misn.setReward(misn_reward)
     misn.markerAdd(system.get(destsysname), "low")
     
     gregar = misn.cargoAdd("Gregar", 0)

--- a/dat/missions/neutral/animaltransport.lua
+++ b/dat/missions/neutral/animaltransport.lua
@@ -13,17 +13,17 @@ text = {}
 title = {}
 
 title[1] = _("Animal transport")
-text[1] = _([["Good day to you, captain," the man greets you. "I'm looking for someone with a ship who can take this crate here to planet %s in the %s system. The crate contains a colony of rodents I've bred myself, and my in-law has a pet shop on %s where I hope to sell them. Upon delivery, you will be paid 20,000 credits. Are you interested in the job?]])
+text[1] = _([["Good day to you, captain," the man greets you. "I'm looking for someone with a ship who can take this crate here to planet %s in the %s system. The crate contains a colony of rodents I've bred myself, and my in-law has a pet shop on %s where I hope to sell them. Upon delivery, you will be paid 200,000 credits. Are you interested in the job?]])
 
 text[2] = _([["Excellent! My in-law will send someone to meet you at the spaceport to take the crate off your hands, and you'll be paid immediately on delivery. Thanks again!"]])
 
-text[3] = _([[As promised, there's someone at the spaceport who accepts the crate. In return, you receive a number of credit chips worth 20,000 credits, as per the arrangement. You go back into your ship to put the chips away before heading off to check in with the local authorities. But did you just hear something squeak...?]])
+text[3] = _([[As promised, there's someone at the spaceport who accepts the crate. In return, you receive a number of credit chips worth 200,000 credits, as per the arrangement. You go back into your ship to put the chips away before heading off to check in with the local authorities. But did you just hear something squeak...?]])
 
 NPCname = _("A Fyrra civilian")
 NPCdesc = _("There's a civilian here, from the Fyrra echelon by the looks of him. He's got some kind of crate with him.")
 
 misndesc = _("You've been hired to transport a crate of specially engineered rodents to %s (%s system).")
-misnreward = _("You will be paid 20,000 credits on arrival.")
+misnreward = _("You will be paid 200,000 credits on arrival.")
 
 OSDtitle = _("Animal transport")
 OSD = {}
@@ -76,7 +76,7 @@ end
 function land()
     if planet.cur() == destplanet then
         tk.msg(title[1], text[3])
-        player.pay(20000) -- 20K
+        player.pay(200000) -- 200K
         var.push("shipinfested", true)
         misn.finish(true)
     end

--- a/dat/missions/neutral/aristodrink.lua
+++ b/dat/missions/neutral/aristodrink.lua
@@ -29,7 +29,7 @@ OSDtable = {}
 prevPlanets = {}
 prevPlanets.__save = true
 
-payment = 75000
+payment = 200000
 
 title = {}  --stage titles
 text = {}   --mission text

--- a/dat/missions/neutral/crimelord.lua
+++ b/dat/missions/neutral/crimelord.lua
@@ -43,7 +43,7 @@ function accept ()
    end
    
    misn.accept()
-   reward = 40000
+   reward = 600000
    tk.msg( title[1], text[1] ) --dialogue 2
    misn.setTitle( title[0] ) --OSD stuff
    misn.setReward( reward_desc )

--- a/dat/missions/neutral/diy-nerds.lua
+++ b/dat/missions/neutral/diy-nerds.lua
@@ -14,7 +14,7 @@ bar_desc = _("You see a bunch of guys and gals, excitedly whispering over some p
 
 -- Mission details.
 misn_title = _("DIY Nerds") 
-misn_reward = _("20000 credits")
+misn_reward = _("20,000 credits")
 misn_desc = _("Cart some nerds to their contest, and back.")
 
 title = {}
@@ -25,7 +25,7 @@ title[1] = _("A group of excited nerds")
 text[1] = [[As you approach the group, the babbling ceases and the papers are quickly and jealously stashed away. One of the girls comes forward and introduces herself.
     "Hi, I'm Mia. We need transportation, and you look as if you could need some dough. Interested?"
     You reply that for a deal to be worked out, they better provide some detail.
-    "Listen," she says, "there's this Homebrew Processing Box Masters on %s. Right over there, this system. I'm sure our box will get us the first prize. You take us there, you take us back, you get 20000."
+    "Listen," she says, "there's this Homebrew Processing Box Masters on %s. Right over there, this system. I'm sure our box will get us the first prize. You take us there, you take us back, you get 20,000."
     You just start wondering at the boldness of so young a lady as she already signals her impatience. "What now, you do it?"]]
 
 -- you accept
@@ -77,21 +77,21 @@ text[11] = [[Seeing that it is already too late to pick up the nerds, and that y
 
 -- you return the nerds, who have won the contest
 title[12] = _("The End")
-text[12] = [[The nerds, finally exhausted from all the partying, still smile as they pack up their prize-winning box and leave your ship. Mia beams as she turns to you. "Well done, %s. You see, since we got loads of prize money, we decided to give you a bonus. After all, we wouldn't have gotten there without your service. Here, you have 30000. Good day to you."]]
+text[12] = [[The nerds, finally exhausted from all the partying, still smile as they pack up their prize-winning box and leave your ship. Mia beams as she turns to you. "Well done, %s. You see, since we got loads of prize money, we decided to give you a bonus. After all, we wouldn't have gotten there without your service. Here, have 30,000. Good day to you."]]
 
 -- you return the nerds, who did not win the contest
 title[13] = _("Minor Complications")
 text[13] = [[With sagging shoulders, the nerds unload their box. Mia turns to address you, not bold at all this time. "Um, we got a bit of a problem here. You know, we intended to pay the trip from our prize money. Now we don't have no prize money."
     As you're trying to decide what to make of the situation, one of the other nerds creeps up behind Mia and cautiously gestures for her to join the group a few yards away, all the time avoiding your eyes. Strange guy, you think, as if he was not accustomed to be socializing with strangers. Mia joins the group, and some whispering ensues. Mia returns to you after a few minutes.
-    "Ok, we have just solved our problem. See, that ass of a champion won the contest with a ship's processing unit. We can do it the other way round. We'll modify our box so that it can be used as a ship's coprocessor, and you can have it as a compensation for your troubles. Interested?"]]
+    "Ok, we have just solved our problem. See, that ass of a champion won the contest with a ship's processing unit. We can do it the other way round. We'll modify our box so that it can be used as a ship's core system, and you can have it as a compensation for your troubles. Interested?"]]
 
 title[14] = _("So what?")
 text[14] = [["Honestly, there is nothing you can do about it," Mia says impatiently, as if you were a small child complaining about the finiteness of an ice cream cone. "Just stand by while we rig the thing up."]]
 
 title[15] = _("The End")
 text[15] = [["You can wait for it, won't take longer than half a period," Mia informs you. You stand by as the nerds start to mod their box. As they are going for it, you wonder if they're actually wrecking it and you'll maybe be left with a piece of worthless junk.
-    Finally, the modified box is set before you. "Here you are. Now you're the proud owner of the system's only home-made coprocessing unit. It's gotten a bit bulkier than we thought, with all this rigging for energy and coolant supply, but it should work just fine. We must go now and think about something more advanced for the next competition. Have a nice day."
-    With that, the nerds leave. Having gotten nothing else out of this, you think you should visit an outfitter to see if the box may actually be of any use.]]
+    Finally, the modified box is set before you. "Here you are. Now you're the proud owner of the system's only home-made core system. It's gotten a bit bulkier than we thought, with all this rigging for energy and coolant supply, but it should work just fine, about equivalent to the %s. We need to go now and think about something more advanced for the next competition. Have a nice day."
+    With that, the nerds leave. Having gotten nothing else out of this, you think you should visit an outfitter to see if the homemade core system may actually be of any use, or if you can at least sell it.]]
 
 -- for use in accept(), if any of the mission's preconditions are not met
 title[16] = _("Not enough cargo space")
@@ -354,7 +354,7 @@ function nerds_land3()
          if not tk.yesno(title[13], text[13]) then
             tk.msg(title[14], text[14])
          end
-         tk.msg(title[15], text[15])
+         tk.msg(title[15], text[15]:format( outfit ))
          time.inc(time.create(0,0,5000))
          player.addOutfit(outfit)
          if planet.services(cp)["outfits"] then

--- a/dat/missions/neutral/drunkard.lua
+++ b/dat/missions/neutral/drunkard.lua
@@ -23,7 +23,7 @@ OSDdesc = {}
 OSDdesc[1] = _("Go pickup some goods at %s in the %s system.")
 OSDdesc[2] = _("Drop off the goods at %s in the %s system.")
 
-payment = 250000
+payment = 500000
 
 -- Cargo Details
 cargo = "Goods"

--- a/dat/missions/neutral/nebu_satellite.lua
+++ b/dat/missions/neutral/nebu_satellite.lua
@@ -55,7 +55,7 @@ function create ()
       misn.finish(false)
    end
    satellite_sys = system.get("Arandon") -- Not too unstable
-   credits = 75000
+   credits = 750000
 
    -- Set stuff up for the spaceport bar
    misn.setNPC( _("Scientists"), "neutral/scientist" )

--- a/dat/missions/neutral/oldwoman.lua
+++ b/dat/missions/neutral/oldwoman.lua
@@ -103,7 +103,7 @@ end
 function land()
     if planet.cur() == destplanet then
         tk.msg(title2, text3)
-        player.pay(50000) -- 50K
+        player.pay(500000) -- 500K
         misn.finish(true)
     end
 end

--- a/dat/missions/neutral/race1.lua
+++ b/dat/missions/neutral/race1.lua
@@ -77,7 +77,7 @@ function create ()
    curplanet = planet.cur()
    misn.setNPC(NPCname, "neutral/male1")
    misn.setDesc(NPCdesc)
-   credits = rnd.rnd(10000, 50000)
+   credits = rnd.rnd(20000, 100000)
 end
 
 

--- a/dat/missions/neutral/race2.lua
+++ b/dat/missions/neutral/race2.lua
@@ -88,8 +88,8 @@ function create ()
    curplanet = planet.cur()
    misn.setNPC(NPCname, "neutral/male1")
    misn.setDesc(NPCdesc)
-   credits_easy = rnd.rnd(10000, 50000)
-   credits_hard = rnd.rnd(50000, 100000)
+   credits_easy = rnd.rnd(20000, 100000)
+   credits_hard = rnd.rnd(200000, 300000)
 end
 
 

--- a/dat/missions/neutral/spacefamily.lua
+++ b/dat/missions/neutral/spacefamily.lua
@@ -120,9 +120,9 @@ end
 
 function land()
    if planet.cur() == destplanet then -- We've arrived!
-      if nextstop == 3 then -- This is the last stop
+      if nextstop >= 3 then -- This is the last stop
          tk.msg(title[4], string.format(text[3], destsysname)) -- Final message
-         player.pay(20000)
+         player.pay(500000)
          misn.cargoJet(carg_id)
          misn.finish(true)
       else

--- a/dat/missions/neutral/teenager.lua
+++ b/dat/missions/neutral/teenager.lua
@@ -120,7 +120,7 @@ end
 function land()
     if planet.cur() == curplanet then
         tk.msg(title[5], text[5])
-        player.pay(30000) -- 30K
+        player.pay(300000) -- 300K
         misn.finish(true)
     end
 end

--- a/dat/missions/pirate/pir_ship_stealing.lua
+++ b/dat/missions/pirate/pir_ship_stealing.lua
@@ -15,6 +15,7 @@
 
 include "jumpdist.lua"
 include "numstring.lua"
+include "dat/missions/pirate/common.lua"
 
 local informer
 local refusal
@@ -242,13 +243,7 @@ function create ()
 
    ship.system = ship.planet:system()
 
-   -- FIXME: Portrait
-   local portraits = {}
-   portraits[1] = "pirate/pirate1"
-   portraits[2] = "pirate/pirate2"
-   portraits[3] = "pirate/pirate3"
-   portraits[4] = "pirate/pirate4"
-   local portrait = portraits[ rnd.rnd( 1, #portraits ) ]
+   local portrait = pir_getLordRandomPortrait()
    misn.setNPC( _("A Pirate informer"), portrait )
    misn.setDesc( informer.description )
 end

--- a/dat/missions/pirate/ruse.lua
+++ b/dat/missions/pirate/ruse.lua
@@ -3,7 +3,7 @@
    Pirate The Ruse
 
    A girl asks you to find his brother but it turns out it is her assassination target.
-   Creates a ship in one out of 3 listed systems. The system and planet the brother is is chosen randomly.
+   Creates a ship in one out of 3 listed systems. The system and planet the brother is in is chosen randomly.
    spawns some mercenaries that were supposed to protect the brother to intercept the player
 
    Author: fart but based on Mission Ideas in wiki: wiki.naev.org/wiki/Mission_Ideas
@@ -47,9 +47,9 @@ text[6] = _([["My sister? What the heck could she want from me? Prepare for dock
 text[7] = _([[The woman is standing next to you while the airlock opens. You see the man. The grin on his face changes to a baffled expression. You hear the sound of a blaster. A dark spot on chest of the man. The lady rushes past you and closes the airdock before you entirely realize what happens. While the airdock mechanism locks in you see the Poppy Seed depart.]])
 text[8] = _([[You find some of the stuff she left in your ship that you can turn to cash and a note saying:"Sorry"]])
 text[9] = _([[Your com starts beeping: "We received confirmation that you were invovled in the killing of our associate. Prepare to be boarded."]])
-text[10] = _([[What do you do: Chase the Poppy Seed or run away from the mercenaries closing in on you]])
+text[10] = _([[What do you do: Chase the Poppy Seed or run away from the mercenaries closing in on you?]])
 refusetitle = _("Sorry, I can't")
-refusetext = _([["How can you be such a heartless person?" asks you the woman half weepingly. " What has this universe become..."]])
+refusetext = _([["How can you be such a heartless person?" the woman asks half weepingly. "What has this universe become?..."]])
 
 -- Messages
 msg      = {}
@@ -183,7 +183,7 @@ function got_boarded(shipp)
       badguys[i]:setHostile(true)
    end
    tk.msg( title[4], text[10] )
-   player.pay(rnd.rnd(40,60)*1000)
+   player.pay(rnd.rnd(40,60)*10000)
    misn.finish(true)
 end
 -- idle

--- a/dat/missions/shadow/darkshadow.lua
+++ b/dat/missions/shadow/darkshadow.lua
@@ -151,7 +151,7 @@ function seiryuuBoard()
         stage = 2
     elseif stage == 6 then -- Debriefing
         tk.msg(title[7], text[11]:format(player.name(), player.name()))
-        player.pay(500000) -- 500K
+        player.pay(1000000) -- 1M
         seiryuu:control()
         seiryuu:hyperspace()
         var.pop("darkshadow_active")

--- a/dat/missions/shadow/shadowrun.lua
+++ b/dat/missions/shadow/shadowrun.lua
@@ -120,7 +120,7 @@ function create ()
     if not misn.claim( {sys, sys2} ) then
     end
 
-    credits = 100000 -- 100K
+    credits = 400000 -- 400K
     timelimit1 = 20 -- In STP
     timelimit2 = 50 -- In STP
     

--- a/dat/missions/shadow/shadowvigil.lua
+++ b/dat/missions/shadow/shadowvigil.lua
@@ -555,7 +555,7 @@ function board()
     seiryuu:setActiveBoard(false)
     seiryuu:setHilight(false)
     tk.msg(title[4], string.format(text[4], player.name(), player.name()))
-    player.pay(250000)
+    player.pay(700000)
     var.pop("shadowvigil_active")
     misn.finish(true)
 end

--- a/dat/missions/shark/sh01_corvette.lua
+++ b/dat/missions/shark/sh01_corvette.lua
@@ -77,7 +77,7 @@ end
 function accept()
 
    stage = 0
-   reward = 100000
+   reward = 750000
 
    if tk.yesno(title[1], text[1]:format(battlesys:name(), numstring(reward/2))) then
       misn.accept()

--- a/dat/missions/shark/sh02_tapping.lua
+++ b/dat/missions/shark/sh02_tapping.lua
@@ -79,7 +79,7 @@ end
 function accept()
 
    stage = 0
-   reward = 50000
+   reward = 750000
    proba = 0.3  --the chances you have to get an ambush
 
    if tk.yesno(title[1], text[1]:format(pplname, psyname)) then

--- a/dat/missions/shark/sh03_hailing.lua
+++ b/dat/missions/shark/sh03_hailing.lua
@@ -70,7 +70,7 @@ end
 function accept()
 
    stage = 0
-   reward = 50000
+   reward = 750000
 
    if tk.yesno(title[1], text[1]:format(missys:name(), nextpla:name(), nextsys:name())) then
       misn.accept()

--- a/dat/missions/shark/sh04_meeting.lua
+++ b/dat/missions/shark/sh04_meeting.lua
@@ -74,7 +74,7 @@ end
 function accept()
 
    stage = 0
-   reward = 50000
+   reward = 750000
    proba = 0.3  --the probability of ambushes will change
    firstambush = true  --In the first ambush, there will be a little surprise text
 

--- a/dat/missions/shark/sh05_flf.lua
+++ b/dat/missions/shark/sh05_flf.lua
@@ -67,7 +67,7 @@ end
 function accept()
 
    stage = 0
-   reward = 200000
+   reward = 1000000
 
    if tk.yesno(title[1], text[1]:format(player.name())) then
       misn.accept()

--- a/dat/missions/shark/sh06_arandon.lua
+++ b/dat/missions/shark/sh06_arandon.lua
@@ -68,7 +68,7 @@ end
 function accept()
 
    stage = 0
-   reward = 50000
+   reward = 750000
 
    if tk.yesno(title[1], text[1]) then
       misn.accept()

--- a/dat/missions/shark/sh07_pirates.lua
+++ b/dat/missions/shark/sh07_pirates.lua
@@ -95,7 +95,7 @@ end
 
 function accept()
 
-   reward = 4000000
+   reward = 6000000
    stage = 0
 
    --Initialization of dead pirate memory

--- a/dat/missions/sirius/achack/achack01.lua
+++ b/dat/missions/sirius/achack/achack01.lua
@@ -7,7 +7,7 @@ title1 = _("A Sirian with a grudge")
 text1 = _([[You find a young Fyrra man sitting uncomfortably amidst the uncouth characters that frequent the Wringer. He seems to be here with a purpose, but nobody seems to be giving him the time of day. Curious, you decide to talk to the man and find out why he is here.
     "Well met, stranger," the young Sirian greets you. "My name is Harja. I'm looking for someone who can help me with this... problem I have, it requires some violence. But nobody I've talked to so far seems interested! I thought this place was supposed to be filled with mercenaries and killers for hire. I can't believe how difficult this is!"
     Harja clearly seems frustrated. And it seems he's here to hire someone to do some dirty work for him. Maybe it was not such a good idea to talk to him after all?
-    "Listen," he continues. "I don't intend to bore you with my personal sob story, so let's just say there's someone I want dead, a dangerous criminal. This woman did something to me cycles ago that just can't go unpunished. I've got money, I'm willing to pay. All you need to do is locate her, and discreetly take her out. I don't care how you do it. I don't even care if you enjoy it. Just come back when she's dead, and I'll pay you 100,000 credits. Do we have a deal?"]])
+    "Listen," he continues. "I don't intend to bore you with my personal sob story, so let's just say there's someone I want dead, a dangerous criminal. This woman did something to me cycles ago that just can't go unpunished. I've got money, I'm willing to pay. All you need to do is locate her, and discreetly take her out. I don't care how you do it. I don't even care if you enjoy it. Just come back when she's dead, and I'll pay you 400,000 credits. Do we have a deal?"]])
 
 text2 = _([["Great! I was about to give up hope that I would find anyone with enough guts to do this for me. Okay, so, let me tell you about your target. She's a member of the Serra echelon, and she's got long, brown hair and blue eyes. She can usually be found in Sirius space, I believe she'll be on %s in the %s system right now. Come back to me when she's dead, and I'll give you your reward!"
     Harja leaves the spacedock bar, satisfied that he's finally found someone to take his request. You can't help but wonder why he would try to hire a mercenary in a place like the Wringer, though. If the target is such a dangerous criminal, then wouldn't he be better off posting a bounty mission on the public board? Oh well, it's none of your business. You accepted the job, now all that's left is to complete it.]])
@@ -17,7 +17,7 @@ text3 = _([[You approach the young officer, determined to find out what you've g
     "Good day, pilot," the officer greets you as you approach her table. She seems quite polite, and nothing indicates that she is anything less than completely respectable. "Is there something I can help you with?"
     You introduce yourself and explain that in your travels you've come across a man who tried to hire you to murder her. When you mention that his name is Harja, the officer's eyes go wide.
     "Are you sure? Unbelievable. Just unbelievable. I know the man you speak of, and I certainly don't count him as one of my friends. But I assure you, what he told you about me is a complete lie. Yes, there is bad blood between us, it's rather personal. But as you can see my record is clean, or I wouldn't have been accepted into the military.
-    "I appreciate that you used your better judgment instead of recklessly trying to attack me, which would have ended badly for at least one of us. You said Harja offered you 100,000 credits for my death, yes? I will arrange for half that again to be deposited into your account. Consider it a token of gratitude. Now, it seems I may have a situation to take care of..."
+    "I appreciate that you used your better judgment instead of recklessly trying to attack me, which would have ended badly for at least one of us. You said Harja offered you 400,000 credits for my death, yes? I will arrange for half that again to be deposited into your account. Consider it a token of gratitude. Now, it seems I may have a situation to take care of..."
     The officer excuses herself from the table and heads to the local military station. You are satisfied for now that you got paid without having to get your hands dirty. You just hope this won't come back to bite you in the butt one day.]])
 
 -- Mission info stuff
@@ -33,7 +33,7 @@ osd_msg[2] = _("Find your target on %s and kill her")
 osd_msg["__save"] = true
 
 misn_desc = _([[A Sirian man named Harja has hired you to dispatch a "dangerous criminal" who supposedly committed some kind of crime against him.]])
-misn_reward = _("Harja promised 100,000 credits.")
+misn_reward = _("Harja promised 400,000 credits.")
 
 function create()
     -- This mission ONLY spawns if the system it's in is not claimed by another mission. Special hack to mutex with Dark Shadow.
@@ -79,7 +79,7 @@ end
 
 function talkJoanne()
     tk.msg(title2, text3)
-    player.pay(150000) -- 150K
+    player.pay(500000) -- 500K
     misn.finish(true)
 end
 

--- a/dat/missions/sirius/achack/achack02.lua
+++ b/dat/missions/sirius/achack/achack02.lua
@@ -14,7 +14,7 @@ text1 = _([[When you approach her, the officer greets you with a smile. "What a 
     
 text1r = _([["Hello again, %s," Joanne greets you. "I'm afraid I still find myself under threat from mercenary assassins. Have you reconsidered my offer? Let me tell you again what I need."]])
    
-text2 = _([["See, this is the situation," she continues. "My duties as a Sirian administration officer require me to pay visits to several military outposts throughout Sirius space. It's a long trek every time, but that just comes with the job. Now, the trouble is that Harja's assassins might have many opportunities to ambush me along the way. I've had combat training, of course, just like every other Serra soldier, but I'm afraid I have little actual fighting experience, and I'm not sure I could survive an attack unassisted. You, however, seem to have seen quite some action. If you were to escort me while I make my rounds, I would feel a lot more secure. I can reward you, of course. Let's see... Another 150,000 credits seems a fair sum. What do you think, are you willing to do it?"]])
+text2 = _([["See, this is the situation," she continues. "My duties as a Sirian administration officer require me to pay visits to several military outposts throughout Sirius space. It's a long trek every time, but that just comes with the job. Now, the trouble is that Harja's assassins might have many opportunities to ambush me along the way. I've had combat training, of course, just like every other Serra soldier, but I'm afraid I have little actual fighting experience, and I'm not sure I could survive an attack unassisted. You, however, seem to have seen quite some action. If you were to escort me while I make my rounds, I would feel a lot more secure. I can reward you, of course. Let's see... Another 750,000 credits seems a fair sum. What do you think, are you willing to do it?"]])
     
 title2 = _("Joanne's escort")
 text3 = _([["That's wonderful! Thank you so much. As I said, my job requires that I travel between Sirian military bases. You're going to need fuel to make the necessary jumps, of course. Now that you have agreed to be my personal escort I can give you clearance to dock with those bases if you don't have it already so you can automatically refuel, but either way I won't be on station long, so you won't have time to disembark and do other things while you're there.
@@ -74,7 +74,7 @@ osd_final = {_("Land on Sroolu to get your reward")}
 osd_final["__save"] = true
 
 misn_desc = _("Joanne needs you to escort her ship and fight off mercenaries sent to kill her.")
-misn_reward = _("Joanne will pay you another 150,000 credits.")
+misn_reward = _("Joanne will pay you another 750,000 credits.")
 
 function create()
    if not misn.claim ( {system.get("Humdrum"), system.get("Lapis")} ) then
@@ -158,7 +158,7 @@ function land()
       tk.msg(title4, text5:format(player.name(), player.name()))
       tk.msg(title5, text6)
       tk.msg(title5, text7:format(player.name()))
-      player.pay(150000) -- 150K
+      player.pay(750000) -- 750K
       var.pop("achack02repeat")
       misn.finish(true)
    end

--- a/dat/missions/sirius/achack/achack03.lua
+++ b/dat/missions/sirius/achack/achack03.lua
@@ -16,7 +16,7 @@ text1r = _([["Hi %s," Joanne says. "Good to see you again. Say, I still haven't 
 
 text2 = _([["I want you to get out there and find Harja. I doubt he's on the Wringer anymore, that place isn't healthy to stick around for anyone, especially an academic type like Harja. He's probably on the move, doing whatever it is he does to be able to hire those assassins. So, I need you to intercept him and get him to tell you what he thinks he's doing. I don't know where he is now, you'll have to look for him yourself. I don't think he'll venture outside Sirius controlled space though. He won't be happy to see you, of course, so you may have to be a little... persuasive, shall we say? Just make sure to find out what his motives are and what it'll take for him to leave the past alone. But!" and here Joanne's face turns stern, "I don't want any serious harm to come to him. You may be thinking that removing Harja will solve the problem, but even if he's a threat to my life, murder is still murder. This is a private investigation, not a private war. Are we clear?"
     You acknowledge that you won't kill Harja if you can possibly help it. This seems to satisfy Joanne.
-    "Good. I know I can trust you, %s. I can offer you 150,000 credits if you complete this job. Go find Harja. Make him talk. Then come back and tell me what he said. Maybe, hopefully, it'll put my mind at rest."]])
+    "Good. I know I can trust you, %s. I can offer you 1,000,000 credits if you complete this job. Go find Harja. Make him talk. Then come back and tell me what he said. Maybe, hopefully, it'll put my mind at rest."]])
 
 title2 = _("The hunt begins")
 text3 = _([["Oh, I'm glad to hear that. Here, I'll upload the details of Harja's private ship into your computer. I did some digging in the military database to find them. You don't graduate from the Sinass High Academy with honors without picking up a few tricks! I know, I know, it's classified data, but it's for a good cause, wouldn't you say? You should be able to identify Harja when you pick him up on your sensors now. If you have trouble locating him, consider installing better sensors on your ship so you can pick him up from farther away. But don't spend too much effort looking for him, just keep a look out as you go about your normal business. If you just stay in Sirius space, I'm sure you'll run into him sooner or later."
@@ -66,7 +66,7 @@ osd_msg[3] = _("Return to Joanne on %s (%s)")
 osd_msg["__save"] = true
 
 misn_desc = _("Joanne wants you to find Harja and interrogate him about his motives.")
-misn_reward = _("Joanne will pay you another 150,000 credits.")
+misn_reward = _("Joanne will pay you another 1,000,000 credits.")
 
 function create()
    -- Note: this mission does not make any system claims.
@@ -205,7 +205,7 @@ function land()
    if planet.cur() == destplanet and harjatalked then
       player.landWindow("bar")
       tk.msg(title5, text7:format(player.name()))
-      player.pay(150000) -- 150K
+      player.pay(1000000) -- 1M
       var.pop("achack03repeat")
       misn.finish(true)
    end

--- a/dat/missions/sirius/achack/achack04.lua
+++ b/dat/missions/sirius/achack/achack04.lua
@@ -44,7 +44,7 @@ text7 = _([[Harja raises an eyebrow when he's confronted with you again. "Well w
    
 title7 = _("Building a bridge")
 text8 = _([[You and Harja finish the post-landing protocol and meet up at the terminal. Harja seems a little apprehensive - he clearly doesn't like the idea of meeting Joanne face to face much. But he doesn't complain. In this he really does appear to be a man of his word. Together, you make your way to a small conference room Joanne booked for the occasion.
-    Joanne greets you, and Harja somewhat more stiffly. You notice she looks a bit tired. "My apologies," she says when she notices your glance. "I just came off my shift, and my work can be a bit taxing at times. But never mind that, we're not here to talk about my job today." She turns to Harja. "There's something I want to ask you, Harja. Last time we both had dealings with %s here, he told me you swore your innocence, by Sirichana's name." Harja doesn't respond. He doesn't even meet Joanne's gaze. She continues regardless. "If this is true, then I want you to repeat that oath, here and now, at me directly."
+    Joanne greets you, and Harja somewhat more stiffly. You notice she looks a bit tired. "My apologies," she says when she notices your glance. "I just came off my shift, and my work can be a bit taxing at times. But never mind that, we're not here to talk about my job today." She turns to Harja. "There's something I want to ask you, Harja. Last time we both had dealings with %s here, I was told that you swore your innocence, by Sirichana's name." Harja doesn't respond. He doesn't even meet Joanne's gaze. She continues regardless. "If this is true, then I want you to repeat that oath, here and now, at me directly."
     There is silence for a few moments, but then Harja makes up his mind. He looks at Joanne and speaks. "Very well. I did not do the things I have been accused of. I did not tamper in any way with the central computer of the High Academy. By the grace of the Touched and the Word of Sirichana, I so swear."]])
    
 text9 = _([[There is silence again. Harja's oath sounded practiced and formal, but despite that you feel he was being very sincere when he spoke it.
@@ -118,7 +118,7 @@ function land()
    elseif planet.cur() == startplanet and stage == stages.finish then
       tk.msg(title7, text8:format(player.name()))
       tk.msg(title7, text9:format(player.name()))
-      player.pay(100000) -- 100K
+      player.pay(1500000) -- 1.5M
       var.pop("achack04repeat")
       misn.finish(true)
    end

--- a/dat/missions/sirius/heretic/heretic0.lua
+++ b/dat/missions/sirius/heretic/heretic0.lua
@@ -37,11 +37,12 @@ npc_name = _("Ragnarok")
 bar_desc = _("You see a rougher looking gent sitting at the bar, guzzling a brownish ale.")
 misn_desc = _("Deliver the shipment to %s in %s for the Nasin.")
 misn_title = _("The Gauntlet")
+misn_reward = _("%s credits")
 
 function create()
    --this mission makes no mission claims
    --set the variables
-   reward = 20000 --reward algorithm after this mission = 10000 + (rnd.rnd(5,8)*200 * (nasin_rep^1.51). flat rate for first mission.
+   reward = 200000 --reward algorithm after this mission = 100000 + (rnd.rnd(5,8)*2000 * (nasin_rep^1.51). flat rate for first mission.
    startworld = planet.cur()
    targetasset = planet.get("Margot")
    targetsystem = system.get("Brendon")
@@ -49,7 +50,7 @@ function create()
       misn.finish(false)
    end
    --set the mission stuff
-   misn.setReward(reward)
+   misn.setReward(misn_reward:format(numstring(reward)))
    misn.setTitle(misn_title)
    misn.setNPC(npc_name,"neutral/thief1") --using a generic picture for now.
    misn.setDesc(bar_desc)

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -36,6 +36,7 @@ misn_title = _("The Return")
 npc_name = _("Shaman")
 bar_desc = _("A tall man sitting at a table littered with papers.")
 misn_desc = _("Deliver the message to %s in %s for Shaman.")
+misn_reward = _("%s credits")
 osd = {}
 osd[1] = _("Fly to %s in the %s system and deliver the message.")
 
@@ -44,11 +45,11 @@ function create()
    --create some mission variables
    nasin_rep = faction.playerStanding("Nasin")
    misn_tracker = var.peek("heretic_misn_tracker") --we use this at the end.
-   reward = math.floor((10000+(math.random(5,8)*200)*(nasin_rep^1.315))*.01+.5)/.01 --using the actual reward algorithm now.
+   reward = math.floor((100000+(math.random(5,8)*2000)*(nasin_rep^1.315))*.01+.5)/.01 --using the actual reward algorithm now.
    targetasset, targetsystem = planet.get("The Wringer")
    --set the mission stuff
    misn.setTitle(misn_title)
-   misn.setReward(reward)
+   misn.setReward(misn_reward:format(numstring(reward)))
    misn.setNPC(npc_name,"neutral/male1")
    misn.setDesc(bar_desc)
 

--- a/dat/missions/sirius/heretic/heretic2.lua
+++ b/dat/missions/sirius/heretic/heretic2.lua
@@ -42,6 +42,7 @@ doom_clock_msg = _([[A scratchy voice jumps in on your comms priority channel.
 out_sys_failure_msg = _([[Your comm station flares up with a scratchy, obviously-from-far-away noise. A voice is heard through it.
    "%s! We told you we needed you to stay in system! Apparently you have more important things to do. So get lost, kid! We'll take care of ourselves." The static cuts out, and you consider yourself fired.]])
 misn_desc = _("Destroy the Sirius recon element that flew into %s. WARNING: DO NOT JUMP OUT-SYSTEM OR LAND ON THE PLANET PREMATURELY.")
+misn_reward = _("%s credits")
 
 function create()
    --this mission does make one system claim, in suna.
@@ -53,7 +54,7 @@ function create()
    nasin_rep = faction.playerStanding("Nasin")
    misn_tracker = var.peek("heretic_misn_tracker")
    playername = player.name()
-   reward = math.floor((10000+(math.random(5,8)*200)*(nasin_rep^1.315))*.01+.5)/.01
+   reward = math.floor((100000+(math.random(5,8)*2000)*(nasin_rep^1.315))*.01+.5)/.01
    chronic = 0
    finished = 0
    takeoff_counter = 0
@@ -61,7 +62,7 @@ function create()
    deathcount = 0
    --set the mission stuff
    misn.setTitle(misn_title)
-   misn.setReward(numstring(reward) .. "credits")
+   misn.setReward(misn_reward:format(numstring(reward)))
    misn.setNPC(npc_name,"neutral/thief2")
    misn.setDesc(bar_desc)
 

--- a/dat/missions/sirius/heretic/heretic3.lua
+++ b/dat/missions/sirius/heretic/heretic3.lua
@@ -57,13 +57,14 @@ oos_failure = _([[A scratchy voice from what sounds like very far away cut in on
    The voice cuts out, and you feel like you've made a horrible mistake.]])
 misn_desc = _([[A Sirius assault fleet has just jumped into %s. Destroy this fleet. WARNING: DO NOT JUMP OUT-SYSTEM OR LAND ON ANY ASSETS.]])
 time_to_come_home = _([[Your comm squeaks as the voice of Draga comes onto the channel. "%s! This is a lot larger of an assault than we thought. There is no way that we can handle this. We need you to get back to the station now! We are evacuating!" The comm goes silent, and you start heading back.]])
+misn_reward = _("%s credits")
 
 function create()
    --this mission makes one mission claim, in suna.
    --initialize your variables
    nasin_rep = faction.playerStanding("Nasin")
    misn_tracker = var.peek("heretic_misn_tracker")
-   reward = math.floor((10000+(math.random(5,8)*200)*(nasin_rep^1.315))*.01+.5)/.01
+   reward = math.floor((100000+(math.random(5,8)*2000)*(nasin_rep^1.315))*.01+.5)/.01
    planding = 0
    homeasset, homesys = planet.cur()
    msg_checker = 0
@@ -71,7 +72,7 @@ function create()
    if not misn.claim(homesys) then
       misn.finish(false)
    end
-   misn.setReward( reward )
+   misn.setReward( misn_reward:format( numstring( reward ) ) )
    misn.setTitle( misn_title )
    misn.setNPC(npc_name,"neutral/thief2")
    misn.setDesc(bar_desc)

--- a/dat/missions/sirius/heretic/heretic4.lua
+++ b/dat/missions/sirius/heretic/heretic4.lua
@@ -32,13 +32,14 @@ misn_title = _("The Egress")
 npc_name = _("Draga")
 bar_desc = _("Draga is running around, helping the few Nasin in the bar to get stuff together and get out.")
 misn_desc = _("Assist the Nasin refugees by flying to %s in %s, and unloading them there.")
+misn_reward = _("%s credits")
 
 function create()
    --this mission make no system claims.
    --initalize your variables
    nasin_rep = faction.playerStanding("Nasin")
    misn_tracker = var.peek("heretic_misn_tracker")
-   reward = math.floor((10000+(math.random(5,8)*200)*(nasin_rep^1.315))*.01+.5)/.01
+   reward = math.floor((100000+(math.random(5,8)*2000)*(nasin_rep^1.315))*.01+.5)/.01
    homeasset = planet.cur()
    targetasset, targetsys = planet.get("Ulios") --this will be the new HQ for the nasin in the next part.
    free_cargo = player.pilot():cargoFree()
@@ -46,8 +47,8 @@ function create()
    --set some mission stuff
    misn.setNPC(npc_name,"neutral/thief2")
    misn.setDesc(bar_desc)
-   misn.setTitle = misn_title
-   misn.setReward = reward
+   misn.setTitle(misn_title)
+   misn.setReward(misn_reward:format(numstring(reward)))
 
    osd[1] = osd[1]:format(targetasset:name(),targetsys:name())
 end

--- a/dat/missions/trader/anxiousmerchant.lua
+++ b/dat/missions/trader/anxiousmerchant.lua
@@ -110,7 +110,7 @@ function create()
         time_limit:add(time.create( 0, 0, math.floor((num_jumps-1) / jumpsperstop) * stu_jumps ))
     end
 
-   payment = stu_distance + (stu_jumps / 10)
+   payment = 5 * (stu_distance + (stu_jumps / 10))
 
    -- Range of 5-10 tons for tier 0, 21-58 for tier 4.
    cargo_size = rnd.rnd( 5 + 4 * tier, 10 + 12 * tier )
@@ -137,7 +137,7 @@ function accept()
 
    -- mission details
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward:format(payment))
+   misn.setReward(misn_reward:format(numstring(payment)))
    misn.setDesc(misn_desc:format(dest_planet:name()))
    marker = misn.markerAdd(dest_sys, "low") -- destination
    cargo_ID = misn.cargoAdd(cargo, cargo_size) -- adds cargo

--- a/dat/missions/zalek/sciencegonewrong/00_sciwrong.lua
+++ b/dat/missions/zalek/sciencegonewrong/00_sciwrong.lua
@@ -23,16 +23,16 @@ t_pla[2] = "Waterhole's Moon"
 -- t_x[3] is empty bc it depends on where the mission will start finally. (To be set in mission.xml and then adjusted in the following campaign missions)
 t_sys[3] = "Seiben"
 t_pla[3] = "Gastan"
--- player makes maximum 49k+, minimum 30k
+-- player makes maximum 490k+, minimum 300k
 pho_mny = 50000
-reward = pho_mny+30000+rnd.rnd(3,4)*10000+rnd.rnd(10)*1000 
+reward = pho_mny+300000+rnd.rnd(3,4)*100000+rnd.rnd(10)*1000 
 title = {}
 text = {}
 osd_msg = {}
 -- set text variables
 -- Mission details
 misn_title = _("The one with the Shopping")
-misn_reward = _("A the gratitude of science and a bit of compensation")
+misn_reward = _("The gratitude of science and a bit of compensation")
 misn_desc = _("You've been hired by Dr. Geller to collect some materials he urgently needs to build his prototype.")
 bar_desc = _("You see this scientist talking to various pilots. He looks at you with a measuring look.")
 trd1_desc = _("This seems to be a regular trader with some bodyguards. Business is dangerous nowadays...")
@@ -90,6 +90,7 @@ function accept()
    misn.osdCreate(misn_title, {osd_msg[1]:format(t_sys[1], t_pla[1])})
    misn.setDesc(misn_desc)
    misn.setTitle(misn_title)
+   misn.setReward(misn_reward)
    misn_mark = misn.markerAdd( system.get(t_sys[1]), "high" )
    talked = false
    lhook1 =  hook.land("land1", "land")

--- a/dat/missions/zalek/sciencegonewrong/01_sciwrong.lua
+++ b/dat/missions/zalek/sciencegonewrong/01_sciwrong.lua
@@ -16,15 +16,15 @@ t_pla = {}
 t_pla[1] = "Gastan"
 t_sys[1] = "Seiben"
 t_sys[2] = "Shikima"
--- player makes maximum 50k, minimum 30k
-reward = rnd.rnd(3,4)*10000+rnd.rnd(10)*1000 
+-- player makes maximum 500k, minimum 300k
+reward = rnd.rnd(3,4)*100000+rnd.rnd(10)*10000 
 shpnm = _("Tokera")
 -- Mission details
 title = {}
 text = {}
 osd_msg = {}
 misn_title = _("The one with the Visit")
-misn_reward = _("A the gratitude of science and a bit of compensation")
+misn_reward = _("The gratitude of science and a bit of compensation")
 misn_desc = _("You've been hired by Dr. Geller to retrieve technology he urgently needs to build his prototype.")
 bar_desc = _("You see Dr Geller and he is waving you over. Apparently he has another job for you.")
 
@@ -74,6 +74,7 @@ function accept()
    misn.osdCreate(misn_title, {osd_msg[1]:format(t_sys[2],shpnm),osd_msg[2]:format(shpnm),osd_msg[3]:format(t_pla[1],t_sys[1])})
    misn.setDesc(misn_desc)
    misn.setTitle(misn_title)
+   misn.setReward(misn_reward)
    misn.osdActive(1)
    misn_mark = misn.markerAdd( system.get(t_sys[2]), "high" )
    targetalive = true

--- a/dat/missions/zalek/sciencegonewrong/02_sciwrong.lua
+++ b/dat/missions/zalek/sciencegonewrong/02_sciwrong.lua
@@ -20,7 +20,7 @@ osd_msg = {}
 t_sys = {}
 t_pla = {}
 -- Mission details
-reward = 100000
+reward = 1000000
 -- amount of jumps the drone did to escape. Each jump reduces it's speed
 fled = false
 jumps = 0 
@@ -85,6 +85,7 @@ function accept()
    misn.osdCreate(misn_title, {osd_msg[1]:format(t_sys[1]),osd_msg[2],osd_msg[3]:format(t_pla[2],t_sys[2])})
    misn.setDesc(misn_desc)
    misn.setTitle(misn_title)
+   misn.setReward(misn_reward)
    misn.osdActive(1)
    mmarker = misn.markerAdd(system.get(t_sys[1]), "high")
    hook.jumpin("sys_enter")


### PR DESCRIPTION
Whew, that's a lot!

So the gist of this is that most unique missions have had their
rewards substantially increased. The general rule of thumb I followed
was to make the rewards 10 times what they previously were, but of
course there were exceptions to this. Most notably, most of the
Collective campaign previously had no rewards at all, so very large
rewards (progressing slowly from 500k to 5m) have been added to it.
Some, on the other hand, were only increased slightly.

The main goal of this is to balance out the mission rewards, which
has been a serious problem with Naev. It used to be that standard
missions gave you more money than unique missions, and this change
should hopefully reverse that and encourage players to try more
missions.

While I was doing that, I also fixed the presention of rewards and
numbers for several missions, and corrected some small dialog problems
I found (mostly typos).