### PR TITLE
Fixed up the Brushed GUI to show weapsets properly.

### DIFF
--- a/dat/gui/brushed.lua
+++ b/dat/gui/brushed.lua
@@ -523,8 +523,14 @@ function renderWeapBar( weapon, x, y )
       if weapon.is_outfit then
          gfx.renderTex( icon_outfit, x + offsets[1], y + offsets[5] )
          gfx.renderTexRaw( icon, x + offsets[1] + bar_w/2 - 20, y + offsets[2] + outfit_yoffset, 40, 40, 1, 1, 0, 0, 1, 1 )
-         if weapon.weapset then
-            gfx.print( false, weapon.weapset, x + offsets[1], y + offsets[2] + name_offset, col_text, 40, true )
+         if weapon.weapset ~= nil then
+            local ws_name
+            if weapon.weapset == 10 then
+               ws_name = "0"
+            else
+               ws_name = string.format( "%d", weapon.weapset )
+            end
+            gfx.print( false, ws_name, x + offsets[1], y + offsets[2] + name_offset, col_text, 40, true )
          end
       else
          local col = nil
@@ -636,12 +642,18 @@ function render( dt )
    energy = pp:energy()
    fuel = player.fuel() / stats.fuel_max * 100
    heat = math.max( math.min( (pp:temp() - 250)/87.5, 2 ), 0 )
-   wset_name, wset = pp:weapset( true )
+   wset_name, pwset = pp:weapset( true )
+   wset_id = string.format( "%d", pp:activeWeapset() )
+   if wset_id == 10 then wset_id = 0 end
+   wset = {}
    aset = pp:actives( true )
    table.sort( aset, function(v) return v.weapset end )
 
-   for k, v in ipairs( wset ) do
+   for k, v in ipairs( pwset ) do
       v.is_outfit = false
+      if v.level ~= 0 then
+         wset[ #wset + 1 ] = v
+      end
    end
    for k, v in ipairs( aset ) do
       v.is_outfit = true
@@ -712,7 +724,8 @@ function render( dt )
       gfx.renderTex( icon_lockon, 378 + mod_x, 50 )
    end
    if autonav then
-      gfx.renderTex( icon_autonav, 246 + mod_x, 52 )
+      --gfx.renderTex( icon_autonav, 246 + mod_x, 52 )
+      gfx.print( false, "A", 246 + mod_x, 52, col_text, 12 )
    end
 
    for k, v in ipairs( bars ) do --bars = { "shield", "armour", "energy", "fuel" }, remember?
@@ -724,6 +737,9 @@ function render( dt )
       end
       renderBar( v, _G[v], _G[v .. "_light"], nil, nil, mod_x, ht, st )
    end
+
+   --Weapon set indicator
+   gfx.print( false, wset_id, 383 + mod_x, 52, col_text, 12, true )
 
    --Speed Lights
    local nlights = 11

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -76,6 +76,7 @@ static int pilotL_exists( lua_State *L );
 static int pilotL_target( lua_State *L );
 static int pilotL_inrange( lua_State *L );
 static int pilotL_nav( lua_State *L );
+static int pilotL_activeWeapset( lua_State *L );
 static int pilotL_weapset( lua_State *L );
 static int pilotL_weapsetHeat( lua_State *L );
 static int pilotL_actives( lua_State *L );
@@ -165,6 +166,7 @@ static const luaL_Reg pilotL_methods[] = {
    { "target", pilotL_target },
    { "inrange", pilotL_inrange },
    { "nav", pilotL_nav },
+   { "activeWeapset", pilotL_activeWeapset },
    { "weapset", pilotL_weapset },
    { "weapsetHeat", pilotL_weapsetHeat },
    { "actives", pilotL_actives },
@@ -1012,6 +1014,22 @@ static int pilotL_nav( lua_State *L )
    }
 
    return 2;
+}
+
+
+/**
+ * @brief Gets the ID (number from 1 to 10) of the current active weapset.
+ *
+ * @usage set_id = p:activeWeapset() -- A number from 1 to 10
+ *
+ *    @luatparam Pilot p Pilot to get active weapset ID of.
+ *    @luatparam number current active weapset ID.
+ */
+static int pilotL_activeWeapset( lua_State *L )
+{
+   Pilot *p = luaL_validpilot(L,1);
+   lua_pushnumber( L, p->active_set + 1 );
+   return 1;
 }
 
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -2504,6 +2504,7 @@ void pilot_init( Pilot* pilot, Ship* ship, const char* name, int faction, const 
    for (i=0; i<pilot->outfit_nstructure; i++) {
       pilot->outfits[p] = &pilot->outfit_structure[i];
       pilot->outfits[p]->sslot = &ship->outfit_structure[i];
+      pilot->outfits[p]->weapset = -1;
       if (ship->outfit_structure[i].data != NULL)
          pilot_addOutfitRaw( pilot, ship->outfit_structure[i].data, pilot->outfits[p] );
       p++;
@@ -2511,6 +2512,7 @@ void pilot_init( Pilot* pilot, Ship* ship, const char* name, int faction, const 
    for (i=0; i<pilot->outfit_nutility; i++) {
       pilot->outfits[p] = &pilot->outfit_utility[i];
       pilot->outfits[p]->sslot = &ship->outfit_utility[i];
+      pilot->outfits[p]->weapset = -1;
       if (ship->outfit_utility[i].data != NULL)
          pilot_addOutfitRaw( pilot, ship->outfit_utility[i].data, pilot->outfits[p] );
       p++;


### PR DESCRIPTION
A few things are a part of this:

1. The Lua API didn't support grabbing the current weapset ID (only the
   name), so I added this to the Lua API.

2. There was a bug in the weapset value of activated outfits caused by
   a variable not being initialized at the start, which led to unassigned
   activated outfits being listed as an arbitrary slot (1 in all cases
   that I saw but it seems that value isn't a guarantee in any way). Fixed
   that by initializing the weapset variable of structurals and utilities
   when pilots are created.

3. Activated outfits in weapset 10 now show up as "0" instead of "10" (matching
   the key it is assigned to by default).

4. The ID of the current weapon set is shown next to the radar; weapon set 10
   is shown as "0" for the same reason as for activated outfits.

5. Only weapons in the current weapon sets are shown now.