### PR TITLE
Switched some dialog in dv_diversion to gender-neutral.

### DIFF
--- a/dat/missions/dvaered/dv_diversion.lua
+++ b/dat/missions/dvaered/dv_diversion.lua
@@ -59,9 +59,9 @@ misn_desc = _("You have been recruited to distract the Dvaered fighter escorts a
 misn_reward = _("Some good money, hopefully")
 
 chatter[0] = _("All right men, this will be Hawk's maiden jump. Continue on course to the %s jump gate.")
-chatter[1] = _("How dare he attack me! Get them!")
-chatter[2] = _("You heard Warlord Khan, blow him to pieces!")
-chatter[3] = _("He's attacking us, blow him to pieces!")
+chatter[1] = _("How dare they attack me! Get them!")
+chatter[2] = _("You heard Warlord Khan, blow them to pieces!")
+chatter[3] = _("They're attacking us, blow them to pieces!")
 chatter[4] = _("Arrgh!")
 chatter[5] = _("Khan is dead! Who will be our warlord now?")
 chatter[6] = _("Obviously the one who killed him, idiot!")


### PR DESCRIPTION
I noticed this just  after I submitted #841. Dialog in this mission has a lot of references to "he" and "him" directed at the player, and... well, the player isn't necessarily a "he" or a "him". :) Switched to singular "they" in those messages to correct this.