### PR TITLE
equipment_addAmmo -> pilot_fillAmmo

### DIFF
--- a/src/land.c
+++ b/src/land.c
@@ -1290,9 +1290,6 @@ void takeoff( int delay )
    /* Refuel if needed. */
    land_refuel();
 
-   /* Refill ammo if needed. */
-   equipment_addAmmo();
-
    /* In case we had paused messy sounds. */
    sound_stopAll();
 
@@ -1315,6 +1312,9 @@ void takeoff( int delay )
 
    /* heal the player */
    pilot_healLanded( player.p );
+
+   /* Refill ammo */
+   pilot_fillAmmo( player.p );
 
    /* Clear planet target. Allows for easier autonav out of the system. */
    player_targetPlanetSet( -1 );


### PR DESCRIPTION
This *might* solve a bad reference I saw once, but since I don't know how
to reproduce it I can't be certain. Either way it's clear that
pilot_fillAmmo should be used in the takeoff function rather than
equipment_addAmmo.