### PR TITLE
Pirate Koala does not re-spawn in kidnappers mission

### DIFF
--- a/dat/missions/neutral/kidnapped/traffic_00.lua
+++ b/dat/missions/neutral/kidnapped/traffic_00.lua
@@ -166,7 +166,7 @@ end
 
 function enter()
 
-  if eavesdropped1 and eavesdropped2 and system.cur() == system.get(sysname2) then
+  if eavesdropped1 and eavesdropped2 and system.cur() == system.get(sysname2) and (not rescued) then
     kidnappers = pilot.add("Trader Koala", nil, planet.get("Zhiru"):pos() + vec2.new(-800,-800))[1]
     kidnappers:rename(_("Progeny"))
     kidnappers:setFaction("Kidnappers")
@@ -213,7 +213,9 @@ function attackedkidnappers()
 end
 
 function explodedkidnappers()
-  hook.timer(1500, "kidskilled")
+  if (not rescued) then
+     hook.timer(1500, "kidskilled")
+  end
 end
 
 function kidskilled()


### PR DESCRIPTION
If the children have been rescued, there is no more reason for the kidnapper's Koala to be still there. What's more, I've added the possibility to destroy the Koala after having boarded it (as there are no more children in it)