### PR TITLE
Replaced jammer functionality with a replacement that uses ewarfare.

### DIFF
--- a/dat/outfits/activated/milspec_jammer.xml
+++ b/dat/outfits/activated/milspec_jammer.xml
@@ -10,9 +10,9 @@
   <limit>jammer</limit>
   <cpu>-8</cpu>
  </general>
- <specific type="jammer" group="7">
-  <range>230</range>
-  <power>50</power>
-  <energy>-30</energy>
+ <specific type="modification" group="7">
+  <active/>
+  <ew_hide>90</ew_hide>
+  <energy_loss>40</energy_loss>
  </specific>
 </outfit>

--- a/dat/outfits/activated/unicorp_jammer.xml
+++ b/dat/outfits/activated/unicorp_jammer.xml
@@ -10,9 +10,9 @@
   <limit>jammer</limit>
   <cpu>-4</cpu>
  </general>
- <specific type="jammer" group="7">
-  <range>170</range>
-  <power>35</power>
-  <energy>-15</energy>
+ <specific type="modification" group="7">
+  <active/>
+  <ew_hide>70</ew_hide>
+  <energy_loss>35</energy_loss>
  </specific>
 </outfit>

--- a/dat/outfits/modifiers/milspec_scrambler.xml
+++ b/dat/outfits/modifiers/milspec_scrambler.xml
@@ -10,7 +10,7 @@
   <cpu>-3</cpu>
  </general>
  <specific type="modification">
-  <energy_usage>12</energy_usage>
+  <energy_usage>6</energy_usage>
   <ew_hide>20</ew_hide>
  </specific>
 </outfit>

--- a/dat/outfits/modifiers/unicorp_scrambler.xml
+++ b/dat/outfits/modifiers/unicorp_scrambler.xml
@@ -10,7 +10,7 @@
   <cpu>-1</cpu>
  </general>
  <specific type="modification">
-  <energy_usage>10</energy_usage>
-  <ew_hide>15</ew_hide>
+  <energy_usage>4</energy_usage>
+  <ew_hide>10</ew_hide>
  </specific>
 </outfit>

--- a/dat/outfits/rockets/convulsion_missile.xml
+++ b/dat/outfits/rockets/convulsion_missile.xml
@@ -16,7 +16,7 @@
   <thrust>0</thrust>
   <turn>55</turn>
   <speed>850</speed>
-  <resist>10</resist>
+  <resist>50</resist>
   <damage>
    <type>shieldbreaker</type>
    <penetrate>5</penetrate>

--- a/dat/outfits/rockets/energy_cell_i.xml
+++ b/dat/outfits/rockets/energy_cell_i.xml
@@ -17,7 +17,7 @@
   <thrust>0</thrust>
   <turn>80</turn>
   <speed>600</speed>
-  <resist>5</resist>
+  <resist>100</resist>
   <energy>12.5</energy>
   <damage>
    <type>normal</type>

--- a/dat/outfits/rockets/energy_cell_ii.xml
+++ b/dat/outfits/rockets/energy_cell_ii.xml
@@ -17,7 +17,7 @@
   <thrust>0</thrust>
   <turn>80</turn>
   <speed>600</speed>
-  <resist>5</resist>
+  <resist>100</resist>
   <energy>40</energy>
   <damage>
    <type>normal</type>

--- a/dat/outfits/rockets/energy_cell_iii.xml
+++ b/dat/outfits/rockets/energy_cell_iii.xml
@@ -17,7 +17,7 @@
   <thrust>0</thrust>
   <turn>80</turn>
   <speed>600</speed>
-  <resist>5</resist>
+  <resist>100</resist>
   <energy>90</energy>
   <damage>
    <type>normal</type>

--- a/dat/outfits/rockets/fury_missile.xml
+++ b/dat/outfits/rockets/fury_missile.xml
@@ -16,7 +16,7 @@
   <thrust>0</thrust>
   <turn>50</turn>
   <speed>800</speed>
-  <resist>5</resist>
+  <resist>10</resist>
   <damage>
    <type>impact</type>
    <penetrate>5</penetrate>

--- a/dat/outfits/rockets/headhunter_missile.xml
+++ b/dat/outfits/rockets/headhunter_missile.xml
@@ -17,7 +17,7 @@
   <thrust>0</thrust>
   <turn>40</turn>
   <speed>600</speed>
-  <resist>10</resist>
+  <resist>20</resist>
   <damage>
    <type>impact</type>
    <penetrate>10</penetrate>

--- a/dat/outfits/rockets/medusa_missile.xml
+++ b/dat/outfits/rockets/medusa_missile.xml
@@ -16,7 +16,7 @@
   <thrust>0</thrust>
   <turn>50</turn>
   <speed>500</speed>
-  <resist>15</resist>
+  <resist>20</resist>
   <damage>
    <type>emp</type>
    <penetrate>15</penetrate>

--- a/dat/outfits/rockets/spearhead_missile.xml
+++ b/dat/outfits/rockets/spearhead_missile.xml
@@ -17,7 +17,7 @@
   <thrust>0</thrust>
   <turn>35</turn>
   <speed>600</speed>
-  <resist>12</resist>
+  <resist>20</resist>
   <damage>
    <type>shieldbreaker</type>
    <penetrate>20</penetrate>

--- a/src/ai.c
+++ b/src/ai.c
@@ -214,7 +214,6 @@ static int aiL_weapSet( lua_State *L ); /* weapset( number ) */
 static int aiL_shoot( lua_State *L ); /* shoot( number ); number = 1,2,3 */
 static int aiL_hascannons( lua_State *L ); /* bool hascannons() */
 static int aiL_hasturrets( lua_State *L ); /* bool hasturrets() */
-static int aiL_hasjammers( lua_State *L ); /* bool hasjammers() */
 static int aiL_hasafterburner( lua_State *L ); /* bool hasafterburner() */
 static int aiL_getenemy( lua_State *L ); /* number getenemy() */
 static int aiL_getenemy_size( lua_State *L ); /* number getenemy_size() */
@@ -303,7 +302,6 @@ static const luaL_Reg aiL_methods[] = {
    { "weapset", aiL_weapSet },
    { "hascannons", aiL_hascannons },
    { "hasturrets", aiL_hasturrets },
-   { "hasjammers", aiL_hasjammers },
    { "hasafterburner", aiL_hasafterburner },
    { "shoot", aiL_shoot },
    { "getenemy", aiL_getenemy },
@@ -2821,19 +2819,6 @@ static int aiL_hascannons( lua_State *L )
 static int aiL_hasturrets( lua_State *L )
 {
    lua_pushboolean( L, cur_pilot->nturrets > 0 );
-   return 1;
-}
-
-
-/**
- * @brief Does the pilot have jammers?
- *
- *    @luatreturn boolean True if the pilot has jammers.
- * @luafunc hasjammers()
- */
-static int aiL_hasjammers( lua_State *L )
-{
-   lua_pushboolean( L, cur_pilot->njammers > 0 );
    return 1;
 }
 

--- a/src/dev_outfit.c
+++ b/src/dev_outfit.c
@@ -241,7 +241,7 @@ void dout_csvAmmo( const char *path )
             "%f,%s,%f,%f\n",
             o->name, outfit_getType(o), o->license,
             o->mass, o->price,
-            o->u.amm.duration, o->u.amm.resist * 100, ai,
+            o->u.amm.duration, o->u.amm.resist, ai,
             o->u.amm.speed, o->u.amm.turn * 180 / M_PI, o->u.amm.thrust, o->u.amm.energy,
             dmg->penetration * 100, dtype_damageTypeToStr(dmg->type), dmg->damage, dmg->disable
             );

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -1162,8 +1162,7 @@ static int pilotL_weapset( lua_State *L )
             continue;
 
          /* Must be weapon. */
-         if (outfit_isJammer(o) ||
-               outfit_isMod(o) ||
+         if (outfit_isMod(o) ||
                outfit_isAfterburner(o))
             continue;
 
@@ -1380,8 +1379,7 @@ static int pilotL_weapsetHeat( lua_State *L )
             continue;
 
          /* Must be weapon. */
-         if (outfit_isJammer(o) ||
-               outfit_isMod(o) ||
+         if (outfit_isMod(o) ||
                outfit_isAfterburner(o))
             continue;
 
@@ -1470,8 +1468,7 @@ static int pilotL_actives( lua_State *L )
          continue;
       if (!o->active)
          continue;
-      if (!outfit_isJammer(o->outfit) &&
-            !outfit_isMod(o->outfit) &&
+      if (!outfit_isMod(o->outfit) &&
             !outfit_isAfterburner(o->outfit))
          continue;
 

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -2367,12 +2367,12 @@ static void outfit_launcherDesc( Outfit* o )
          "%.1f EPS [%.0f Energy]\n"
          "%.0f Range [%.1f duration]\n"
          "%.0f Maximum Speed\n"
-         "%.0f%% Jam Resistance\n"),
+         "%.1f%% Jam Resistance\n"),
          1. / o->u.lau.delay,
          o->u.lau.delay * a->u.amm.energy, a->u.amm.energy,
          outfit_range(a), a->u.amm.duration,
          a->u.amm.speed,
-         (a->u.amm.resist <= 0 ? 0. : (1. - 1. / a->u.amm.resist) * 100.) );
+         (a->u.amm.resist <= 0 ? 0. : (1. - 0.5 / a->u.amm.resist) * 100.) );
 }
 
 

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -1457,8 +1457,7 @@ static void outfit_parseSAmmo( Outfit* temp, const xmlNodePtr parent )
    } while (xml_nextNode(node));
 
    /* Post-processing */
-   temp->u.amm.resist /= 100.; /* Set it in per one */
-   temp->u.amm.turn   *= M_PI/180.; /* Convert to rad/s. */
+   temp->u.amm.turn *= M_PI/180.; /* Convert to rad/s. */
 
    /* Set short description. */
    temp->desc_short = malloc( OUTFIT_SHORTDESC_MAX );
@@ -2368,12 +2367,12 @@ static void outfit_launcherDesc( Outfit* o )
          "%.1f EPS [%.0f Energy]\n"
          "%.0f Range [%.1f duration]\n"
          "%.0f Maximum Speed\n"
-         "%.0f%% Jam resistance\n"),
+         "%.0f%% Jam Resistance\n"),
          1. / o->u.lau.delay,
          o->u.lau.delay * a->u.amm.energy, a->u.amm.energy,
          outfit_range(a), a->u.amm.duration,
          a->u.amm.speed,
-         a->u.amm.resist );
+         (a->u.amm.resist <= 0 ? 0. : (1. - 1. / a->u.amm.resist) * 100.) );
 }
 
 

--- a/src/outfit.h
+++ b/src/outfit.h
@@ -51,7 +51,6 @@ typedef enum OutfitType_ {
    OUTFIT_TYPE_TURRET_LAUNCHER, /**< Turret launcher. */
    OUTFIT_TYPE_MODIFICATION, /**< Modifies the ship base features. */
    OUTFIT_TYPE_AFTERBURNER, /**< Gives the ship afterburn capability. */
-   OUTFIT_TYPE_JAMMER, /**< Used to nullify seeker missiles. */
    OUTFIT_TYPE_FIGHTER_BAY, /**< Contains other ships. */
    OUTFIT_TYPE_FIGHTER, /**< Ship contained in FIGHTER_BAY. */
    OUTFIT_TYPE_MAP, /**< Gives the player more knowledge about systems. */
@@ -303,16 +302,6 @@ typedef struct OutfitLocalMapData_ {
 } OutfitLocalMapData;
 
 /**
- * @brief Represents a jammer.
- */
-typedef struct OutfitJammerData_ {
-   double energy;    /**< Energy it uses to run */
-   double range;     /**< Range it starts to do effect */
-   double range2;    /**< Range squared. */
-   double power;     /**< Strength of the effect. */
-} OutfitJammerData;
-
-/**
  * @brief Represents a GUI.
  */
 typedef struct OutfitGUIData_ {
@@ -354,7 +343,6 @@ typedef struct Outfit_ {
       OutfitAmmoData amm;         /**< AMMO */
       OutfitModificationData mod; /**< MODIFICATION */
       OutfitAfterburnerData afb;  /**< AFTERBURNER */
-      OutfitJammerData jam;       /**< JAMMER */
       OutfitFighterBayData bay;   /**< FIGHTER_BAY */
       OutfitFighterData fig;      /**< FIGHTER */
       OutfitMapData_t *map;       /**< MAP */
@@ -382,7 +370,6 @@ int outfit_isSeeker( const Outfit* o );
 int outfit_isTurret( const Outfit* o );
 int outfit_isMod( const Outfit* o );
 int outfit_isAfterburner( const Outfit* o );
-int outfit_isJammer( const Outfit* o );
 int outfit_isFighterBay( const Outfit* o );
 int outfit_isFighter( const Outfit* o );
 int outfit_isMap( const Outfit* o );

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -365,15 +365,10 @@ typedef struct Pilot_ {
    int ncannons;      /**< Number of cannons equipped. */
    int nturrets;      /**< Number of turrets equipped. */
    int nbeams;        /**< Number of beams equipped. */
-   int njammers;      /**< Number of jammers equipped. */
    int nafterburners; /**< Number of afterburners equipped. */
 
    /* For easier usage. */
    PilotOutfitSlot *afterburner; /**< the afterburner */
-
-   /* Jamming */
-   int jamming;      /**< Pilot is current jamming with at least a single jammer (used to
-                          speed up later checks in the code). */
 
    /* Weapon sets. */
    PilotWeaponSet weapon_sets[PILOT_WEAPON_SETS]; /**< All the weapon sets the pilot has. */

--- a/src/pilot_ew.c
+++ b/src/pilot_ew.c
@@ -285,7 +285,10 @@ double pilot_ewWeaponTrack( const Pilot *p, const Pilot *t, double track )
 {
    double limit, lead;
 
-   limit = track * p->ew_detect;
+   limit = track;
+   if (p != NULL)
+      limit *= p->ew_detect;
+
    if (t->ew_evasion * t->ew_movement < limit)
       lead = 1.;
    else

--- a/src/pilot_outfit.c
+++ b/src/pilot_outfit.c
@@ -309,8 +309,6 @@ int pilot_addOutfitRaw( Pilot* pilot, Outfit* outfit, PilotOutfitSlot *s )
       pilot->nturrets++;
    else if (outfit_isBolt(outfit))
       pilot->ncannons++;
-   else if (outfit_isJammer(outfit))
-      pilot->njammers++;
    else if (outfit_isAfterburner(outfit))
       pilot->nafterburners++;
 
@@ -942,7 +940,6 @@ void pilot_calcStats( Pilot* pilot )
     * Now add outfit changes
     */
    pilot->mass_outfit   = 0.;
-   pilot->jamming       = 0;
    for (i=0; i<pilot->noutfits; i++) {
       slot = pilot->outfits[i];
       o    = slot->outfit;
@@ -1002,10 +999,6 @@ void pilot_calcStats( Pilot* pilot )
       else if (outfit_isAfterburner(o)) { /* Afterburner */
          pilot_setFlag( pilot, PILOT_AFTERBURNER ); /* We use old school flags for this still... */
          pilot->energy_loss += pilot->afterburner->outfit->u.afb.energy; /* energy loss */
-      }
-      else if (outfit_isJammer(o)) { /* Jammer */
-         pilot->jamming        = 1;
-         pilot->energy_loss   += o->u.jam.energy;
       }
    }
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -325,7 +325,7 @@ static void think_seeker( Weapon* w, const double dt )
       return;
    }
 
-   ewtrack = pilot_ewWeaponTrack( pilot_get(w->parent), p, w->outfit->u.amm.resist );
+   ewtrack = MAX( w->outfit->u.amm.resist, pilot_ewWeaponTrack( pilot_get(w->parent), p, 1. ) );
 
    /* Handle by status. */
    switch (w->status) {
@@ -356,7 +356,7 @@ static void think_seeker( Weapon* w, const double dt )
          }
 
          /* Set turn. */
-         turn_max = w->outfit->u.amm.turn * (1. - ewtrack);
+         turn_max = w->outfit->u.amm.turn * ewtrack;
          weapon_setTurn( w, CLAMP( -turn_max, turn_max,
                   10 * diff * w->outfit->u.amm.turn ));
          break;
@@ -372,10 +372,10 @@ static void think_seeker( Weapon* w, const double dt )
 
    /* Limit speed here */
    w->real_vel = MIN( w->outfit->u.amm.speed, w->real_vel + w->outfit->u.amm.thrust*dt );
-   vect_pset( &w->solid->vel, (1. - ewtrack) * w->real_vel, w->solid->dir );
+   vect_pset( &w->solid->vel, ewtrack * w->real_vel, w->solid->dir );
 
    /* Modulate max speed. */
-   //w->solid->speed_max = w->outfit->u.amm.speed * (1. - ewtrack);
+   //w->solid->speed_max = w->outfit->u.amm.speed * ewtrack;
 }
 
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -325,7 +325,7 @@ static void think_seeker( Weapon* w, const double dt )
       return;
    }
 
-   ewtrack = MAX( w->outfit->u.amm.resist, pilot_ewWeaponTrack( pilot_get(w->parent), p, 1. ) );
+   ewtrack = pilot_ewWeaponTrack( pilot_get(w->parent), p, w->outfit->u.amm.resist );
 
    /* Handle by status. */
    switch (w->status) {
@@ -372,7 +372,7 @@ static void think_seeker( Weapon* w, const double dt )
 
    /* Limit speed here */
    w->real_vel = MIN( w->outfit->u.amm.speed, w->real_vel + w->outfit->u.amm.thrust*dt );
-   vect_pset( &w->solid->vel, ewtrack * w->real_vel, w->solid->dir );
+   vect_pset( &w->solid->vel, /* ewtrack * */ w->real_vel, w->solid->dir );
 
    /* Modulate max speed. */
    //w->solid->speed_max = w->outfit->u.amm.speed * ewtrack;

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -313,6 +313,7 @@ static void think_seeker( Weapon* w, const double dt )
    Pilot *p;
    Vector2d v;
    double t, turn_max;
+   double ewtrack;
 
    if (w->target == w->parent)
       return; /* no self shooting */
@@ -323,6 +324,8 @@ static void think_seeker( Weapon* w, const double dt )
       weapon_setTurn( w, 0. );
       return;
    }
+
+   ewtrack = pilot_ewWeaponTrack( pilot_get(w->parent), p, w->outfit->u.amm.resist );
 
    /* Handle by status. */
    switch (w->status) {
@@ -353,7 +356,7 @@ static void think_seeker( Weapon* w, const double dt )
          }
 
          /* Set turn. */
-         turn_max = w->outfit->u.amm.turn * (1. - p->ew_hide);
+         turn_max = w->outfit->u.amm.turn * (1. - ewtrack);
          weapon_setTurn( w, CLAMP( -turn_max, turn_max,
                   10 * diff * w->outfit->u.amm.turn ));
          break;
@@ -369,10 +372,10 @@ static void think_seeker( Weapon* w, const double dt )
 
    /* Limit speed here */
    w->real_vel = MIN( w->outfit->u.amm.speed, w->real_vel + w->outfit->u.amm.thrust*dt );
-   vect_pset( &w->solid->vel, (1. - p->ew_hide) * w->real_vel, w->solid->dir );
+   vect_pset( &w->solid->vel, (1. - ewtrack) * w->real_vel, w->solid->dir );
 
    /* Modulate max speed. */
-   //w->solid->speed_max = w->outfit->u.amm.speed * (1. - p->ew_hide);
+   //w->solid->speed_max = w->outfit->u.amm.speed * (1. - ewtrack);
 }
 
 


### PR DESCRIPTION
What I've done here is change jammers to simple ewarfare-enhancing activated outfits, and replace the existing jam functionality with one that uses ewarfare. I needed some help from @bobbens for this, so thank you. 😛

The "Jam Resistance" value of missiles is now used as a "tracking" value to determine the missile's turn rate. I also updated the way jam resistance is displayed to more accurately represent how it affects jamming.

The numbers I picked are more or less ballparks, but I did test them a bit to make sure they're at least sane. They may need further adjustment. Choosing the right numbers is kind of hard because the way ewarfare is calculated is complicated / poorly documented and the way tracking works is dependent on that (tracking effectively works as a double-divisor for the relevant ewarfare info).

Worth noting: this removes the reduction of speed that jammers had on missiles. The main reason I did this is because I removed the bit of only affecting missiles in a certain range, and without that reducing speed effectively causes missile range to plummet. I decided it wasn't really worth it, so I left it out; jamming missiles via ewarfare is all about making them less maneuverable (slower turn rate).