### PR TITLE
Added "Fake ID" pirate "mission".

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -75,6 +75,14 @@
    <location>Computer</location>
   </avail>
  </mission>
+ <mission name="Fake ID">
+  <lua>pirate/fake_id</lua>
+  <avail>
+   <chance>100</chance>
+   <location>Computer</location>
+   <faction>Pirate</faction>
+  </avail>
+ </mission>
  <mission name="Cargo Rush">
   <lua>neutral/cargo_rush</lua>
   <avail>

--- a/dat/missions/pirate/empbounty_dead.lua
+++ b/dat/missions/pirate/empbounty_dead.lua
@@ -1,7 +1,6 @@
 --[[
 
    Pirate Empire bounty
-   Copyright 2014, 2015, 2019 Julie Marchant
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dat/missions/pirate/fake_id.lua
+++ b/dat/missions/pirate/fake_id.lua
@@ -1,0 +1,156 @@
+--[[
+
+   Fake ID
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--]] 
+
+include "numstring.lua"
+
+
+misn_title = _("Fake ID")
+misn_desc = _([[This fake ID will allow you to conduct business with all major locations where you are currently wanted. It will be as if you were a new person. However, committing any crime will risk discovery of your identity by authorities, no gains in reputation under your fake ID will ever improve your real name's reputation under any circumstance, and gaining too much reputation with factions where you are wanted can lead to the discovery of your true identity as well. Note that fake ID does not work on pirates, for whom your reputation will be affected as normal (whether good or bad).
+Cost: %s credits]])
+misn_reward = _("None")
+
+lowmoney = _("You don't have enough money to buy a fake ID. The price is %s credits.")
+
+noticed_onplanet = _([[During a routine check, you hand over your fake ID as usual, but the person checking your ID eyes it strangely for a time that seems to be periods long. Eventually you are handed your ID back, but this is not a good sign.
+    When you check, you see that the secrecy of your identity is in jeopardy. You're safe for now, but you make a mental note to prepare for the worst when you take off, because your fake ID probably won't be of any further use by then.]])
+
+noticed_offplanet = _("It seems your actions have led to the discovery of your identity. As a result, your fake ID is now useless.")
+
+
+factions = {
+   "Empire", "Goddard", "Dvaered", "Za'lek", "Sirius", "Soromid", "Frontier",
+   "Trader", "Miner"
+}
+misnvars = {
+   Empire = "_fcap_empire", Goddard = "_fcap_goddard",
+   Dvaered = "_fcap_dvaered", ["Za'lek"] = "_fcap_zalek",
+   Sirius = "_fcap_sirius", Soromid = "_fcap_soromid",
+   Frontier = "_fcap_frontier", Trader = "_fcap_trader",
+   Miner = "_fcap_miner"
+}
+orig_standing = {}
+orig_standing["__save"] = true
+orig_cap = {}
+orig_cap["__save"] = true
+
+temp_cap = 10
+next_discovered = false
+
+
+function create ()
+   local nhated = 0
+   for i, j in ipairs( factions ) do
+      if faction.get(j):playerStanding() < 0 then
+         nhated = nhated + 1
+      end
+   end
+   if nhated <= 0 then misn.finish( false ) end
+
+   credits = 50000 * nhated
+
+   misn.setTitle( misn_title )
+   misn.setDesc( misn_desc:format( numstring( credits ) ) )
+   misn.setReward( misn_reward )
+end
+
+
+function accept ()
+   if player.credits() < credits then
+      tk.msg( "", lowmoney:format( numstring( credits ) ) )
+      misn.finish()
+   end
+
+   player.pay( -credits )
+   misn.accept()
+
+   for i, j in ipairs( factions ) do
+      local f = faction.get(j)
+      if f:playerStanding() < 0 then
+         orig_standing[j] = f:playerStanding()
+         orig_cap[j] = var.peek( misnvars[j] )
+         var.push( misnvars[j], temp_cap )
+         f:setPlayerStanding( 0 )
+      end
+   end
+
+   landed = true
+   standhook = hook.standing( "standing" )
+   hook.takeoff( "takeoff" )
+   hook.land( "land" )
+end
+
+
+function standing( f, delta )
+   local fn = f:name()
+   if orig_standing[fn] ~= nil then
+      if delta >= 0 then
+         if var.peek( misnvars[fn] ) ~= temp_cap then
+            abort()
+         end
+      else
+         abort()
+      end
+   elseif fn == "Pirate" and delta >= 0 then
+      local sf = system.cur():faction()
+      if sf ~= nil and orig_standing[sf:name()] ~= nil then
+         -- We delay choice of when you are discovered to prevent players
+         -- from subverting the system to eliminate the risk.
+         if next_discovered then
+            abort()
+         else
+            next_discovered = rnd.rnd() < 0.1
+         end
+      end
+   end
+end
+
+
+function takeoff ()
+   landed = false
+end
+
+
+function land ()
+   landed = true
+end
+
+
+function abort ()
+   if standhook ~= nil then hook.rm(standhook) end
+   
+   for i, j in ipairs( factions ) do
+      if orig_standing[j] ~= nil then
+         if misnvars[j] ~= nil then
+            var.push( misnvars[j], orig_cap[j] )
+         end
+         faction.get(j):setPlayerStanding( orig_standing[j] )
+      end
+   end
+   
+   local msg = noticed_offplanet
+   if landed then
+      local f = planet.cur():faction()
+      if f ~= nil and orig_standing[f:name()] ~= nil then
+         msg = noticed_onplanet
+      end
+   end
+
+   tk.msg( "", msg )
+   misn.finish( false )
+end

--- a/dat/missions/rehab_common.lua
+++ b/dat/missions/rehab_common.lua
@@ -9,31 +9,28 @@
 
 include "dat/scripts/numstring.lua"
 
--- Localization, choosing a language if naev is translated for non-english-speaking locales.
-lang = naev.lang()
-if lang == "es" then
-else -- Default to English
-    misn_title = "%s Rehabilitation"
-    misn_desc = [[You may pay a fine for a chance to redeem yourself in the eyes of a faction you have offended. You may interact with this faction as if your reputation were neutral, but your reputation will not actually improve until you've regained their trust. ANY hostile action against this faction will immediately void this agreement.
+
+misn_title = _("%s Rehabilitation")
+misn_desc = _([[You may pay a fine for a chance to redeem yourself in the eyes of a faction you have offended. You may interact with this faction as if your reputation were neutral, but your reputation will not actually improve until you've regained their trust. ANY hostile action against this faction will immediately void this agreement.
 Faction: %s
-Cost: %s credits]]
-    misn_reward = "None."
-    
-    lowmoney = "You don't have enough money. You need at least %s credits to buy a cessation of hostilities with this faction."
-    accepted = [[Your application has been processed. The %s security forces will no longer attack you on sight. You may conduct your business in %s space again, but remember that you still have a criminal record! If you attack any traders, civilians or %s ships, or commit any other felony against this faction, you will immediately become their enemy again.
-    While this agreement is active your reputation will not change, but if you continue to behave properly and perform beneficial services, your past offenses will eventually be stricken from the record.]]
-    
-    failuretitle = "%s Rehabilitation Canceled"
-    failuretext = [[You have committed another offense against this faction! Your rehabilitation procedure has been canceled, and your reputation is once again bad. You may start another rehabilitation procedure at a later time.]]
-    
-    successtitle = "%s Rehabilitation Successful"
-    successtext = [[Congratulations, you have successfully worked your way back into good standing with this faction. Try not to relapse into your life of crime!]]
-    
-    osd_msg = {}
-    osd_msg[1] = "You need to gain %d more reputation"
-    osd_msg1 = "You need to gain %d more reputation"
-    osd_msg["_save"] = true
-end
+Cost: %s credits]])
+misn_reward = _("None")
+
+lowmoney = _("You don't have enough money. You need at least %s credits to buy a cessation of hostilities with this faction.")
+accepted = _([[Your application has been processed. The %s security forces will no longer attack you on sight. You may conduct your business in %s space again, but remember that you still have a criminal record! If you attack any traders, civilians or %s ships, or commit any other felony against this faction, you will immediately become their enemy again.
+While this agreement is active your reputation will not change, but if you continue to behave properly and perform beneficial services, your past offenses will eventually be stricken from the record.]])
+
+failuretitle = _("%s Rehabilitation Canceled")
+failuretext = _([[You have committed another offense against this faction! Your rehabilitation procedure has been canceled, and your reputation is once again bad. You may start another rehabilitation procedure at a later time.]])
+
+successtitle = _("%s Rehabilitation Successful")
+successtext = _([[Congratulations, you have successfully worked your way back into good standing with this faction. Try not to relapse into your life of crime!]])
+
+osd_msg = {}
+osd_msg[1] = _("You need to gain %d more reputation")
+osd_msg1 = _("You need to gain %d more reputation")
+osd_msg["__save"] = true
+
 
 function create()
     -- Note: this mission does not make any system claims.
@@ -60,7 +57,7 @@ end
 
 function accept()
     if player.credits() < fine then
-        tk.msg(lowmoneyformat(numstring(fine)))
+        tk.msg("", lowmoney:format(numstring(fine)))
         misn.finish()
     end
     


### PR DESCRIPTION
This is the same concept as rehabilitation missions, except that the
fake ID "mission" has no victory condition. It simply gives you a
fake reputation with the major factions that you can use to conduct
your business uninterrupted, but takes that away if you do too much
to get noticed.

Namely, you lose your fake ID if you ever wrong an affected faction
in any way (as with rehab missions), if you gain reputation on an
affected faction after its mission cap has been adjusted (i.e. doing
major campaigns for the faction, since that gets you attention which
means added scrutiny), and occasionally when you gain pirate
reputation within one of the affected factions' systems.

Of course, the effect is reversed when aborting the "mission", too.

This can serve three purposes:

1. To help pirate-aligned players travel and do pirate cargo missions more easily.
2. To allow former pirates or FLF pilots to give up on a life of piracy/terrorism.
3. As a part of some campaigns (like maybe the Thurion and/or Proteron campaigns).