### PR TITLE
Reset faction flags when resetting their standing.

### DIFF
--- a/src/faction.c
+++ b/src/faction.c
@@ -82,6 +82,7 @@ typedef struct Faction_ {
 
    /* Flags. */
    unsigned int flags; /**< Flags affecting the faction. */
+   unsigned int oflags; /**< Original flags (for when new game is started). */
 } Faction;
 
 static Faction* faction_stack = NULL; /**< Faction stack. */
@@ -1422,13 +1423,15 @@ static void faction_parseSocial( xmlNodePtr parent )
 
 
 /**
- * @brief Resets the player's standing with the factions to default.
+ * @brief Resets player standing and flags of factions to default.
  */
 void factions_reset (void)
 {
    int i;
-   for (i=0; i<faction_nstack; i++)
+   for (i=0; i<faction_nstack; i++) {
       faction_stack[i].player = faction_stack[i].player_def;
+      faction_stack[i].flags = faction_stack[i].oflags;
+   }
 }
 
 
@@ -1481,6 +1484,7 @@ int factions_load (void)
 
          /* Load faction. */
          faction_parse(&faction_stack[faction_nstack-1], node);
+         faction_stack[faction_nstack-1].oflags = faction_stack[faction_nstack-1].flags;
       }
    } while (xml_nextNode(node));
 

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -884,19 +884,18 @@ double pilot_weapFlyTime( Outfit *o, Pilot *parent, Vector2d *pos, Vector2d *vel
    dist = vect_dist( &parent->solid->pos, pos );
 
    /* Beam weapons */
-   if (outfit_isBeam(o))
-      {
+   if (outfit_isBeam(o)) {
       if (dist > o->u.bem.range)
          return INFINITY;
       return 0.;
-      }
+   }
 
    /* A bay doesn't have range issues */
    if (outfit_isFighterBay(o))
       return 0.;
 
-   /* Rockets use absolute velocity while bolt use relative vel */
-   if (outfit_isLauncher(o))
+   /* Missiles use absolute velocity while bolts and dumbfire rockets use relative vel */
+   if (outfit_isLauncher(o) && o->u.lau.ammo->u.amm.ai != AMMO_AI_DUMB)
          vect_cset( &approach_vector, - vel->x, - vel->y );
    else
          vect_cset( &approach_vector, VX(parent->solid->vel) - vel->x,

--- a/src/player.c
+++ b/src/player.c
@@ -319,7 +319,6 @@ void player_newTutorial (void)
 void player_new (void)
 {
    int r;
-   int i;
 
    /* Set up new player. */
    player_newSetup( 0 );

--- a/src/player.c
+++ b/src/player.c
@@ -319,6 +319,7 @@ void player_newTutorial (void)
 void player_new (void)
 {
    int r;
+   int i;
 
    /* Set up new player. */
    player_newSetup( 0 );


### PR DESCRIPTION
This fixes a problem where starting a new game after having loaded
a previous save (in the same session) leads to the "known" status
of the previous save leaking into the new one. It should fix any
other such problems with flags if they crop up again, too.