### PR TITLE
Fixed several instances of assuming that planet.faction always returns a faction.

### DIFF
--- a/dat/events/neutral/news.lua
+++ b/dat/events/neutral/news.lua
@@ -379,7 +379,9 @@ articles["Thurion"]={}
    --create generic news
 function create()
 
-   faction = planet.cur():faction():name()
+   local f = planet.cur():faction()
+   faction = f ~= nil and f:name() or nil
+   if faction == nil then evt.finish(false) end
 
    remove_header(faction)
 

--- a/dat/events/neutral/npc.lua
+++ b/dat/events/neutral/npc.lua
@@ -285,7 +285,8 @@ function spawnNPC()
 
    local nongeneric = false
 
-   local planfaction = planet.cur():faction():name()
+   local f = planet.cur():faction()
+   local planfaction = f ~= nil and f:name() or nil
    local fac = "general"
    local select = rnd.rnd()
    if planfaction ~= nil then

--- a/dat/missions/dvaered/dv_antiflf01.lua
+++ b/dat/missions/dvaered/dv_antiflf01.lua
@@ -52,7 +52,7 @@ function create()
 end
 
 function land()
-    if planet.cur():faction():name() == "Dvaered" then
+    if planet.cur():faction() == faction.get("Dvaered") then
         if var.peek("flfbase_flfshipkilled") then
             tk.msg(title[2], text[2] .. text[3] .. text[5])
             player.pay(100000) -- 100K

--- a/dat/missions/dvaered/dv_antiflf02.lua
+++ b/dat/missions/dvaered/dv_antiflf02.lua
@@ -136,7 +136,7 @@ function enter()
 end
 
 function land()
-    if logsfound and planet.cur():faction():name() == "Dvaered" then
+    if logsfound and planet.cur():faction() == faction.get("Dvaered") then
         tk.msg(title[6], text[6])
         var.push("flfbase_intro", 3)
         faction.get("Dvaered"):modPlayerSingle(5)

--- a/dat/missions/flf/dvk/flf_dvk01.lua
+++ b/dat/missions/flf/dvk/flf_dvk01.lua
@@ -86,7 +86,7 @@ end
 
 
 function land ()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", pay_text[ rnd.rnd( 1, #pay_text ) ] )
       player.pay( credits )
       flf_setReputation( 35 )

--- a/dat/missions/flf/dvk/flf_dvk03.lua
+++ b/dat/missions/flf/dvk/flf_dvk03.lua
@@ -366,7 +366,7 @@ end
 
 
 function land ()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( title[8], text[8] )
       finish()
    end

--- a/dat/missions/flf/dvk/flf_dvk04.lua
+++ b/dat/missions/flf/dvk/flf_dvk04.lua
@@ -86,7 +86,7 @@ end
 
 
 function land ()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", pay_text[ rnd.rnd( 1, #pay_text ) ] )
       player.pay( credits )
       flf_setReputation( 85 )

--- a/dat/missions/flf/dvk/flf_dvk06.lua
+++ b/dat/missions/flf/dvk/flf_dvk06.lua
@@ -339,7 +339,7 @@ end
 
 
 function land ()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( title[4], text[4]:format( player.name() ) )
       finish()
    end

--- a/dat/missions/flf/dvk/flf_dvk07.lua
+++ b/dat/missions/flf/dvk/flf_dvk07.lua
@@ -90,7 +90,7 @@ end
 function land_flf ()
    leave()
    last_system = nil
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", pay_text[1] )
       player.pay( credits )
       flf_setReputation( 95 )

--- a/dat/missions/flf/flf_diversion.lua
+++ b/dat/missions/flf/flf_diversion.lua
@@ -177,7 +177,7 @@ end
 
 
 function land ()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", pay_text[ rnd.rnd( 1, #pay_text ) ] )
       player.pay( credits )
       faction.get("FLF"):modPlayer( reputation )

--- a/dat/missions/flf/flf_patrol.lua
+++ b/dat/missions/flf/flf_patrol.lua
@@ -206,7 +206,7 @@ end
 function land_flf ()
    leave()
    last_system = planet.cur()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", text[ rnd.rnd( 1, #text ) ] )
       player.pay( credits )
       faction.get("FLF"):modPlayer( reputation )

--- a/dat/missions/flf/flf_pirates.lua
+++ b/dat/missions/flf/flf_pirates.lua
@@ -203,7 +203,7 @@ end
 function land_flf ()
    leave()
    last_system = planet.cur()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", pay_text[ rnd.rnd( 1, #pay_text ) ] )
       player.pay( credits )
       faction.get("FLF"):modPlayerSingle( reputation )

--- a/dat/missions/flf/flf_pre01.lua
+++ b/dat/missions/flf/flf_pre01.lua
@@ -145,7 +145,7 @@ function land()
         misn.cargoJet(gregar)
         misn.finish(true)
     -- Case Dvaered planet
-    elseif planet.cur():faction():name() == "Dvaered" and not basefound then
+    elseif planet.cur():faction() == faction.get("Dvaered") and not basefound then
         if tk.yesno(turnintitle[1], turnintext[1]) then
             tk.msg(turnintitle[2], turnintext[2])
             faction.get("Dvaered"):modPlayerSingle(5)

--- a/dat/missions/flf/flf_pre02.lua
+++ b/dat/missions/flf/flf_pre02.lua
@@ -351,7 +351,7 @@ end
 
 function land_flf ()
    leave()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( title[4], text[4] )
       tk.msg( title[4], text[5]:format( player.name() ) )
       tk.msg( title[4], text[6] )

--- a/dat/missions/flf/flf_rogue.lua
+++ b/dat/missions/flf/flf_rogue.lua
@@ -166,7 +166,7 @@ end
 function land_flf ()
    leave()
    last_system = planet.cur()
-   if planet.cur():faction():name() == "FLF" then
+   if planet.cur():faction() == faction.get("FLF") then
       tk.msg( "", text[ rnd.rnd( 1, #text ) ] )
       player.pay( credits )
       misn.finish( true )

--- a/dat/missions/pirate/empbounty_dead.lua
+++ b/dat/missions/pirate/empbounty_dead.lua
@@ -127,7 +127,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( misn_level[level], missys:name() ) )
 
-   if planet.cur():faction():name() == "Pirate" then
+   if planet.cur():faction() == faction.get("Pirate") then
       misn.setDesc( misn_desc:format( target_faction, missys:name(), paying_faction:name() ) )
    else
       -- We're not on a pirate stronghold, so include a warning that the

--- a/dat/missions/pirate/pir_ship_stealing.lua
+++ b/dat/missions/pirate/pir_ship_stealing.lua
@@ -223,9 +223,9 @@ function create ()
 
    ship.planet  = random_planet()
 
-   if not ship.planet then
+   if not ship.planet or ship.planet:faction() == nil then
       -- If we’re here, it means we couldn’t get a planet close enough.
-      misn.finish()
+      misn.finish(false)
    end
 
    ship.faction = ship.planet:faction():name()
@@ -234,7 +234,7 @@ function create ()
    if not ship.class then
       -- If we’re here, it means we couldn’t get a ship of the right faction
       -- and of the right class.
-      misn.finish()
+      misn.finish(false)
    end
 
    -- We’re assuming ships[faction][class] is not empty, here…

--- a/src/nlua_planet.c
+++ b/src/nlua_planet.c
@@ -494,7 +494,7 @@ static int planetL_radius( lua_State *L )
  *
  * @usage f = p:faction()
  *    @luatparam Planet p Planet to get the faction of.
- *    @luatreturn Faction The planet's faction.
+ *    @luatreturn Faction The planet's faction, or nil if it has no faction.
  * @luafunc faction( p )
  */
 static int planetL_faction( lua_State *L )


### PR DESCRIPTION
The function actually returns nil if the planet has no faction (i.e. Eirok),
so code that relied on this broke whenever the player landed on such a
planet. I've done a grep for these and I think I've fixed every one,
preventing Lua errors in the News and NPC events most notably but also
preventing possible (albeit unlikely) mission errors.

I also added a note that it can return nil to the Lua documentation of the function to make it less likely for this to happen again.