### PR TITLE
Fixed calling a nonexistent function in ec06.

### DIFF
--- a/dat/missions/empire/collective/ec06.lua
+++ b/dat/missions/empire/collective/ec06.lua
@@ -50,7 +50,7 @@ osd_msg["__save"] = true
 function create ()
     missys = {system.get("C-59"), system.get("C-28"), system.get("C-00")}
     if not misn.claim(missys) then
-        abort()
+        misn.finish( false )
     end
 
    misn.setNPC( _("Keer"), "empire/unique/keer" )


### PR DESCRIPTION
It calls abort() which isn't defined in this mission. Replaced that
with the obvious misn.finish(false) instead.