### PR TITLE
Fixed the music so it plays combat music correctly.

### DIFF
--- a/dat/snd/music.lua
+++ b/dat/snd/music.lua
@@ -315,7 +315,7 @@ function choose_combat ()
       local cur = music.current()
       for k,v in pairs(combat) do
          if cur == v then
-            return false
+            return true
          end
       end
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -1494,7 +1494,11 @@ void pilot_updateDisable( Pilot* p, const unsigned int shooter )
 
       /* If hostile, must remove counter. */
       if (pilot_isHostile(p))
+      {
          player.disabled_enemies--;
+         /* Time to play combat music. */
+         music_choose("combat");
+      }
 
       /* Reset the accumulated disable time. */
       p->dtimer_accum = 0.;

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -967,8 +967,7 @@ void pilot_setHostile( Pilot* p )
 {
    if (!pilot_isFlag(p, PILOT_HOSTILE)) {
       /* Time to play combat music. */
-      if (player.enemies == 0)
-         music_choose("combat");
+      music_choose("combat");
 
       player.enemies++;
       pilot_setFlag(p, PILOT_HOSTILE);
@@ -1164,14 +1163,14 @@ void pilot_distress( Pilot *p, Pilot *attacker, const char *msg, int ignore_int 
 void pilot_rmHostile( Pilot* p )
 {
    if (pilot_isFlag(p, PILOT_HOSTILE)) {
-      if (!pilot_isDisabled(p))
-         player.enemies--;
+      player.enemies--;
+      if (pilot_isDisabled(p))
+         player.disabled_enemies--;
       pilot_rmFlag(p, PILOT_HOSTILE);
 
       /* Change music back to ambient if no more enemies. */
-      if (player.enemies <= 0) {
+      if (player.enemies <= player.disabled_enemies) {
          music_choose("ambient");
-         player.enemies = 0;
       }
    }
 }
@@ -1444,12 +1443,9 @@ void pilot_updateDisable( Pilot* p, const unsigned int shooter )
       pilot_rmFlag(p, PILOT_HYP_BRAKE);
       pilot_rmFlag(p, PILOT_HYPERSPACE);
 
-      /* If hostile, must remove counter. */
-      h = (pilot_isHostile(p)) ? 1 : 0;
-      pilot_rmHostile(p);
-      if (h == 1) /* Horrible hack to make sure player.p can hit it if it was hostile. */
-         /* Do not use pilot_setHostile here or music will change again. */
-         pilot_setFlag(p,PILOT_HOSTILE);
+      /* If hostile, must add counter. */
+      if (pilot_isHostile(p))
+         player.disabled_enemies++;
 
       /* Modify player combat rating if applicable. */
       /* TODO: Base off something more sensible than mass. */
@@ -1495,6 +1491,10 @@ void pilot_updateDisable( Pilot* p, const unsigned int shooter )
       pilot_rmFlag( p, PILOT_DISABLED ); /* Undisable. */
       pilot_rmFlag( p, PILOT_DISABLED_PERM ); /* Clear perma-disable flag if necessary. */
       pilot_rmFlag( p, PILOT_BOARDING ); /* Can get boarded again. */
+
+      /* If hostile, must remove counter. */
+      if (pilot_isHostile(p))
+         player.disabled_enemies--;
 
       /* Reset the accumulated disable time. */
       p->dtimer_accum = 0.;

--- a/src/player.h
+++ b/src/player.h
@@ -73,6 +73,7 @@ typedef struct Player_s {
    /* Player data. */
    PlayerFlags flags; /**< Player's flags. */
    int enemies; /**< Amount of enemies the player has. */
+   int disabled_enemies; /**< Amount of enemies that are disabled. */
    double crating; /**< Combat rating. */
    int autonav; /**< Current autonav state. */
    Vector2d autonav_pos; /**< Target autonav position. */

--- a/src/space.c
+++ b/src/space.c
@@ -1466,6 +1466,7 @@ void space_init( const char* sysname )
 
    /* Reset player enemies. */
    player.enemies = 0;
+   player.disabled_enemies = 0;
 
    /* Update the pilot sensor range. */
    pilot_updateSensorRange();


### PR DESCRIPTION
There were a few parts to this. In a nutshell:

1. Fixed the way enemies are counted so that disabled pilots are properly
   accounted for (previously a disabled and then destroyed enemy would
   decrease the enemy counter twice, for instance).

2. Removed the unnecessary requirement for the enemy becoming hostile
   to be the first enemy before setting combat music. (Lua already takes
   care of this, so the check in C was redundant.)

3. Fixed choose_combat Lua function so that if it finds that it's already
   playing, it still marks itself as the last music played (important because
   otherwise "ambient" is always set to "last" when jumping in, and music for
   missions ends up getting set before "idle" plays but after "ambient";
   if previous system had been playing combat music it would catch this and
   then not record itself as the "last" type, leading to ambient being "last"
   even though combat really was).

TL;DR: combat music now plays correctly, 100% of the time. No strange cases
of ambient music when you're fighting a gigantic horde of pirates.