### PR TITLE
Some small fixes to the FLF

### DIFF
--- a/dat/factions/standing/flf.lua
+++ b/dat/factions/standing/flf.lua
@@ -10,6 +10,9 @@ _fcap_misn     = 5 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_flf"
 _fthis         = faction.get("FLF")
 
+_fstanding_friendly = 30
+_fstanding_neutral = 0
+
 
 function faction_hit( current, amount, source, secondary )
     return default_hit(current, amount, source, secondary)

--- a/dat/missions/flf/flf_empatrol.lua
+++ b/dat/missions/flf/flf_empatrol.lua
@@ -29,7 +29,7 @@ misn_desc[3] = _(" There is a Pacifier among them, so you must proceed with caut
 misn_desc[4] = _(" There is a Hawking among them, so you must be very careful.")
 misn_desc[5] = _(" You will be accompanied by %d other FLF pilots for this mission.")
 
-osd_title   = _("Dvaered Patrol")
+osd_title   = _("FLF Patrol")
 osd_desc    = {}
 osd_desc[1] = _("Fly to the %s system")
 osd_desc[2] = _("Eliminate the Empire patrol")

--- a/dat/missions/flf/flf_patrol.lua
+++ b/dat/missions/flf/flf_patrol.lua
@@ -49,7 +49,7 @@ misn_level[4] = _("Large")
 misn_level[5] = _("Dangerous")
 misn_level[6] = _("Highly Dangerous")
 
-osd_title   = _("Dvaered Patrol")
+osd_title   = _("FLF Patrol")
 osd_desc    = {}
 osd_desc[1] = _("Fly to the %s system")
 osd_desc[2] = _("Eliminate the Dvaered patrol")


### PR DESCRIPTION
Two changes:

1. Count the FLF as "friendly" at 30 reputation instead of 70. This doesn't have much of a substantial effect except that they show as "friendly" much sooner (which mainly just makes more sense). Also prevents the absurdity (during the campaign) of the pirates being friendly while the FLF are just neutral.

2. Renamed "Dvaered Patrol" to "FLF Patrol" in the OSD, since it makes it clearer that it's an FLF mission and prevents the weirdness of Empire patrol eliminations being called "Dvaered Patrol".