### PR TITLE
Added descriptions for plasma turrets, changed Orion Beam image

### DIFF
--- a/dat/outfits/weapons/orion_beam.xml
+++ b/dat/outfits/weapons/orion_beam.xml
@@ -7,7 +7,7 @@
   <mass>30</mass>
   <price>30000</price>
   <description>The turret-mounted edition of the Orion design offers mid-sized ships exceptional short-duration firepower, a potent deterrent against lighter vessels.</description>
-  <gfx_store>orion</gfx_store>
+  <gfx_store>ragnarok</gfx_store>
   <cpu>-16</cpu>
  </general>
  <specific type="turret beam">

--- a/dat/outfits/weapons/plasma_turret_mk1.xml
+++ b/dat/outfits/weapons/plasma_turret_mk1.xml
@@ -6,7 +6,7 @@
   <license>Medium Weapon License</license>
   <mass>18</mass>
   <price>21000</price>
-  <description>The mark 2 plasma blaster improves on its predecessor in many ways, maintaining good energy efficiency while augmenting range and firepower. Though intended primarily for military use, many have found their way to pirate hands.</description>
+  <description>The plasma turret essentially takes a plasma blaster and mounts it on a turret. Its short range makes it ill-suited for defense, so it is not especially popular with traders and merchants, but it has found a niche among inexperienced mercenaries who are not as well-practiced at aiming as the pros.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-10</cpu>
  </general>

--- a/dat/outfits/weapons/plasma_turret_mk2.xml
+++ b/dat/outfits/weapons/plasma_turret_mk2.xml
@@ -6,7 +6,7 @@
   <license>Medium Weapon License</license>
   <mass>24</mass>
   <price>31000</price>
-  <description>The mark 2 plasma blaster improves on its predecessor in many ways, maintaining good energy efficiency while augmenting range and firepower. Though intended primarily for military use, many have found their way to pirate hands.</description>
+  <description>The mark 2 plasma turret isn't especially impressive compared to other medium-size turrets, but it is sometimes favored by corvettes for its unusually low weight compared to its range and damage output.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-16</cpu>
  </general>


### PR DESCRIPTION
The plasma turrets have just had the Plasma Blaster MK2 description
copied and pasted for them, so I've given them some proper descriptions.
I also changed the Orion Beam gfx to "ragnarok" instead of "orion" to
match other (turreted) beams. (Of course dedicated gfx should be
used for each of these in the future but this at leastt makes things
consistent for now.)