### PR TITLE
Prevent an occasional bad read when searching for outfits

### DIFF
--- a/src/map_find.c
+++ b/src/map_find.c
@@ -369,10 +369,15 @@ static int map_findDistance( StarSystem *sys, Planet *pnt, int *jumps, double *d
 
    /* Account final travel to planet for planet targets. */
    if (pnt != NULL) {
-      ss = slist[ i ];
-      for (j=0; j < ss->njumps; j++)
-         if (ss->jumps[j].target == slist[i-1])
-            vs = &ss->jumps[j].pos;
+      if (i > 0) {
+         ss = slist[ i ];
+         for (j=0; j < ss->njumps; j++) {
+            if (ss->jumps[j].target == slist[i-1]) {
+               vs = &ss->jumps[j].pos;
+               break;
+            }
+         }
+      }
 
       ve = &pnt->pos;
       d += vect_dist( vs, ve );


### PR DESCRIPTION
I wasn't able to reproduce it, but I ran into an AddressSanitizer
error that appeared to be caused by accessing slist[i-1] when i was
0. How this happened, I haven't a clue. But I've added a check to
make sure that i > 0 before doing this.