### PR TITLE
Fixed up Thurion energy missiles.

### DIFF
--- a/dat/outfits/launchers/energy_torpedo_mk1.xml
+++ b/dat/outfits/launchers/energy_torpedo_mk1.xml
@@ -5,7 +5,7 @@
   <size>small</size>
   <license>Medium Weapon License</license>
   <mass>5</mass>
-  <price>0</price>
+  <price>50000</price>
   <description>One of the greatest advancements the Thurion have made was in the field of non-corporeal computation. While it wasn't the original intention, the self-contained energy cascades that are capable of doing simple calculations are used as weapons. While such weapons have very high computational requirements, the homing energy projectiles have a high chance of hitting an evasive target.</description>
   <gfx_store>energy_dart</gfx_store>
   <cpu>-14</cpu>
@@ -14,8 +14,8 @@
   <ammo>Thurion Energy Cell I</ammo>
   <delay>1.0</delay>
   <reload_time>240</reload_time>
-  <amount>150</amount>
-  <lockon>1</lockon>
+  <amount>50</amount>
+  <lockon>0.2</lockon>
   <arc>15</arc>
   <ew_target>2</ew_target>
  </specific>

--- a/dat/outfits/launchers/energy_torpedo_mk2.xml
+++ b/dat/outfits/launchers/energy_torpedo_mk2.xml
@@ -5,17 +5,17 @@
   <size>medium</size>
   <license>Medium Weapon License</license>
   <mass>14</mass>
-  <price>0</price>
+  <price>75000</price>
   <description>One of the greatest advancements the Thurion have made was in the field of non-corporeal computation. While it wasn't the original intention, the self-contained energy cascades that are capable of doing simple calculations are used as weapons. While such weapons have very high computational requirements, the homing energy projectiles have a high chance of hitting an evasive target.</description>
   <gfx_store>energy_missile</gfx_store>
   <cpu>-26</cpu>
   </general>
  <specific type="launcher" secondary="1">
   <ammo>Thurion Energy Cell II</ammo>
-  <delay>2.0</delay>
+  <delay>1.0</delay>
   <reload_time>240</reload_time>
-  <amount>125</amount>
-  <lockon>1</lockon>
+  <amount>50</amount>
+  <lockon>0.2</lockon>
   <arc>15</arc>
   <ew_target>2</ew_target>
  </specific>

--- a/dat/outfits/launchers/energy_torpedo_mk3.xml
+++ b/dat/outfits/launchers/energy_torpedo_mk3.xml
@@ -5,17 +5,17 @@
   <size>large</size>
   <license>Heavy Weapon License</license>
   <mass>37</mass>
-  <price>0</price>
+  <price>100000</price>
   <description>One of the greatest advancements the Thurion have made was in the field of non-corporeal computation. While it wasn't the original intention, the self-contained energy cascades that are capable of doing simple calculations are used as weapons. While such weapons have very high computational requirements, the homing energy projectiles have a high chance of hitting an evasive target.</description>
   <gfx_store>energy_torpedo</gfx_store>
   <cpu>-42</cpu>
   </general>
  <specific type="launcher" secondary="1">
   <ammo>Thurion Energy Cell III</ammo>
-  <delay>3.0</delay>
+  <delay>1.0</delay>
   <reload_time>240</reload_time>
-  <amount>100</amount>
-  <lockon>1</lockon>
+  <amount>50</amount>
+  <lockon>0.2</lockon>
   <arc>15</arc>
   <ew_target>2</ew_target>
  </specific>

--- a/dat/outfits/rockets/energy_cell_i.xml
+++ b/dat/outfits/rockets/energy_cell_i.xml
@@ -13,10 +13,10 @@
   <sound_hit>empexplode</sound_hit>
   <spfx_shield>EmpS</spfx_shield>
   <spfx_armour>EmpM</spfx_armour>
-  <duration blowup="shield">1.2</duration>
+  <duration blowup="shield">1.0</duration>
   <thrust>0</thrust>
-  <turn>120</turn>
-  <speed>800</speed>
+  <turn>80</turn>
+  <speed>600</speed>
   <resist>5</resist>
   <energy>12.5</energy>
   <damage>

--- a/dat/outfits/rockets/energy_cell_ii.xml
+++ b/dat/outfits/rockets/energy_cell_ii.xml
@@ -13,10 +13,10 @@
   <sound_hit>empexplode</sound_hit>
   <spfx_shield>EmpS</spfx_shield>
   <spfx_armour>EmpM</spfx_armour>
-  <duration blowup="shield">1.4</duration>
+  <duration blowup="shield">1.8</duration>
   <thrust>0</thrust>
-  <turn>100</turn>
-  <speed>700</speed>
+  <turn>80</turn>
+  <speed>600</speed>
   <resist>5</resist>
   <energy>40</energy>
   <damage>

--- a/dat/outfits/rockets/energy_cell_iii.xml
+++ b/dat/outfits/rockets/energy_cell_iii.xml
@@ -13,7 +13,7 @@
   <sound_hit>empexplode</sound_hit>
   <spfx_shield>EmpS</spfx_shield>
   <spfx_armour>EmpM</spfx_armour>
-  <duration blowup="shield">1.8</duration>
+  <duration blowup="shield">2.6</duration>
   <thrust>0</thrust>
   <turn>80</turn>
   <speed>600</speed>


### PR DESCRIPTION
I've reworked them to balance with everything else a bit better.
Some things I did:

* Lowered the Energy Dart and Energy Missile the same speed and with
  the same turn rate as the Energy Torpedo.

* Lowered the duration of the Energy Dart, increased the duration of
  the others (each size energy dart now has a range comparable to
  cannons of the same size).

* Added prices to these weapons rather than offering them up for free.

* Lowered the lock-on time from 1 second to 0.2 seconds for all sizes,
  so that these weapons can be used rapidly (important because they're
  short-range weapons).