### PR TITLE
A few small tweaks and improvements

### DIFF
--- a/dat/missions/flf/dvk/flf_dvk02.lua
+++ b/dat/missions/flf/dvk/flf_dvk02.lua
@@ -253,7 +253,8 @@ function enter ()
          hook.pilot( boss, "death", "pilot_death_boss" )
          hook.pilot( boss, "hail", "pilot_hail_boss" )
          boss:setHostile()
-         boss:setHilight( true )
+         boss:setHilight()
+         boss:setVisible()
 
          pirates_left = 4
          pirates = addShips( "Pirate Hyena", "pirate_norun", vec, pirates_left )
@@ -280,7 +281,8 @@ function enter ()
          hook.pilot( boss, "death", "pilot_death_boss" )
          boss_hook = hook.pilot( boss, "hail", "pilot_hail_boss" )
          boss:setFriendly()
-         boss:setHilight( true )
+         boss:setHilight()
+         boss:setVisible()
       end
    end
 end

--- a/dat/missions/flf/dvk/flf_dvk02.lua
+++ b/dat/missions/flf/dvk/flf_dvk02.lua
@@ -131,7 +131,7 @@ function accept ()
       pirates = nil
       boss_hook = nil
 
-      ore_needed = 300
+      ore_needed = 40
       credits = 300000
       reputation = 10
       pir_reputation = 10

--- a/dat/missions/flf/dvk/flf_dvk02.lua
+++ b/dat/missions/flf/dvk/flf_dvk02.lua
@@ -254,7 +254,6 @@ function enter ()
          hook.pilot( boss, "hail", "pilot_hail_boss" )
          boss:setHostile()
          boss:setHilight()
-         boss:setVisible()
 
          pirates_left = 4
          pirates = addShips( "Pirate Hyena", "pirate_norun", vec, pirates_left )

--- a/dat/ships/flf_lancelot.xml
+++ b/dat/ships/flf_lancelot.xml
@@ -8,6 +8,7 @@
  <price>400000</price>
  <time_mod>1</time_mod>
  <fabricator>Nexus Shipyards</fabricator>
+ <license>Small Combat Vessel License</license>
  <description>The Lancelot is commonly used by FLF pilots both because of its widespread availability and its general well-roundedness.</description>
  <health>
   <absorb>7</absorb>

--- a/dat/ships/flf_vendetta.xml
+++ b/dat/ships/flf_vendetta.xml
@@ -8,6 +8,7 @@
  <price>400000</price>
  <time_mod>1</time_mod>
  <fabricator>House Dvaered</fabricator>
+ <license>Small Combat Vessel License</license>
  <description>It's something of an irony that one of the most popular ships in use by FLF pilots comes from House Dvaered. Still, the Vendetta has been proven to be a great choice for dealing a lot of damage in a short amount of time, which is vital when going up against ships more than twice your size.</description>
  <health>
   <absorb>6</absorb>

--- a/src/space.h
+++ b/src/space.h
@@ -53,8 +53,7 @@
 #define planet_setFlag(p,f)   ((p)->flags |= (f)) /**< Sets a planet flag. */
 #define planet_rmFlag(p,f)    ((p)->flags &= ~(f)) /**< Removes a planet flag. */
 #define planet_isKnown(p) \
-   (!planet_exists((p)->name) || !planet_hasSystem((p)->name) || \
-      planet_isFlag(p,PLANET_KNOWN)) /**< Checks if planet is known. */
+   (!planet_hasSystem((p)->name) || planet_isFlag(p,PLANET_KNOWN)) /**< Checks if planet is known. */
 
 
 /**


### PR DESCRIPTION
Changes include:

* Specified the small FLF ships as needing the Light Combat Vessel License. This is purely cosmetic; Sindbad is a black market asset so the station allows you to buy any ship regardless of the licenses you have.

* Made the Kestrel in the FLF Pirate Alliance mission visible when you get to the Anger system (so you don't need to search around for it).

* Reduced the ore needed to complete the mission from 300 down to 40 (ensuring that you can always complete the mission using only ships bought from Sindbad, and allowing you to use couriers as well as freighters).

* Removed the check for whether or not a planet exists in planet_isKnown, since it should be unnecessary.