### PR TITLE
Fix checking for bar when choosing a planet

### DIFF
--- a/dat/missions/shark/sh02_tapping.lua
+++ b/dat/missions/shark/sh02_tapping.lua
@@ -55,13 +55,9 @@ osd_msg[1] = _("Land on %s in %s and meet the Nexus agent")
 osd_msg[2] = _("Bring the recording back to %s in the %s system")
 
 function create ()
-
-   --Change here to change the planets and the systems
-   mispla,missys = planet.getLandable(faction.get("Sirius"))
-
-   while mispla:services()["bar"] == false do  --It must be a bar on this Planet
-      mispla,missys = planet.getLandable(faction.get("Sirius"))
-   end
+   repeat
+      mispla, missys = planet.getLandable(faction.get("Sirius"))
+   until mispla:services()["bar"]
 
    pplname = "Darkshed"
    psyname = "Alteris"


### PR DESCRIPTION
This fixes the shark/sh02 mission.

Here, comparing `services()["bar"]` with `false` is an error: if there's no bar on the planet it will be `nil`, not `false`, leading to a mission that cannot be finished.

I've grepped the code for this kind of errors and haven't found any.

The patch still requires testing as I couldn't trigger the game to create that mission again