### PR TITLE
Made ending fake ID include any changes to rep caps in the restoration of rep.

### DIFF
--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -78,6 +78,7 @@
  <mission name="Fake ID">
   <lua>pirate/fake_id</lua>
   <avail>
+   <priority>10</priority>
    <chance>100</chance>
    <location>Computer</location>
    <faction>Pirate</faction>

--- a/dat/missions/pirate/fake_id.lua
+++ b/dat/missions/pirate/fake_id.lua
@@ -137,7 +137,7 @@ function abort ()
    for i, j in ipairs( factions ) do
       if orig_standing[j] ~= nil then
          if misnvars[j] ~= nil then
-            var.push( misnvars[j], orig_cap[j] )
+            var.push( misnvars[j], orig_cap[j] + var.peek( misnvars[j] ) - temp_cap )
          end
          faction.get(j):setPlayerStanding( orig_standing[j] )
       end


### PR DESCRIPTION
Also set the Fake ID priority lower so it appears at the top of the list.