### PR TITLE
Revert "Add a 'local' keyword"

### DIFF
--- a/dat/scripts/formation.lua
+++ b/dat/scripts/formation.lua
@@ -10,7 +10,7 @@ local function count_classes(pilots)
    return class_count
 end
 
-local formations = {}
+formations = {}
 
 function formations.cross(leader)
    local pilots = leader:followers()


### PR DESCRIPTION
This reverts commit 99e96d38aae677ec64116ed4b8ce45ba8a013801.

I left a comment on the commit itself about why; the change breaks spawning of any ships with formations (e.g. Empire ships). So far as I can see there's no good reason for the change.