### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ Install compile-time dependencies on Ubuntu 16.04 (and hopefully later) with:
 ```bash
 apt-get install build-essential automake libsdl2-dev libsdl2-image-dev \
 libgl1-mesa-dev libxml2-dev libfreetype6-dev libpng-dev libopenal-dev \
-libvorbis-dev binutils-dev libzip-dev libiberty-dev autopoint intltool
+libvorbis-dev binutils-dev libzip-dev libiberty-dev autopoint intltool libfontconfig-dev
 ```
 
 ### Other \*nix 


### PR DESCRIPTION
During compilation, the configure process failed due to missing development libraries for fontconfig. Add libfontconfig-dev to Ubuntu apt install line.