### PR TITLE
Fix mission "The Runaway"

### DIFF
--- a/dat/missions/neutral/runaway/runaway_search.lua
+++ b/dat/missions/neutral/runaway/runaway_search.lua
@@ -38,6 +38,7 @@ osd3 = _("Catch Cynthia on Torloth in Cygnus")
 osd4 = _("Return Cynthia to her father on Zhiru in the Goddard system.")
 osdlie = _("Go to Zhiru in Goddard to lie to Cynthia's father")
 
+
 function create ()
    targetworld_sys = system.get("Dohriabi")
    targetworld = planet.get("Niflheim")
@@ -127,7 +128,7 @@ function land ()
       misn.markerRm(runawayMarker)
 
       --Talk to the father and get the reward
-      if osd_text[4] == osd4 then
+      if misn.osdGetActiveItem() == osd4 then
          tk.msg(title, misn_father)
          player.pay(reward)
          misn.cargoRm(cargoID)

--- a/src/nlua_misn.c
+++ b/src/nlua_misn.c
@@ -85,6 +85,7 @@ static int misn_cargoJet( lua_State *L );
 static int misn_osdCreate( lua_State *L );
 static int misn_osdDestroy( lua_State *L );
 static int misn_osdActive( lua_State *L );
+static int misn_osdGetActiveItem( lua_State *L );
 static int misn_npcAdd( lua_State *L );
 static int misn_npcRm( lua_State *L );
 static int misn_claim( lua_State *L );
@@ -105,6 +106,7 @@ static const luaL_Reg misn_methods[] = {
    { "osdCreate", misn_osdCreate },
    { "osdDestroy", misn_osdDestroy },
    { "osdActive", misn_osdActive },
+   { "osdGetActiveItem", misn_osdGetActiveItem },
    { "npcAdd", misn_npcAdd },
    { "npcRm", misn_npcRm },
    { "claim", misn_claim },
@@ -856,6 +858,24 @@ static int misn_osdActive( lua_State *L )
       osd_active( cur_mission->osd, n );
 
    return 0;
+}
+
+static int misn_osdGetActiveItem( lua_State *L )
+{
+   Mission *cur_mission;
+   cur_mission = misn_getFromLua(L);
+
+   int nitems;
+   char **items = osd_getItems(cur_mission->osd, &nitems);
+   int active   = osd_getActive(cur_mission->osd);
+
+   if (!items || active < 0) {
+      lua_pushnil(L);
+      return 1;
+   }
+
+   lua_pushstring(L, items[active]);
+   return 1;
 }
 
 


### PR DESCRIPTION
During the mission player gets to decide how to finish the mission:
they can release or capture Cynthia.
Player's choice is not saved and doesn't affect the outcome of the
mission if the game is reloaded before the mission is finished.

The fix is to check the text of the OSD item in the final part of the
mission:

* Implement misn.osdGetActiveItem
* Check active OSD item to determine mission state