### PR TITLE
small correction in race missions

### DIFF
--- a/dat/missions/neutral/race1.lua
+++ b/dat/missions/neutral/race1.lua
@@ -239,6 +239,7 @@ end
 function board(ship)
    for i,j in ipairs(checkpoint) do
       if ship == j and target[4] == i then
+         player.msg( string.format( positionmsg, player.name(),target[4]) )
          misn.osdActive(i+1)
          target[4] = target[4] + 1
          if target[4] == 4 then
@@ -246,10 +247,10 @@ function board(ship)
          else
             tk.msg(string.format(title[3], i), string.format(text[3], i+1))
          end
+         break
       end
    end
-   player.msg( string.format( positionmsg, player.name(),target[4]) )
-   player.unboard() 
+   player.unboard()
 end
 
 

--- a/dat/missions/neutral/race2.lua
+++ b/dat/missions/neutral/race2.lua
@@ -271,6 +271,7 @@ end
 function board(ship)
    for i,j in ipairs(checkpoint) do
       if ship == j and target[4] == i then
+         player.msg( string.format( positionmsg, player.name(),target[4]) )
          misn.osdActive(i+1)
          target[4] = target[4] + 1
          if target[4] == 4 then
@@ -278,9 +279,9 @@ function board(ship)
             else
             tk.msg(string.format(title[3], i), string.format(text[3], i+1))
          end
+         break
       end
    end
-   player.msg( string.format( positionmsg, player.name(),target[4]) )
    player.unboard()       
 end
 


### PR DESCRIPTION
The n° of checkpoint displayed in the message was wrong, and if the player tried to board checkpoint 2 or 3 first, there was a message saying you had just boarded checkpoint 1.
I did the same modification on race2, but I didn't check this one.

I also added a break (more elegant)