### PR TITLE
Add a small world of Proteron survivors in Iris

### DIFF
--- a/dat/assets/osiris.xml
+++ b/dat/assets/osiris.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Osiris">
+ <pos>
+  <x>8165.439424</x>
+  <y>-3379.428504</y>
+ </pos>
+ <GFX>
+  <space>moon-X00.png</space>
+  <exterior>uninhabited-rocky-magenta-01.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>5.000000</value>
+  <range>0</range>
+ </presence>
+ <general>
+  <class>A</class>
+  <population>100</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>House Proteron was once a formidable Great House of the Empire, before all of its teritories were destroyed in the incident. The Proteron ships that were outside what is now the Sol Nebula gathered at the uninhabited world of Osiris.
+
+In principle, the system is under Empire sovereignty, and House Proteron was dissolved after the destruction of all of its worlds in the incident. In practice, the former Proteron officers and soldiers residing here do not care for imperial control, nor does anyone else have an interest in the world.</description>
+  <bar>The bar has a very utilitarian design, consisting of the bare minimum to keep out the toxic atmosphere. They offer a small selection of drinks imported from neighboring Empire and Soromid space.</bar>
+ </general>
+</asset>

--- a/dat/ssys/iris.xml
+++ b/dat/ssys/iris.xml
@@ -12,6 +12,7 @@
  </pos>
  <assets>
   <asset>Aluben</asset>
+  <asset>Osiris</asset>
   <asset>Tenal-P</asset>
   <asset>Virtual Trader Local</asset>
  </assets>


### PR DESCRIPTION
This consists of the survivors of the Proteron who were left on this side of the nebula.

According to the lore, the Proteron were a Great House before the incident. Since they were not a secret, unlike the Thurion, there probably should be some mention of them. It seems logical that some would have been stranded on this side of the nebula.

This provides some interest in the Proteron for the player, and could be a useful site for future missions (a Proteron invasion might begin by secretly establishing contact with and control of Osiris).

https://web.archive.org/web/20170813171731/http://wiki.naev.org/wiki/Proteron