### PR TITLE
made autonav follow ships

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -55,7 +55,7 @@ int input_clickPos( SDL_Event *event, double x, double y, double zoom, double mi
 int input_clickedJump( int jump, int autonav );
 int input_clickedPlanet( int planet, int autonav );
 int input_clickedAsteroid( int field, int asteroid );
-int input_clickedPilot( unsigned int pilot );
+int input_clickedPilot( unsigned int pilot, int autonav );
 void input_clicked( void *clicked );
 int input_isDoubleClick( void *clicked );
 

--- a/src/player.c
+++ b/src/player.c
@@ -1890,6 +1890,10 @@ void player_targetSet( unsigned int id )
       player_soundPlayGUI( snd_target, 1 );
    }
    gui_setTarget();
+
+   /* The player should not continue following if the target pilot has been changed. */
+   if (player_isFlag(PLAYER_AUTONAV) && player.autonav == AUTONAV_PLT_FOLLOW)
+      player_autonavAbort(NULL);
 }
 
 

--- a/src/player_autonav.h
+++ b/src/player_autonav.h
@@ -17,6 +17,7 @@
 #define AUTONAV_JUMP_BRAKE      1 /**< Player is braking at a jump. */
 #define AUTONAV_POS_APPROACH   10 /**< Player is going to a position. */
 #define AUTONAV_PNT_APPROACH   11 /**< Player is going to a planet. */
+#define AUTONAV_PLT_FOLLOW    100 /**<Player is following a pilot. */
 
 
 void player_thinkAutonav( Pilot *pplayer, double dt );
@@ -30,6 +31,7 @@ int player_autonavShouldResetSpeed (void);
 void player_autonavStartWindow( unsigned int wid, char *str);
 void player_autonavPos( double x, double y );
 void player_autonavPnt( char *name );
+void player_autonavPil( unsigned int p );
 
 
 #endif /* PLAYER_AUTONAV_H */


### PR DESCRIPTION
If I remember right, this used to be a Todo on the old Wiki.
If you right-click on a pilot (via overlay or on screen), the autonav start following this current pilot (and enables time compression). This mainly aims at increasing the attractivity of escort missions. However, there are some limitations right now:

* overlay has still priority over default screen, which means that you cannot select a pilot by clicking right on screen if overlay is activated.
* The autonav follows the selected pilot, which means that if you target an other pilot while following an other one, the autonav aborts
* The autonav does not follow ships that jump away, it aborts when the target has disappeared
