### PR TITLE
Added text explaining what to press to autohail.

### DIFF
--- a/dat/event.xml
+++ b/dat/event.xml
@@ -80,7 +80,7 @@
  <event name="Baroncomm_baron">
   <lua>neutral/baron_comm</lua>
   <trigger>enter</trigger>
-  <chance>100</chance>
+  <chance>4</chance>
   <cond>
    not var.peek("baron_hated") and
    not player.misnDone("Baron") and

--- a/src/input.c
+++ b/src/input.c
@@ -479,9 +479,10 @@ SDL_Keycode input_getKeybind( const char *keybind, KeybindType *type, SDL_Keymod
  * @brief Gets the display name of a keybind
  *
  *    @param[in] keybind Name of the keybinding to get display name of.
- *    @param[out] buf Buffer to write the display name to. 
+ *    @param[out] buf Buffer to write the display name to.
+ *    @param[in] len Length of buffer.
  */
-void input_getKeybindDisplay( const char *keybind, char *buf )
+void input_getKeybindDisplay( const char *keybind, char *buf, int len )
 {
    int p;
    SDL_Keycode key;
@@ -493,49 +494,48 @@ void input_getKeybindDisplay( const char *keybind, char *buf )
 
    /* Handle type. */
    switch (type) {
+      case KEYBIND_NULL:
+         strncpy( buf, gettext_noop("Not bound"), len );
+         break;
+
       case KEYBIND_KEYBOARD:
          p = 0;
          /* Handle mod. */
          if ((mod != NMOD_NONE) && (mod != NMOD_ALL))
-            p += nsnprintf( &buf[p], sizeof(buf)-p, "%s + ", input_modToText(mod) );
+            p += nsnprintf( &buf[p], len-p, "%s + ", input_modToText(mod) );
          /* Print key. */
          if (nstd_isalpha(key))
-            p += nsnprintf( &buf[p], sizeof(buf)-p, "%c", nstd_toupper(key) );
+            p += nsnprintf( &buf[p], len-p, "%c", nstd_toupper(key) );
          else
-            p += nsnprintf( &buf[p], sizeof(buf)-p, "%s", SDL_GetKeyName(key) );
+            p += nsnprintf( &buf[p], len-p, "%s", SDL_GetKeyName(key) );
          break;
 
       case KEYBIND_JBUTTON:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy button %d"), key );
+         nsnprintf( buf, len, gettext_noop("joy button %d"), key );
          break;
 
       case KEYBIND_JHAT_UP:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d up"), key );
+         nsnprintf( buf, len, gettext_noop("joy hat %d up"), key );
          break;
 
       case KEYBIND_JHAT_DOWN:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d down"), key );
+         nsnprintf( buf, len, gettext_noop("joy hat %d down"), key );
          break;
 
       case KEYBIND_JHAT_LEFT:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d left"), key );
+         nsnprintf( buf, len, gettext_noop("joy hat %d left"), key );
          break;
 
       case KEYBIND_JHAT_RIGHT:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d right"), key );
+         nsnprintf( buf, len, gettext_noop("joy hat %d right"), key );
          break;
 
       case KEYBIND_JAXISPOS:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy axis %d-"), key );
+         nsnprintf( buf, len, gettext_noop("joy axis %d-"), key );
          break;
 
       case KEYBIND_JAXISNEG:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy axis %d+"), key );
-         break;
-
-      case KEYBIND_NULL:
-      default:
-         strncpy( buf, gettext_noop("Not bound"), sizeof(buf) );
+         nsnprintf( buf, len, gettext_noop("joy axis %d+"), key );
          break;
    }
 }

--- a/src/input.c
+++ b/src/input.c
@@ -32,6 +32,7 @@
 #include "camera.h"
 #include "map_overlay.h"
 #include "hook.h"
+#include "nstring.h"
 
 
 #define MOUSE_HIDE   ( 3.) /**< Time in seconds to wait before hiding mouse again. */
@@ -452,7 +453,7 @@ void input_setKeybind( const char *keybind, KeybindType type, SDL_Keycode key, S
 /**
  * @brief Gets the value of a keybind.
  *
- *    @brief keybind Name of the keybinding to get.
+ *    @param[in] keybind Name of the keybinding to get.
  *    @param[out] type Stores the type of the keybinding.
  *    @param[out] mod Stores the modifiers used with the keybinding.
  *    @return The key associated with the keybinding.
@@ -475,9 +476,75 @@ SDL_Keycode input_getKeybind( const char *keybind, KeybindType *type, SDL_Keymod
 
 
 /**
+ * @brief Gets the display name of a keybind
+ *
+ *    @param[in] keybind Name of the keybinding to get display name of.
+ *    @param[out] buf Buffer to write the display name to. 
+ */
+void input_getKeybindDisplay( const char *keybind, char *buf )
+{
+   int p;
+   SDL_Keycode key;
+   KeybindType type;
+   SDL_Keymod mod;
+
+   /* Get the keybinding. */
+   key = input_getKeybind( keybind, &type, &mod );
+
+   /* Handle type. */
+   switch (type) {
+      case KEYBIND_KEYBOARD:
+         p = 0;
+         /* Handle mod. */
+         if ((mod != NMOD_NONE) && (mod != NMOD_ALL))
+            p += nsnprintf( &buf[p], sizeof(buf)-p, "%s + ", input_modToText(mod) );
+         /* Print key. */
+         if (nstd_isalpha(key))
+            p += nsnprintf( &buf[p], sizeof(buf)-p, "%c", nstd_toupper(key) );
+         else
+            p += nsnprintf( &buf[p], sizeof(buf)-p, "%s", SDL_GetKeyName(key) );
+         break;
+
+      case KEYBIND_JBUTTON:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy button %d"), key );
+         break;
+
+      case KEYBIND_JHAT_UP:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d up"), key );
+         break;
+
+      case KEYBIND_JHAT_DOWN:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d down"), key );
+         break;
+
+      case KEYBIND_JHAT_LEFT:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d left"), key );
+         break;
+
+      case KEYBIND_JHAT_RIGHT:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d right"), key );
+         break;
+
+      case KEYBIND_JAXISPOS:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy axis %d-"), key );
+         break;
+
+      case KEYBIND_JAXISNEG:
+         nsnprintf( buf, sizeof(buf), gettext_noop("joy axis %d+"), key );
+         break;
+
+      case KEYBIND_NULL:
+      default:
+         strncpy( buf, gettext_noop("Not bound"), sizeof(buf) );
+         break;
+   }
+}
+
+
+/**
  * @brief Gets the human readable version of mod.
  *
- *    @brief mod Mod to get human readable version from.
+ *    @param mod Mod to get human readable version from.
  *    @return Human readable version of mod.
  */
 const char* input_modToText( SDL_Keymod mod )

--- a/src/input.h
+++ b/src/input.h
@@ -41,7 +41,7 @@ SDL_Keycode input_keyConv( const char *name );
 void input_setKeybind( const char *keybind, KeybindType type, SDL_Keycode key, SDL_Keymod mod );
 const char *input_modToText( SDL_Keymod mod );
 SDL_Keycode input_getKeybind( const char *keybind, KeybindType *type, SDL_Keymod *mod );
-void input_getKeybindDisplay( const char *keybind, char *buf );
+void input_getKeybindDisplay( const char *keybind, char *buf, int len );
 const char *input_getKeybindDescription( const char *keybind );
 const char *input_keyAlreadyBound( KeybindType type, SDL_Keycode key, SDL_Keymod mod );
 

--- a/src/input.h
+++ b/src/input.h
@@ -39,9 +39,10 @@ typedef enum {
 void input_setDefault( int wasd );
 SDL_Keycode input_keyConv( const char *name );
 void input_setKeybind( const char *keybind, KeybindType type, SDL_Keycode key, SDL_Keymod mod );
-const char* input_modToText( SDL_Keymod mod );
+const char *input_modToText( SDL_Keymod mod );
 SDL_Keycode input_getKeybind( const char *keybind, KeybindType *type, SDL_Keymod *mod );
-const char* input_getKeybindDescription( const char *keybind );
+void input_getKeybindDisplay( const char *keybind, char *buf );
+const char *input_getKeybindDescription( const char *keybind );
 const char *input_keyAlreadyBound( KeybindType type, SDL_Keycode key, SDL_Keymod mod );
 
 /*

--- a/src/nlua_naev.c
+++ b/src/nlua_naev.c
@@ -116,7 +116,7 @@ static int naev_keyGet( lua_State *L )
    /* Get parameters. */
    keyname = luaL_checkstring( L, 1 );
 
-   input_getKeybindDisplay( keyname, buf );
+   input_getKeybindDisplay( keyname, buf, sizeof(buf) );
    lua_pushstring( L, buf );
 
    return 1;

--- a/src/nlua_naev.c
+++ b/src/nlua_naev.c
@@ -110,73 +110,14 @@ static int naev_ticks( lua_State *L )
  */
 static int naev_keyGet( lua_State *L )
 {
-   int p;
    const char *keyname;
-   SDL_Keycode key;
-   KeybindType type;
-   SDL_Keymod mod;
    char buf[128];
 
    /* Get parameters. */
    keyname = luaL_checkstring( L, 1 );
 
-   /* Get the keybinding. */
-   key = input_getKeybind( keyname, &type, &mod );
-
-   /* Handle type. */
-   switch (type) {
-      case KEYBIND_NULL:
-         lua_pushstring( L, gettext_noop("Not bound") );
-         break;
-
-      case KEYBIND_KEYBOARD:
-         p = 0;
-         /* Handle mod. */
-         if ((mod != NMOD_NONE) && (mod != NMOD_ALL))
-            p += nsnprintf( &buf[p], sizeof(buf)-p, "%s + ", input_modToText(mod) );
-         /* Print key. */
-         if (nstd_isalpha(key))
-            p += nsnprintf( &buf[p], sizeof(buf)-p, "%c", nstd_toupper(key) );
-         else
-            p += nsnprintf( &buf[p], sizeof(buf)-p, "%s", SDL_GetKeyName(key) );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JBUTTON:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy button %d"), key );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JHAT_UP:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d up"), key );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JHAT_DOWN:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d down"), key );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JHAT_LEFT:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d left"), key );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JHAT_RIGHT:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy hat %d right"), key );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JAXISPOS:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy axis %d-"), key );
-         lua_pushstring( L, buf );
-         break;
-
-      case KEYBIND_JAXISNEG:
-         nsnprintf( buf, sizeof(buf), gettext_noop("joy axis %d+"), key );
-         lua_pushstring( L, buf );
-         break;
-   }
+   input_getKeybindDisplay( keyname, buf );
+   lua_pushstring( L, buf );
 
    return 1;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -1684,10 +1684,16 @@ double player_dt_default (void)
  */
 void player_hailStart (void)
 {
+   char msg[1024];
+   char buf[128];
+
    player_hailCounter = 5;
 
-   /* Abort autonav. */
-   player_messageRaw(_("\arReceiving hail!"));
+   input_getKeybindDisplay( "autohail", buf );
+   nsnprintf( msg, sizeof(msg), buf );
+   player_messageRaw(_("\arReceiving hail! Press %s to respond."));
+
+   /* Reset speed. */
    player_autonavResetSpeed();
    player.autonav_timer = MAX( player.autonav_timer, 10. );
 }

--- a/src/player.c
+++ b/src/player.c
@@ -1689,7 +1689,7 @@ void player_hailStart (void)
 
    player_hailCounter = 5;
 
-   input_getKeybindDisplay( "autohail", buf );
+   input_getKeybindDisplay( "autohail", buf, sizeof(buf) );
    nsnprintf( msg, sizeof(msg), _("\arReceiving hail! Press %s to respond."), buf );
    player_messageRaw( msg );
 

--- a/src/player.c
+++ b/src/player.c
@@ -1690,8 +1690,8 @@ void player_hailStart (void)
    player_hailCounter = 5;
 
    input_getKeybindDisplay( "autohail", buf );
-   nsnprintf( msg, sizeof(msg), buf );
-   player_messageRaw(_("\arReceiving hail! Press %s to respond."));
+   nsnprintf( msg, sizeof(msg), _("\arReceiving hail! Press %s to respond."), buf );
+   player_messageRaw( msg );
 
    /* Reset speed. */
    player_autonavResetSpeed();


### PR DESCRIPTION
This is in draft mode because, ah, it's not working. I have no idea why, though. With the default autohail bind (Ctrl+Y), I get it displaying at "Ctrl + " (without the "Y").

This also has a bugfix though: I accidentally left the chance of the baron event happening at 100% rather than 4% as it should be (this was a temporary value for testing). Sorry about that.