### PR TITLE
Add cargo to ships as they are equipped.

### DIFF
--- a/dat/factions/equip/generic.lua
+++ b/dat/factions/equip/generic.lua
@@ -1,3 +1,6 @@
+include "jumpdist.lua"
+
+
 -- Table of available core systems by class.
 equip_classOutfits_coreSystems = {
    ["Yacht"] = {
@@ -928,4 +931,22 @@ function equip_generic( p )
    equip_set( p, equip_shipOutfits_structurals[shipname] )
    equip_set( p, equip_typeOutfits_structurals[basetype] )
    equip_set( p, equip_classOutfits_structurals[class] )
+
+   -- Add cargo
+   local avail_cargo = {}
+   local systems = getsysatdistance( nil, 0, 4 )
+   for i, sys in ipairs( systems ) do
+      for j, pl in ipairs( sys:planets() ) do
+         for k, com in ipairs( pl:commoditiesSold() ) do
+            avail_cargo[ #avail_cargo + 1 ] = com
+         end
+      end
+   end
+
+   if avail_cargo then
+      for i=1,rnd.rnd(1,3) do
+         local ncargo = rnd.rnd( 0, p:cargoFree() )
+         p:cargoAdd( avail_cargo[ rnd.rnd( 1, #avail_cargo ) ]:name(), ncargo )
+      end
+   end
 end

--- a/src/board.c
+++ b/src/board.c
@@ -460,6 +460,7 @@ static int board_fail( unsigned int wdw )
 static void board_update( unsigned int wdw )
 {
    int i, j;
+   int total_cargo;
    char str[PATH_MAX];
    char cred[ECON_CRED_STRLEN];
    Pilot* p;
@@ -475,14 +476,15 @@ static void board_update( unsigned int wdw )
    if ((p->ncommodities==0) && (j < PATH_MAX))
       j += snprintf( &str[j], PATH_MAX-j, _("none\n") );
    else {
-     for (i=0; i<p->ncommodities; i++) {
+      total_cargo = 0;
+      for (i=0; i<p->ncommodities; i++) {
          if (j > PATH_MAX)
             break;
          if (p->commodities[i].commodity == NULL)
             continue;
-         j += snprintf( &str[j], PATH_MAX-j, "%d %s\n",
-                        p->commodities[i].quantity, p->commodities[i].commodity->name );
-     }
+         total_cargo += p->commodities[i].quantity;
+      }
+      j += snprintf( &str[j], PATH_MAX-j, _("%d tons\n"), total_cargo );
    }
 
    /* Fuel. */


### PR DESCRIPTION
This should enable galactic piracy to be a much more possible prospect. Before, no ship ever had cargo. Now, most do have some amount (the exact amount is randomized, but biased toward being 50%, 75%, or 87.5%).

After I did this, I noticed that the way a boarded ship's cargo is presented is buggy in its attempt to show what type(s) of cargo it has. I considered fixing that but ultimately decided that since technically there could be any number of different kinds of cargo on one ship, just listing the total amount of cargo (without naming the kind) is probably for the best, because there's no solution to cases like a ship having a dozen or even a hundred different kinds of cargo. Chances are you wouldn't be able to scrutinize what kinds of cargo a ship you're stealing from has anyhow, and I don't think anything is really lost (if cargo is worthless to you, you can jettison it).