### PR TITLE
Removed a now-unnecessary debug print.

### DIFF
--- a/dat/missions/soromid/srm_comingout.lua
+++ b/dat/missions/soromid/srm_comingout.lua
@@ -85,7 +85,6 @@ function create ()
    misplanet, missys = planet.get( "Durea" )
    -- Note: This mission does not make system claims
    if missys:jumpDist( system.cur(), true ) < #chatter * 3 / 2 then
-      print("Invalid planet for Coming Out mission (need distance ", #chatter * 3 / 2, ", have distance ", missys:jumpDist( system.cur(), true ))
       misn.finish( false )
    end
 


### PR DESCRIPTION
I seem to have forgotten to remove this when I finished the Coming Out
mission. It's no longer needed; this just removes the message
being printed to the terminal.