### PR TITLE
Pass SDL_WINDOW_ALLOW_HIGHDPI when creating window (#970)

### DIFF
--- a/src/naev.c
+++ b/src/naev.c
@@ -176,6 +176,7 @@ void naev_quit (void)
 int main( int argc, char** argv )
 {
    char buf[PATH_MAX];
+   int w, h;
 
    if (!log_isTerminal())
       log_copy(1);
@@ -479,7 +480,8 @@ int main( int argc, char** argv )
          }
          else if (event.type == SDL_WINDOWEVENT &&
                event.window.event == SDL_WINDOWEVENT_RESIZED) {
-            naev_resize( event.window.data1, event.window.data2 );
+            SDL_GL_GetDrawableSize( gl_screen.window, &w, &h );
+            naev_resize( w, h );
             continue;
          }
          input_handle(&event); /* handles all the events and player keybinds */
@@ -781,7 +783,7 @@ void naev_resize( int w, int h )
 {
    /* Auto-detect window size. */
    if ((w < 0.) && (h < 0.))
-      SDL_GetWindowSize( gl_screen.window, &w, &h );
+      SDL_GL_GetDrawableSize( gl_screen.window, &w, &h );
 
    /* Nothing to do. */
    if ((w == gl_screen.rw) && (h == gl_screen.rh))

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -388,13 +388,14 @@ static int gl_createWindow( unsigned int flags )
    /* Create the window. */
    gl_screen.window = SDL_CreateWindow( APPNAME,
          SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-         SCREEN_W, SCREEN_H, flags | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE );
+         800, 600, flags | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
+                                   | SDL_WINDOW_ALLOW_HIGHDPI );
    if (gl_screen.window == NULL)
       ERR(_("Unable to create window!"));
 
    /* Reinitialize resolution parameters. */
    if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP)
-      SDL_GetWindowSize( gl_screen.window, &w, &h );
+      SDL_GL_GetDrawableSize( gl_screen.window, &w, &h );
 
    /* Set focus loss behaviour. */
    SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS,
@@ -505,7 +506,17 @@ static int gl_defState (void)
  */
 static int gl_setupScaling (void)
 {
-   int minwh;
+   int minwh, drawable_w, drawable_h, window_w, window_h;
+
+   /* Calculate scale factor, if OS has native HiDPI scaling. */
+   SDL_GL_GetDrawableSize(gl_screen.window, &drawable_w, &drawable_h);
+   SDL_GetWindowSize(gl_screen.window, &window_w, &window_h);
+   gl_screen.dwscale = (double)window_w / (double)drawable_w;
+   gl_screen.dhscale = (double)window_h / (double)drawable_h;
+
+   /* Combine scale factor from OS with the one in Naev's config */
+   gl_screen.scale *= fmax(gl_screen.dwscale, gl_screen.dhscale);
+
    /* New window is real window scaled. */
    gl_screen.nw = (double)gl_screen.rw * gl_screen.scale;
    gl_screen.nh = (double)gl_screen.rh * gl_screen.scale;
@@ -717,6 +728,9 @@ void gl_defViewport (void)
  */
 void gl_windowToScreenPos( int *sx, int *sy, int wx, int wy )
 {
+   wx /= gl_screen.dwscale;
+   wy /= gl_screen.dhscale;
+
    *sx = gl_screen.mxscale * (double)wx - (double)gl_screen.x;
    *sy = gl_screen.myscale * (double)(gl_screen.rh - wy) - (double)gl_screen.y;
 }
@@ -729,6 +743,9 @@ void gl_screenToWindowPos( int *wx, int *wy, int sx, int sy )
 {
    *wx = (sx + (double)gl_screen.x) / gl_screen.mxscale;
    *wy = (double)gl_screen.rh - (sy + (double)gl_screen.y) / gl_screen.myscale;
+
+   *wx *= gl_screen.dwscale;
+   *wy *= gl_screen.dhscale;
 }
 
 

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -71,6 +71,8 @@ typedef struct glInfo_ {
    double scale; /**< Scale factor. */
    double wscale; /**< Width scale factor. */
    double hscale; /**< Height scale factor. */
+   double dwscale; /**< Drawable height scale factor. */
+   double dhscale; /**< Drawable width scale factor. */
    double mxscale; /**< Mouse X scale factor. */
    double myscale; /**< Mouse y scale factor. */
    int depth; /**< Depth in bpp */

--- a/src/options.c
+++ b/src/options.c
@@ -1346,7 +1346,7 @@ static int opt_videoSave( unsigned int wid, char *str )
    SDL_DisplayMode current;
 
    changed = 0;
-   SDL_GetWindowSize( gl_screen.window, &rw, &rh );
+   SDL_GL_GetDrawableSize( gl_screen.window, &rw, &rh );
    SDL_GetWindowDisplayMode( gl_screen.window, &current );
    mode = (conf.modesetting) ?
          SDL_WINDOW_FULLSCREEN : SDL_WINDOW_FULLSCREEN_DESKTOP;


### PR DESCRIPTION
Used on MacOS and (at least some) Wayland compositors.

Without this, the program will be rendered at a low DPI and scaled up.

#970