### PR TITLE
Require a mercenary license for the trader escort mission.

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -136,6 +136,7 @@
   <lua>neutral/trader_escort</lua>
   <avail>
    <priority>5</priority>
+   <cond>player.numOutfit("Mercenary License") &gt; 0</cond>
    <chance>560</chance>
    <location>Computer</location>
    <faction>Dvaered</faction>


### PR DESCRIPTION
Makes sense to me; escorts are usually fighters, so that should fall
under the mercenary category and require a mercenary license.