### PR TITLE
Copy previous ship's target info when swapping ships.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -586,6 +586,13 @@ void player_swapShip( char* shipname )
       /* move cargo over */
       pilot_cargoMove( ship, player.p );
 
+      /* Copy target info */
+      ship->target = player.p->target;
+      ship->nav_planet = player.p->nav_planet;
+      ship->nav_hyperspace = player.p->nav_hyperspace;
+      ship->nav_anchor = player.p->nav_anchor;
+      ship->nav_asteroid = player.p->nav_asteroid;
+
       /* Store position. */
       v = player.p->solid->pos;
       dir = player.p->solid->dir;


### PR DESCRIPTION
This should finally fix #866 (formerly #719). @ids1024 and I did some investigating when the bug surfaced randomly and we found that it was caused by a target planet index being kept as-is when swapping ships; this would cause an attempt to read a bad location if the planet index it had targeted (landed on) previously was an index that isn't valid for the current system (e.g. if it was the 8th planet, but the current system only has 5 planets).

Just to be safe, I decided to copy *all* target info from the previous ship to the new ship. This might be worthwhile anyway because it's possible to call the Lua player.swapShip function in space; copying target info means you don't have your targets cleared when that happens.