### PR TITLE
Added a mission tab to Facett Outpost.

### DIFF
--- a/dat/assets/facett_outpost.xml
+++ b/dat/assets/facett_outpost.xml
@@ -20,6 +20,7 @@
   <services>
    <land>srm_mil_restricted</land>
    <refuel/>
+   <missions/>
    <bar/>
   </services>
   <commodities/>


### PR DESCRIPTION
Not really important, but this allows a player with access to the station a
more convenient stop if they're hunting bounties or doing patrols in the
southward pirate-infested region.