### PR TITLE
Made it unlikely (but not impossible) for double-playing a music track

### DIFF
--- a/dat/snd/music.lua
+++ b/dat/snd/music.lua
@@ -249,7 +249,20 @@ function choose_ambient ()
       end
 
       -- Load music and play
-      music.load( ambient[ rnd.rnd(1,#ambient) ] )
+      local new_track = ambient[ rnd.rnd(1,#ambient) ]
+
+      -- Make it very unlikely (but not impossible) for the same music
+      -- to play twice
+      for i=1, 3 do
+         if new_track == last_track then
+            new_track = ambient[ rnd.rnd(1,#ambient) ]
+         else
+            break
+         end
+      end
+
+      last_track = new_track
+      music.load( new_track )
       music.play()
       return true
    end
@@ -323,7 +336,20 @@ function choose_combat ()
       return true
    end
 
-   music.load( combat[ rnd.rnd(1,#combat) ] )
+   local new_track = combat[ rnd.rnd(1,#combat) ]
+
+   -- Make it very unlikely (but not impossible) for the same music
+   -- to play twice
+   for i=1, 3 do
+      if new_track == last_track then
+         new_track = combat[ rnd.rnd(1,#combat) ]
+      else
+         break
+      end
+   end
+
+   last_track = new_track
+   music.load( new_track )
    music.play()
    return true
 end


### PR DESCRIPTION
It's a pretty simple change: now, if it selects the same ambient or
combat music as the last music played, it reselects music up to 3
times (as long as that same track is chosen). This makes it extremely
unlikely, but not impossible, for the same track to play twice (for
example, if 3 music choices are available, this reduces the chances
of playing a track twice from 33% to 1%).

I chose this method both because there's nothing wrong per se with
playing a duplicate on occasion, and in case only one music choice is
defined for some reason.