### PR TITLE
Modified the OSD to compact itself to hide old information.

### DIFF
--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -370,6 +370,7 @@ int osd_setup( int x, int y, int w, int h )
    /* Calculate some font things. */
    osd_tabLen = gl_printWidthRaw( &gl_smallFont, "   " );
    osd_hyphenLen = gl_printWidthRaw( &gl_smallFont, "- " );
+   osd_calcDimensions();
 
    return 0;
 }

--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -328,6 +328,7 @@ int osd_active( unsigned int osd, int msg )
    }
 
    o->active = msg;
+   osd_calcDimensions();
    return 0;
 }
 


### PR DESCRIPTION
This change does a couple of things to make the OSD much more readable
when you have a whole bunch of missions you've completed but haven't
collected your reward for:

1. Earlier "steps" of the OSD are not shown; when you complete an
   objective it disappears, so that the first highlighted objective
   is always the first one listed.

2. Multiple OSD entries that would render exactly the same are compacted
   together, and the number of them you have is shown in the title.

This is mainly helpful for an FLF-aligned player; missions done in
Frontier space aren't "finished" until the player lands on Sindbad, so
previously you would have a huge cluster of old OSDs that were no longer
relevant. With this change, these old missions collapse down into a
smaller number of shorter entries, allowing the player to see the
ones that are more important. But the change can help in other cases as
well, e.g. if multiple cargo missions to the same planet have been
accepted.