### PR TITLE
Several fixes to the "Heretic" campaign (practically a rewrite)

### DIFF
--- a/dat/events/sirius/preach.lua
+++ b/dat/events/sirius/preach.lua
@@ -364,7 +364,7 @@ function cleanup()
    player.pilot():control(false)
    camera.set()
    player.cinematics(false)
-   evt.finish()
+   evt.finish(true)
 end
 
 --oops, it seems the preacher died. End gracefully
@@ -383,7 +383,7 @@ function badCleanup()
       follower=survivors[rnd.rnd(1,#survivors)]
       follower:broadcast(preacherDead[rnd.rnd(1,#preacherDead)],true)
    end
-   evt.finish()
+   evt.finish(false)
 end
 
 --the preacher has landed. Land all his followers too
@@ -395,7 +395,7 @@ function landCleanup()
          j:land(target)
       end
    end
-   evt.finish()
+   evt.finish(true)
 end
 
 --the preacher has jumped. Jump all his followers too
@@ -408,5 +408,5 @@ function jumpCleanup()
          j:hyperspace(target,true) --attack back as they move away?
       end
    end
-   evt.finish()
+   evt.finish(true)
 end

--- a/dat/faction.xml
+++ b/dat/faction.xml
@@ -132,7 +132,6 @@
    <enemy>Goddard</enemy>
    <enemy>Proteron</enemy>
    <enemy>Thurion</enemy>
-   <enemy>Nasin</enemy>
    <enemy>Comingout_associates</enemy>
   </enemies>
  </faction>
@@ -302,7 +301,6 @@
    <enemy>Trader</enemy>
    <enemy>Miner</enemy>
    <enemy>Independent</enemy>
-   <enemy>Nasin</enemy>
   </enemies>
  </faction>
  <faction>
@@ -478,8 +476,6 @@
   <player>0</player>
   <enemies>
    <enemy>Sirius</enemy>
-   <enemy>Pirate</enemy>
-   <enemy>Wanted Pirate</enemy>
   </enemies>
  </faction>
  <faction>

--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -452,6 +452,75 @@
    <done>Empire Shipping 3</done>
   </avail>
  </mission>
+ <mission name="The Gauntlet">
+  <lua>sirius/heretic/heretic0</lua>
+  <flags>
+   <unique />
+  </flags>
+  <avail>
+   <priority>3</priority>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
+   <chance>50</chance>
+   <location>Bar</location>
+   <faction>Sirius</faction>
+  </avail>
+ </mission>
+ <mission name="The Return">
+  <lua>sirius/heretic/heretic1</lua>
+  <flags>
+   <unique />
+  </flags>
+  <avail>
+   <priority>3</priority>
+   <done>The Gauntlet</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
+   <chance>100</chance>
+   <location>Bar</location>
+   <planet>Margot</planet>
+  </avail>
+ </mission>
+ <mission name="The Patrol">
+  <lua>sirius/heretic/heretic2</lua>
+  <flags>
+   <unique />
+  </flags>
+  <avail>
+   <priority>3</priority>
+   <done>The Return</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
+   <chance>100</chance>
+   <location>Bar</location>
+   <planet>The Wringer</planet>
+  </avail>
+ </mission>
+ <mission name="The Assault">
+  <lua>sirius/heretic/heretic3</lua>
+  <flags>
+   <unique />
+  </flags>
+  <avail>
+   <priority>3</priority>
+   <done>The Patrol</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
+   <chance>100</chance>
+   <location>Bar</location>
+   <planet>The Wringer</planet>
+  </avail>
+ </mission>
+ <mission name="The Egress">
+  <lua>sirius/heretic/heretic4</lua>
+  <flags>
+   <unique />
+  </flags>
+  <avail>
+   <priority>3</priority>
+   <done>The Assault</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
+   <chance>100</chance>
+   <location>Bar</location>
+   <planet>The Wringer</planet>
+  </avail>
+ </mission>
  <mission name="Sirian Bounty">
   <lua>sirius/achack/achack01</lua>
   <flags>
@@ -694,6 +763,23 @@
    <location>Bar</location>
   </avail>
  </mission>
+ <mission name="Anxious Merchant">
+  <lua>trader/anxiousmerchant</lua>
+  <avail>
+   <priority>3</priority>
+   <chance>1</chance>
+   <location>Bar</location>
+   <faction>Dvaered</faction>
+   <faction>Empire</faction>
+   <faction>Frontier</faction>
+   <faction>Goddard</faction>
+   <faction>Independent</faction>
+   <faction>Sirius</faction>
+   <faction>Soromid</faction>
+   <faction>Trader</faction>
+   <faction>Za'lek</faction>
+  </avail>
+ </mission>
  <mission name="Empire Shipping">
   <lua>empire/es_cargo</lua>
   <avail>
@@ -769,92 +855,6 @@
    <faction>FLF</faction>
    <faction>Frontier</faction>
    <cond>diff.isApplied("flf_vs_empire") and not diff.isApplied( "flf_dead" )</cond>
-  </avail>
- </mission>
- <mission name="The Gauntlet">
-  <lua>sirius/heretic/heretic0</lua>
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>3</priority>
-   <cond>faction.playerStanding("Nasin") >= 0</cond>
-   <chance>50</chance>
-   <location>Bar</location>
-   <faction>Sirius</faction>
-  </avail>
- </mission>
- <mission name="The Return">
-  <lua>sirius/heretic/heretic1</lua>
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>3</priority>
-   <done>The Gauntlet</done>
-   <cond>faction.playerStanding("Nasin") >= 0</cond>
-   <chance>100</chance>
-   <location>Bar</location>
-   <planet>Margot</planet>
-  </avail>
- </mission>
- <mission name="The Patrol">
-  <lua>sirius/heretic/heretic2</lua>
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>3</priority>
-   <done>The Return</done>
-   <cond>faction.playerStanding("Nasin") >= 0</cond>
-   <chance>100</chance>
-   <location>Bar</location>
-   <planet>The Wringer</planet>
-  </avail>
- </mission>
- <mission name="The Assault">
-  <lua>sirius/heretic/heretic3</lua>
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>3</priority>
-   <done>The Patrol</done>
-   <cond>faction.playerStanding("Nasin") >= 0</cond>
-   <chance>100</chance>
-   <location>Bar</location>
-   <planet>The Wringer</planet>
-  </avail>
- </mission>
- <mission name="The Egress">
-  <lua>sirius/heretic/heretic4</lua>
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>3</priority>
-   <done>The Assault</done>
-   <cond>faction.playerStanding("Nasin") >= 0</cond>
-   <chance>100</chance>
-   <location>Bar</location>
-   <planet>The Wringer</planet>
-  </avail>
- </mission>
- <mission name="Anxious Merchant">
-  <lua>trader/anxiousmerchant</lua>
-  <avail>
-   <priority>3</priority>
-   <chance>1</chance>
-   <location>Bar</location>
-   <faction>Dvaered</faction>
-   <faction>Empire</faction>
-   <faction>Frontier</faction>
-   <faction>Goddard</faction>
-   <faction>Independent</faction>
-   <faction>Sirius</faction>
-   <faction>Soromid</faction>
-   <faction>Trader</faction>
-   <faction>Za'lek</faction>
   </avail>
  </mission>
  <mission name="Racing Skills 2">

--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -778,7 +778,7 @@
   </flags>
   <avail>
    <priority>3</priority>
-   <cond>var.peek("heretic_misn_tracker") == nil</cond>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
    <chance>50</chance>
    <location>Bar</location>
    <faction>Sirius</faction>
@@ -791,7 +791,8 @@
   </flags>
   <avail>
    <priority>3</priority>
-   <cond>var.peek("heretic_misn_tracker") == 1</cond>
+   <done>The Gauntlet</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
    <chance>100</chance>
    <location>Bar</location>
    <planet>Margot</planet>
@@ -804,7 +805,8 @@
   </flags>
   <avail>
    <priority>3</priority>
-   <cond>var.peek("heretic_misn_tracker") == 2</cond>
+   <done>The Return</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
    <chance>100</chance>
    <location>Bar</location>
    <planet>The Wringer</planet>
@@ -818,6 +820,7 @@
   <avail>
    <priority>3</priority>
    <done>The Patrol</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
    <chance>100</chance>
    <location>Bar</location>
    <planet>The Wringer</planet>
@@ -830,7 +833,8 @@
   </flags>
   <avail>
    <priority>3</priority>
-   <cond>var.peek("heretic_misn_tracker") == 4</cond>
+   <done>The Assault</done>
+   <cond>faction.playerStanding("Nasin") >= 0</cond>
    <chance>100</chance>
    <location>Bar</location>
    <planet>The Wringer</planet>

--- a/dat/missions/sirius/heretic/heretic0.lua
+++ b/dat/missions/sirius/heretic/heretic0.lua
@@ -8,34 +8,25 @@ include "dat/scripts/numstring.lua"
     
 --the intro messages
 bmsg = {}
-bmsg[1] = _([[You walk up to a scrappy little man leaning against the bar. You sit next to him, and he eyes you up and down. You return the stare cooly. Lackadaisically, he strikes up a converrsation.
-    "Good weather on %s these days, I hear." 
-    "I hear nothing but good things about %s." you reply, badly feigning interest. You order a drink, as he takes a gulp of his.
-    He looks at you, sizing you up. He probably has been waiting for someone to set next to him all day. "You look like a man in need of a couple spare credits. I have a, uhh, shipment that needs getting to %s. Are you interested? Thing is, it's not exactly... legal. Pay is good though. All you need to know," he continues, "is that someone will be at the starport in %s waiting for this shipment. And they got credits. %s credits. Just for you, kiddo, if you want."
-    You get your drink, a greenish slimy-looking thing called a "tartar coobadu", and decide you just have to ask. "What exactly is this shipment?"]])
-bmsg[2] = _([[He almost looks suprised at the question. He motions you to a corner table as if to tell you to go there, but forcifully leads you. People seem to be avoiding this table, probably because of a peculiar vomit-odor that is wafting from somewhere underneath. He sits you down rather roughly, and then sits down himself.
-    "Look, I really can't tell you the exact contents of the box. Let's just say it's "small" weaponry. My... employer... isn't fond of the government of %s. As such, he needs... " he takes a drink "a shipment delivered there ASAP. Thats all I can tell you, I'm afraid"
-    You sip your slime, and answer him...]])
-bmsg[3] = _([[You feel a very large hand slap you on the back. "Thats a lad!" he cries exuberantly. "I'll have my boys load up the cargo, as quickly as you please. Remember, all you gotta do is fly to %s, and avoid the military, police, and civvies that like to stick their noses where they don't belong. I'll let my contacts know to expect you, and to pay you when you land."
-    You shake his sticky hand, and walk off, content that you've made an easy buck.]])
+bmsg[1] = _([[You walk up to a scrappy little man leaning against the bar. You sit next to him, and he eyes you up and down. You return the stare cooly and he half-heartedly tries to strikes up a conversation. "Nice drinks they have here." You feign interest so as not to be impolite.
+    He continues impatiently. "You look like you're in need of a couple spare credits," he finally says. "I have, uh, a shipment that needs getting to %s. Are you interested? Just has to be kept under wraps if you know what I mean. Pay is good though. %s credits. That's all you need to know." He pauses for a moment. "How about it?"]])
+bmsg[2] = _([[You feel a very large hand slap you on the back. "I knew you would do it! A great choice!" he says. "I'll have my boys load up the cargo. Remember, all you gotta do is fly to %s, and avoid the military and police. I'll let my contacts know to expect you. They'll pay you when you land."
+    You shake his sticky hand and walk off, content that you've made an easy buck.]])
 
 --ending messages
 emsg = {}
-emsg[1] = _([[As you descend to the %s spaceport, you notice a severe lack of... well... anybody. The place seems deserted. You received an impersonal message saying *LAND IN BAY 71A4* on your way into the atmosphere, but that is the only communication you received. You don't even see any vessels flying around. As you steer your ship into the aforementioned bay, you finally see a small group of gruff and wary men waiting for you. Almost as soon as you land, they have the goods out, and as you walk out to say hello, you already see it disappearing on the far end of the bay.]])
-emsg[2] = _([[You approach the man who appears to be the leader of the group. "One box of... stuff, as requested." You say, motioning to the now-gone box. 
-    The large, unshaven man looks you right in the eyes."Yes, thanks. I suppose you will be wanting payment now." He hands you a credit chip. "You know, we need to get a message back to our... employers. Interested in taking one more trip? If you are, I'll be in the bar after I've verified the contents of our shipment. Meet me there."]])
+emsg[1] = _([[As you descend onto the %s spaceport, you notice how deserted the place seems to be. Finally, after a search that seem to take cycles, you see a small group of gruff and wary men waiting for you. Once you find them, they quickly unload the goods and disappear before you can even react.
+    You then notice that one person, a large, unshaven man, remains from the group. You ask him for your payment. "Yes, yes, of course," he says as he hands you a credit chip. "Actually... if you're interested, we may have another mission for you, if you're interested. A message, as it were. The commander will be in the bar if you'd like to learn more about this opportunity." With that, he retreats along with the rest of the group. You wonder if you should pursue the offer or ignore it.]])
 
 --misn osd stuffs
 osd = {}
-osd[1] = _("Deliver the shipment to %s in the %s system.")
+osd[1] = _("Deliver the shipment to %s in the %s system")
 --random odds and ends
-notenoughcargo = _([["You say you want this job, but you don't have enough cargo room for this assignment, little man!" Ragnarok turns away, displeased at wasting a whole 5 seconds on you.]])
-rejected = _([[He looks at you, almost appearing confused.
-    "Well, thats your choice boy. Be on your way now. I'm busy."
-    You walk away, wondering if you really missed out on an oppourtunity.]])
-npc_name = _("Ragnarok")
-bar_desc = _("You see a rougher looking gent sitting at the bar, guzzling a brownish ale.")
-misn_desc = _("Deliver the shipment to %s in %s for the Nasin.")
+notenoughcargo = _([["You say you want this job, but you don't have enough cargo space! Stop wasting my time!"]])
+rejected = _([["Well, that's your choice. Be on your way now. I'm busy."]])
+npc_name = _("A Scrappy Man")
+bar_desc = _("You see a rougher looking man sitting at the bar and guzzling a brownish ale.")
+misn_desc = _("You are to deliver a shipment to %s in the %s system for a strange man you met at a bar, avoiding police.")
 misn_title = _("The Gauntlet")
 misn_reward = _("%s credits")
 
@@ -62,15 +53,14 @@ function accept()
    --the obligatory opening messages
    local aname = targetasset:name()
 
-   tk.msg(misn_title, bmsg[1]:format( aname, aname, aname, aname, numstring(reward) ))
-   if not tk.yesno(misn_title,bmsg[2]:format(aname)) then
+   if not tk.yesno( misn_title, bmsg[1]:format( aname, aname, numstring(reward) ) ) then
       tk.msg(misn_title,rejected)
       misn.finish(false)
    end
-   tk.msg(misn_title,bmsg[3]:format(aname))
+   tk.msg(misn_title,bmsg[2]:format(aname))
    misn.setDesc(misn_desc)
    misn.accept()
-   misn.markerAdd(targetsystem,"plot")
+   misn.markerAdd(targetsystem,"high")
    misn.osdCreate(misn_title,osd)
    misn.osdActive(1)
    freecargo = player.pilot():cargoFree() --checks to make sure the player has 5 tons available
@@ -84,8 +74,7 @@ end
 
 function land ()
    if planet.cur() == targetasset then
-      tk.msg(misn_title, emsg[1]:format( targetasset:name() ))
-      tk.msg(misn_title, emsg[2])
+      tk.msg( misn_title, emsg[1]:format( targetasset:name() ) )
       player.pay(reward)
       misn.cargoRm(small_arms) --this mission was an act against sirius, and we want sirius to not like us a little bit.
       faction.modPlayer("Nasin",3) --nasin rep is used in mission rewards, and I am trying to avoid having the pay skyrocket.

--- a/dat/missions/sirius/heretic/heretic0.lua
+++ b/dat/missions/sirius/heretic/heretic0.lua
@@ -16,7 +16,7 @@ bmsg[2] = _([[You feel a very large hand slap you on the back. "I knew you would
 --ending messages
 emsg = {}
 emsg[1] = _([[As you descend onto the %s spaceport, you notice how deserted the place seems to be. Finally, after a search that seem to take cycles, you see a small group of gruff and wary men waiting for you. Once you find them, they quickly unload the goods and disappear before you can even react.
-    You then notice that one person, a large, unshaven man, remains from the group. You ask him for your payment. "Yes, yes, of course," he says as he hands you a credit chip. "Actually... if you're interested, we may have another mission for you, if you're interested. A message, as it were. The commander will be in the bar if you'd like to learn more about this opportunity." With that, he retreats along with the rest of the group. You wonder if you should pursue the offer or ignore it.]])
+    You then notice that one person, a large, unshaven man, remains from the group. You ask him for your payment. "Yes, yes, of course," he says as he hands you a credit chip. "Actually... if you're interested, we may have another mission for you. A message, as it were. The commander will be in the bar if you'd like to learn more about this opportunity." With that, he retreats along with the rest of the group. You wonder if you should pursue the offer or ignore it.]])
 
 --misn osd stuffs
 osd = {}
@@ -53,7 +53,7 @@ function accept()
    --the obligatory opening messages
    local aname = targetasset:name()
 
-   if not tk.yesno( misn_title, bmsg[1]:format( aname, aname, numstring(reward) ) ) then
+   if not tk.yesno( misn_title, bmsg[1]:format( aname, numstring(reward) ) ) then
       tk.msg(misn_title,rejected)
       misn.finish(false)
    end

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -7,24 +7,19 @@ include "dat/scripts/numstring.lua"
 
 --all the messages before the mission starts
 bmsg = {}
-bmsg[1] = _([[You approach the tall man who is sitting at a table with papers and maps spread out before him. He glances up at you as you approach. You eye the maps warily, as they discombobulate you. That is, until you realize that they are attack strategy on key points of the %s infrastructure. The man stands up gracefully, and motions for you to sit.]])
-bmsg[2] = _([["Hello there," he begins to speak, "I'm sure you have quite a few questions. My name is Shaman and I am a proud  commander in what is known as the Nasin. We are currently terrorize the Sirius overlords that control %s, and as you can plainly see," he gusteres to the maps,"I have my hands full at the moment. Would you like to know more about the Nasin, or just move on to the work I need you to do?"]])
-bmsg[3] = _([["The mission is simple. The Nasin have their main base operating on..." Shaman looks around, realizing he might not want everyone to know where this place is. He reaches down and scratches something out on a piece of paper, and hands it to you. It simply reads "%s in %s". "I need a message delivered there. Our work is almost done here. Of course, we will pay you for this service. How does %s sound? Will you do it?"]])
-bmsg[4] = _([[Shaman takes a deep breath. "The Nasin were at one point all part of House Sirius, and believed solely in the teachings of Sirichana. We loved him, and our hearts were his. As all religions do at some point, however, the teachings of Sirichana became weighed down by the ideologies and agendas of man. Most people still accepted these teachings as straight from the mouth of Sirichana himself, but we, the Nasin, knew better."]])
-bmsg[5] = _([["We started a splinter religion, still trying to cooperate with the Sirii, but when the Serra felt threatened (as they well should have, I might add), they branded us as heretics and forced us out of Sirius space. At first, we didn't know what to do, but then, Jan Jusi pi Lawa came to lead us. He was the one who named us, the Nasin, which means "The Way" in an old earth language."]])
-bmsg[6] = _([[At this point, Shaman seems very excited, caught up in the moment. "It was he! He who led us to join our hands! He who led us to work together! He who led us to fight back against the oppressors! It was he! The very, the only, the True Voice of Sirichana!"
+bmsg[1] = _([[You approach the tall man and he glances up at you. You notice that some of the papers on the table are maps and as you eye the maps curiously, and the man grins and motions for you to sit.
+    "Hello there," he says. "I'm sure you don't recognize me, but I certainly recognize you!. My name is Shaman, proud commander of the Nasin. You've worked for us before." The strange man and his delivery. Of course.
+    "Let me tell you a bit about our organization. The Sirii describe us simply as "heretics". But we are so much more than that! We are the true followers of Sirichana!"]])
+bmsg[3] = _([[Shaman takes a deep breath. "We Nasin were at one point all part of House Sirius, and believed solely in the teachings of Sirichana. We loved him, and our hearts were his. As all religions do at some point, however, the teachings of Sirichana became weighed down by the ideologies and agendas of man. Most people still accepted these teachings as straight from the mouth of Sirichana himself, but we, the Nasin, knew better.
+    "We started a splinter religion, still trying to cooperate with the Sirii, but when the Serra felt threatened by our presence, they branded us as heretics and forced us out of Sirius space. We didn't know what to do at first, but then Jan Jusi pi Lawa came to lead us. He was the one who named us, the Nasin, which means "The Way" in an old earth language."
+    Shaman seems to get caught up in the moment. "It was he! He who led us to join our hands! He who led us to work together! He who led us to fight back against the oppressors! It was he! The very, the only, the True Voice of Sirichana!"
     Shaman seems to realize just exactly where he is and what he is doing. All the patrons in the bar turn their heads to your table. A group of young fellows start clapping and then degrade into laughter.]])
-bmsg[7] = _([[Shaman coughs out an "excuse me" and looks at you, embarrassed. "It is wrong for me to get so caught up in such things. I suppose you'll want to know about the mission now."]])
+bmsg[4] = _([[Shaman coughs out an "excuse me" and looks at you, embarrassed. "It is wrong for me to get so caught up in such things. I suppose you'll want to know about the mission now.
+    "The mission is simple. Our main base operates on %s in the %s system. I need a message delivered there. Of course, we will pay you for this service. How does %s credits sound? Will you do it?"]])
 
 --all the messages after the player lands on the target asset
 emsg = {}
-emsg[1] = _([[You receive your clearance to land on %s, and begin your computer-assisted entry into the specified bay. Your not sure exactly what to expect, but you think that they've been expecting you. You successfully dock, and proceed into the hangar, ready for someone to come greet you. No one does. The hangar is oddly... empty. And that is when you notice it.]])
-emsg[2] = _([[There is an envelope, folded neatly, and laying squarely in the middle of the hangar. You go up to inspect it, and on the front, it simply says "%s". You snatch it up, and open it quickly.]])
-emsg[3] = _([["Hello %s,
-    My sincerest apologies for being absent. I was... otherwise engaged. By the time you are reading this letter, our message will have already been moved from your ship. I appreciate the hard work, and have heard good things of you from both Ragnarok and Shaman. I do wish to speak with you in person, so please feel free to drop by the bar and have a drink. I'm sure you know the way. Your payment of %s was credited  to your account.
-    Sincerly,
-    Draga
-    Secretary of Jan Jusi pi Lawa]])
+emsg[1] = _([[As you land, you are once again surprised to not be greeted by anyone. After searching for a bit, you return to your ship to find that the message has been taken and a small envelope has replaced it. Inside the envelope is a note. "Our sincere apologies for missing you," it says. "As you can see, we have obtained the message, and you will also notice that a payment of %s credits has been deposited into your account. You have done great work for us and we appreciate your services. Please feel free to meet us at the bar sometime."]])
 
 --conversational options
 option = {}
@@ -33,12 +28,12 @@ option[2] = _("Tell me about the Nasin.")
 
 --random odds and ends
 misn_title = _("The Return")
-npc_name = _("Shaman")
+npc_name = _("A Tall Man")
 bar_desc = _("A tall man sitting at a table littered with papers.")
-misn_desc = _("Deliver the message to %s in %s for Shaman.")
+misn_desc = _("Shaman of Nasin has hired you to deliver the message to %s in the %s system.")
 misn_reward = _("%s credits")
 osd = {}
-osd[1] = _("Fly to %s in the %s system and deliver the message.")
+osd[1] = _("Fly to %s in the %s system and deliver the message")
 
 function create()
    --this mission makes no system claims
@@ -61,25 +56,18 @@ function create()
 end
 
 function accept()
-   spk_choice = tk.choice(misn_title, bmsg[2]:format( planet.cur():name() ),
-         option[1], option[2]) --using tk.choice felt more natural than just a yes or no.
+   tk.msg(misn_title,bmsg[1])
+   tk.msg(misn_title,bmsg[2])
+   tk.msg(misn_title,bmsg[3])
 
-   if spk_choice == 2 then
-      faction.modPlayer("Nasin",3) --a little reward for actually wanting the storyline (read: nasin loyalty).
-      tk.msg(misn_title,bmsg[4])
-      tk.msg(misn_title,bmsg[5])
-      tk.msg(misn_title,bmsg[6])
-      tk.msg(misn_title,bmsg[7])
-   end
-
-   local msg = bmsg[3]:format( targetasset:name(),targetsystem:name(),numstring(reward) )
+   local msg = bmsg[4]:format( targetasset:name(),targetsystem:name(),numstring(reward) )
    if not tk.yesno(misn_title, msg) then
-      misn.finish(false)
+      misn.finish()
    end
 
-   misn.setDesc(misn_desc)
    misn.accept()
-   misn.markerAdd(targetsystem,"plot")
+   misn.setDesc(misn_desc)
+   misn.markerAdd(targetsystem,"high")
    misn.osdCreate(misn_title,osd)
    misn.osdActive(1)
    message = misn.cargoAdd("Message",0)
@@ -88,13 +76,11 @@ end
 
 function landing()
    if planet.cur() == targetasset then
-      tk.msg(misn_title, emsg[1]:format( targetasset:name() ))
-      tk.msg(misn_title, emsg[2]:format( player.name() ))
-      tk.msg(misn_title, emsg[3]:format( player.name(), numstring(reward) ))
+      tk.msg(misn_title, emsg[1]:format( numstring(reward) ))
       player.pay(reward)
       misn.cargoRm(message)
       misn_tracker = misn_tracker + 1
-      faction.modPlayer("Nasin",3) --once again, the nasin like the fact that we are helping the nasin.
+      faction.modPlayer("Nasin",6) --once again, the nasin like the fact that we are helping the nasin.
       var.push("heretic_misn_tracker",misn_tracker)
       misn.osdDestroy()
       misn.finish(true)

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -48,9 +48,6 @@ function create()
    misn.setNPC(npc_name,"neutral/male1")
    misn.setDesc(bar_desc)
 
-   -- TODO: bmsg[1] is currently unused
-   -- bmsg[1] = bmsg[1]:format(planet.cur():name())
-
    osd[1] = osd[1]:format(targetasset:name(),targetsystem:name())
    misn_desc = misn_desc:format(targetasset:name(),targetsystem:name())
 end

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -76,7 +76,7 @@ function landing()
       player.pay(reward)
       misn.cargoRm(message)
       misn_tracker = misn_tracker + 1
-      faction.modPlayer("Nasin",6) --once again, the nasin like the fact that we are helping the nasin.
+      faction.modPlayer("Nasin",5) --once again, the nasin like the fact that we are helping the nasin.
       var.push("heretic_misn_tracker",misn_tracker)
       misn.osdDestroy()
       misn.finish(true)

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -10,11 +10,11 @@ bmsg = {}
 bmsg[1] = _([[You approach the tall man and he glances up at you. You notice that some of the papers on the table are maps and as you eye the maps curiously, and the man grins and motions for you to sit.
     "Hello there," he says. "I'm sure you don't recognize me, but I certainly recognize you!. My name is Shaman, proud commander of the Nasin. You've worked for us before." The strange man and his delivery. Of course.
     "Let me tell you a bit about our organization. The Sirii describe us simply as "heretics". But we are so much more than that! We are the true followers of Sirichana!"]])
-bmsg[3] = _([[Shaman takes a deep breath. "We Nasin were at one point all part of House Sirius, and believed solely in the teachings of Sirichana. We loved him, and our hearts were his. As all religions do at some point, however, the teachings of Sirichana became weighed down by the ideologies and agendas of man. Most people still accepted these teachings as straight from the mouth of Sirichana himself, but we, the Nasin, knew better.
+bmsg[2] = _([[Shaman takes a deep breath. "We Nasin were at one point all part of House Sirius, and believed solely in the teachings of Sirichana. We loved him, and our hearts were his. As all religions do at some point, however, the teachings of Sirichana became weighed down by the ideologies and agendas of man. Most people still accepted these teachings as straight from the mouth of Sirichana himself, but we, the Nasin, knew better.
     "We started a splinter religion, still trying to cooperate with the Sirii, but when the Serra felt threatened by our presence, they branded us as heretics and forced us out of Sirius space. We didn't know what to do at first, but then Jan Jusi pi Lawa came to lead us. He was the one who named us, the Nasin, which means "The Way" in an old earth language."
     Shaman seems to get caught up in the moment. "It was he! He who led us to join our hands! He who led us to work together! He who led us to fight back against the oppressors! It was he! The very, the only, the True Voice of Sirichana!"
     Shaman seems to realize just exactly where he is and what he is doing. All the patrons in the bar turn their heads to your table. A group of young fellows start clapping and then degrade into laughter.]])
-bmsg[4] = _([[Shaman coughs out an "excuse me" and looks at you, embarrassed. "It is wrong for me to get so caught up in such things. I suppose you'll want to know about the mission now.
+bmsg[3] = _([[Shaman coughs out an "excuse me" and looks at you, embarrassed. "It is wrong for me to get so caught up in such things. I suppose you'll want to know about the mission now.
     "The mission is simple. Our main base operates on %s in the %s system. I need a message delivered there. Of course, we will pay you for this service. How does %s credits sound? Will you do it?"]])
 
 --all the messages after the player lands on the target asset
@@ -58,9 +58,8 @@ end
 function accept()
    tk.msg(misn_title,bmsg[1])
    tk.msg(misn_title,bmsg[2])
-   tk.msg(misn_title,bmsg[3])
 
-   local msg = bmsg[4]:format( targetasset:name(),targetsystem:name(),numstring(reward) )
+   local msg = bmsg[3]:format( targetasset:name(),targetsystem:name(),numstring(reward) )
    if not tk.yesno(misn_title, msg) then
       misn.finish()
    end

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -9,13 +9,14 @@ include "dat/scripts/numstring.lua"
 bmsg = {}
 bmsg[1] = _([[You approach the tall man and he glances up at you. You notice that some of the papers on the table are maps and as you eye the maps curiously, and the man grins and motions for you to sit.
     "Hello there," he says. "I'm sure you don't recognize me, but I certainly recognize you!. My name is Shaman, proud commander of the Nasin. You've worked for us before." The strange man and his delivery. Of course.
-    "Let me tell you a bit about our organization. The Sirii describe us simply as "heretics". But we are so much more than that! We are the true followers of Sirichana!"]])
-bmsg[2] = _([[Shaman takes a deep breath. "We Nasin were at one point all part of House Sirius, and believed solely in the teachings of Sirichana. We loved him, and our hearts were his. As all religions do at some point, however, the teachings of Sirichana became weighed down by the ideologies and agendas of man. Most people still accepted these teachings as straight from the mouth of Sirichana himself, but we, the Nasin, knew better.
-    "We started a splinter religion, still trying to cooperate with the Sirii, but when the Serra felt threatened by our presence, they branded us as heretics and forced us out of Sirius space. We didn't know what to do at first, but then Jan Jusi pi Lawa came to lead us. He was the one who named us, the Nasin, which means "The Way" in an old earth language."
+    "Let me tell you a bit about our organization. The Sirii describe us simply as 'heretics'. But we are so much more than that! We are the true followers of Sirichana!"]])
+bmsg[2] = _([["We Nasin were at one point all part of House Sirius and believed solely in the teachings of Sirichana. We loved him, and our hearts were his. As all religions do at some point, however, the teachings of Sirichana became weighed down by the ideologies and agendas of man. Most people still accepted these teachings as straight from the mouth of Sirichana himself, but we, the Nasin, knew better.
+    "We started a splinter religion, still trying to cooperate with the Sirii, but when they felt threatened by our presence, they branded us as heretics and forced us out of Sirius space. We didn't know what to do at first, but then Jan Jusi pi Lawa came to lead us. He was the one who named us, the Nasin, which means "The Way" in an old earth language."
     Shaman seems to get caught up in the moment. "It was he! He who led us to join our hands! He who led us to work together! He who led us to fight back against the oppressors! It was he! The very, the only, the True Voice of Sirichana!"
     Shaman seems to realize just exactly where he is and what he is doing. All the patrons in the bar turn their heads to your table. A group of young fellows start clapping and then degrade into laughter.]])
 bmsg[3] = _([[Shaman coughs out an "excuse me" and looks at you, embarrassed. "It is wrong for me to get so caught up in such things. I suppose you'll want to know about the mission now.
     "The mission is simple. Our main base operates on %s in the %s system. I need a message delivered there. Of course, we will pay you for this service. How does %s credits sound? Will you do it?"]])
+bmsg[4] = _([["Fantastic!" He hands you the message. "They will take care of your payment there. Thank you for aiding the true followers of Sirichana."]])
 
 --all the messages after the player lands on the target asset
 emsg = {}
@@ -61,6 +62,7 @@ function accept()
       misn.finish()
    end
 
+   tk.msg(misn_title, bmsg[4])
    misn.accept()
    misn.setDesc(misn_desc)
    misn.markerAdd(targetsystem,"high")

--- a/dat/missions/sirius/heretic/heretic2.lua
+++ b/dat/missions/sirius/heretic/heretic2.lua
@@ -109,7 +109,7 @@ end
 function land()
    if finished ~= 1 then
       tk.msg(misn_title,chronic_failure) --landing pre-emptively is a bad thing.
-      faction.modPlayer("Nasin",-20)
+      faction.modPlayerSingle("Nasin",-20)
       misn.finish(false) 
    elseif planet.cur() == homeasset and finished == 1 then
       tk.msg(misn_title,emsg_1)
@@ -124,7 +124,7 @@ end
 function out_sys_failure() --jumping pre-emptively is a bad thing.
    if system.cur() ~= homesys then
       tk.msg(misn_title, out_sys_failure_msg:format( player.name() ))
-      faction.modPlayer("Nasin",-20)
+      faction.modPlayerSingle("Nasin",-20)
       misn.finish(false)
    end
 end

--- a/dat/missions/sirius/heretic/heretic2.lua
+++ b/dat/missions/sirius/heretic/heretic2.lua
@@ -58,7 +58,7 @@ end
 
 function accept()
    if tk.yesno( misn_title, bmsg[1]:format( player.name() ) ) then
-      misn.acept()
+      misn.accept()
       tk.msg( misn_title, bmsg[2] )
 
       misn.setDesc(misn_desc)

--- a/dat/missions/sirius/heretic/heretic2.lua
+++ b/dat/missions/sirius/heretic/heretic2.lua
@@ -7,41 +7,25 @@ include "dat/scripts/numstring.lua"
 
 bmsg = {}
 --beginning messages
-bmsg[1] = _([[You walk up to an intimidating man dressed smartly in cool, dark black business attire. He has a large smile spread across his face. 
-    "Ahh, so you're the %s everyone has been talking about. Naught but a glorified delivery boy if you ask me. Still, if you wish to help us out and prove yourself as more than a pirate, I'd be more than happy to oblige." He grins cooly, expecting an answer.]])
-bmsg[2] = _([[Draga snorts impatiently. "Well, do you take the mission or what?"]])
-choice = {}
-choice[1] = _("Tell me more about the Nasin.")
-choice[2] = _("What's the job?")
-choice[3] = _("I'm in. Where do I sign up?")
-choice[4] = _("Sounds risky. Give me some time.")
-chooser = {}
-chooser[1] = _([[He looks at you, betraying a little emotion. "The Nasin are a pure piece of glass. When light shines through glass, the light is only as pure as the glass itself. If the glass is dirty, then the light is distorted, and doesn't come through correctly. If the glass is mishappen or broken, the light may not filter through at all. We, the Nasin, are the purest glass there is, and House Sirius has become corrupt. We exist to see its downfall."]])
-chooser[2] = _([[Draga motions you in closer. "We have reason to believe that %s is about to be attacked. We are expecting Sirius to send in recon elements any hectosecond now. We want you to handle that, as you see fit. Keep them away from the station. Better yet, kill them. We can pay you %s. We do ask that you stay in-system and off-planet until the mission is complete, otherwise you'll be considered AWOL, which means you're fired."]])
-chooser[3] = _([[Draga looks triumphant, but only for an instant. "Great. You should get going, we are expecting them at any second. Good luck, and godspeed."]])
-chooser[4] = _([[You brace yourself, as Draga appears ready to attack. He waves his arms about in obvious anger. "Great! I knew you were a waste of time. Well, if you decide to outgrow your diapers, I'll be right here waiting for you."
-   You walk away insulted, but strangely curious.]])
+bmsg[1] = _([[You walk up to the intimidating man. He's dressed smartly in cool, dark black business attire, with a large smile spread across his face.
+    "Ahh, so you're %s! Everyone has been talking about you," he says. "Allow me to introduce myself. My name is Draga, high commander of Nasin's operations. You remember us, right? People in our organization have started to take notice of your actions. Maybe it is the will of Sirichana that you come to us! If that is the case, then I have an offer you can't refuse. A chance to really prove yourself as more than a glorified courier. You see... we are expecting a Sirian patrol any hectosecond now, and we want you to... take care of it. What do you say? We could really use your help."]])
+bmsg[2] = _([["Marvelous! I knew I could count on you! Don't you worry; you'll be fighting alongside some of our finest pilots. I know you can drive those Sirii off!
+    "Oh, and one last thing: don't even think of bailing out on us at the last second. If you jump out or land before your mission is completed, consider yourself fired."]])
+bmsg[3] = _([["Gah! I should have known you would be so spineless! Get out of my sight!"]])
+
 --message at the end
-emsg_1 = _([[You land, having destroyed the small recon force. Draga is in the hangar, waiting for you.
-   "Good job on proving yourself more than a delivery boy! That wasn't so bad, was it? Here's your payment, meet me in the bar soon."]])
+emsg_1 = _([[You land, having destroyed the small recon force, and find Draga with a smile on his face. "Great job!" he says. "I see you really are what you're made out to be and not just some overblown merchant!" He hands you a credit chip. "Thank you for your services. Meet us in the bar again sometime. We will certainly have another mission for you."]])
 --mission osd
 osd = {}
-osd[1] = _("Destroy the Sirius fighter element.")
-osd[2] = _("Element destroyed. Land on %s.")
+osd[1] = _("Destroy the Sirius patrol")
+osd[2] = _("Land on %s")
 --random odds and ends
 misn_title = _("The Patrol")
-npc_name = _("Draga")
-bar_desc = _("An imposing man leans against the bar easily, looking right at you.")
-not_finished = _("Draga seems to swoop in out of nowhere as soon as you land. \"You are not finished! Get back up there quickly!\"")
-chronic_failure = _([[Draga swoops in. His nostrils are flaring, and he is obviously annoyed.
-   "Apparently you have better things to do. Get out of here. I don't want to see your face anymore."
-   You consider yourself fired.]])
-doom_clock_msg = _([[A scratchy voice jumps in on your comms priority channel. 
-   "You jumped out of the system! We are being scanned by the enemy! We need you back to take care of this situation now, or you are AWOL and are not getting paid!!" 
-   The voice and the scratch cuts out.]])
-out_sys_failure_msg = _([[Your comm station flares up with a scratchy, obviously-from-far-away noise. A voice is heard through it.
-   "%s! We told you we needed you to stay in system! Apparently you have more important things to do. So get lost, kid! We'll take care of ourselves." The static cuts out, and you consider yourself fired.]])
-misn_desc = _("Destroy the Sirius recon element that flew into %s. WARNING: DO NOT JUMP OUT-SYSTEM OR LAND ON THE PLANET PREMATURELY.")
+npc_name = _("An Imposing Man")
+bar_desc = _("This man leans against the bar while looking right at you.")
+chronic_failure = _([[Draga's face goes red with fury when he sees you. For a moment you start to worry he might beat you into a pulp for abandoning your mission, but he moves along, fuming. You breathe a sigh of release; you may have angered Nasin, but at least you're still alive.]])
+out_sys_failure_msg = _([[As you abandon your mission, you recieve a message from Draga saying that Nasin has no need for deserters. You hope you made the right decision.]])
+misn_desc = _("You have been hired once again by Nasin, this time to destroy a Sirius patrol that has entered %s.")
 misn_reward = _("%s credits")
 
 function create()
@@ -73,41 +57,21 @@ function create()
 end
 
 function accept()
-   -- Only referenced in this function.
-   chooser[2] = chooser[2]:format(homeasset:name(), numstring(reward))
+   if tk.yesno( misn_title, bmsg[1]:format( player.name() ) ) then
+      misn.acept()
+      tk.msg( misn_title, bmsg[2] )
 
-   while true do --this is a slightly more complex convo than a yes no. Used break statements as the easiest way to control convo.
-
-      msg = bms
-      if first_talk == nil then --used the first talk one only the first time through. This way, the npc convo feels more natural.
-         msg = bmsg[1]:format( player.name() )
-         first_talk = 1
-      else
-         msg = bmsg[2]
-      end
-      draga_convo = tk.choice(misn_title, msg,
-            choice[1], choice[2], choice[3], choice[4])
-         draga_convo = tk.choice(misn_title,bmsg[2],choice[1],choice[2],choice[3],choice[4])
-
-      if draga_convo == 1 or draga_convo == 2 then
-         tk.msg(misn_title,chooser[draga_convo])
-      elseif draga_convo == 3 then
-         tk.msg(misn_title,chooser[draga_convo])
-      break
-      else
-         tk.msg(misn_title,chooser[draga_convo] )
-         misn.finish()
-      break
-      end
+      misn.setDesc(misn_desc)
+      misn.markerAdd(homesys,"high")
+      misn.osdCreate(misn_title,osd)
+      misn.osdActive(1)
+      hook.takeoff("takeoff")
+      hook.jumpin("out_sys_failure")
+      hook.land("land")
+   else
+      tk.msg( misn_title, bmsg[3] )
+      misn.finish( false )
    end
-   misn.setDesc(misn_desc)
-   misn.accept()
-   misn.markerAdd(homesys,"plot")
-   misn.osdCreate(misn_title,osd)
-   misn.osdActive(1)
-   hook.takeoff("takeoff")
-   hook.jumpin("out_sys_failure")
-   hook.land("land")
 end
 
 function takeoff()
@@ -145,15 +109,13 @@ end
 function land()
    if finished ~= 1 then
       tk.msg(misn_title,chronic_failure) --landing pre-emptively is a bad thing.
-      misn.osdDestroy()
+      faction.modPlayer("Nasin",-20)
       misn.finish(false) 
    elseif planet.cur() == homeasset and finished == 1 then
       tk.msg(misn_title,emsg_1)
       player.pay(reward)
       misn_tracker = misn_tracker + 1
-      faction.modPlayer("Nasin",4)
-      faction.modPlayer("Sirius",-5)
-      misn.osdDestroy()
+      faction.modPlayer("Nasin",7)
       var.push("heretic_misn_tracker",misn_tracker)
       misn.finish(true)
    end
@@ -162,13 +124,8 @@ end
 function out_sys_failure() --jumping pre-emptively is a bad thing.
    if system.cur() ~= homesys then
       tk.msg(misn_title, out_sys_failure_msg:format( player.name() ))
-      misn.osdDestroy()
+      faction.modPlayer("Nasin",-20)
       misn.finish(false)
    end
-end
-
-function abort()
-   misn.osdDestroy()
-   misn.finish(false)
 end
    

--- a/dat/missions/sirius/heretic/heretic2.lua
+++ b/dat/missions/sirius/heretic/heretic2.lua
@@ -14,7 +14,7 @@ bmsg[2] = _([["Marvelous! I knew I could count on you! Don't you worry; you'll b
 bmsg[3] = _([["Gah! I should have known you would be so spineless! Get out of my sight!"]])
 
 --message at the end
-emsg_1 = _([[You land, having destroyed the small recon force, and find Draga with a smile on his face. "Great job!" he says. "I see you really are what you're made out to be and not just some overblown merchant!" He hands you a credit chip. "Thank you for your services. Meet us in the bar again sometime. We will certainly have another mission for you."]])
+emsg_1 = _([[You land, having defeated the small recon force, and find Draga with a smile on his face. "Great job!" he says. "I see you really are what you're made out to be and not just some overblown merchant!" He hands you a credit chip. "Thank you for your services. Meet us in the bar again sometime. We will certainly have another mission for you."]])
 --mission osd
 osd = {}
 osd[1] = _("Destroy the Sirius patrol")

--- a/dat/missions/sirius/heretic/heretic3.lua
+++ b/dat/missions/sirius/heretic/heretic3.lua
@@ -144,7 +144,7 @@ end
 
 function out_sys_failure() --feel like jumping out? AWOL! its easier this way. trust me.
    tk.msg(misn_title,oos_failure) 
-   faction.modPlayer("Nasin",-50)
+   faction.modPlayerSingle("Nasin",-50)
    misn.finish(false)
 end
 
@@ -162,13 +162,13 @@ end
 function return_to_base()
    if not returnchecker then --feel like landing early? AWOL!
       tk.msg(misn_title,p_landing)
-      faction.modPlayer("Nasin",-50)
+      faction.modPlayerSingle("Nasin",-50)
       misn.finish(false) --mwahahahahaha!
    else
       player.pay(reward)
       tk.msg(misn_title,emsg[1]:format( player.name() ))
       misn_tracker = misn_tracker + 1
-      faction.modPlayer("Nasin",20)
+      faction.modPlayer("Nasin",10)
       var.push("heretic_misn_tracker",misn_tracker)
       misn.finish(true)
    end

--- a/dat/missions/sirius/heretic/heretic3.lua
+++ b/dat/missions/sirius/heretic/heretic3.lua
@@ -7,56 +7,31 @@
 
 include "dat/scripts/numstring.lua"
    
---beginning messages and choices
+--beginning messages
 bmsg = {}
-bmsg[1] = _([[Draga is sitting at a table with a couple other people who appear to be official military types. They look at you as you approach. Draga stands and greets you.
-   "Hello, %s. We have a situation, and we need your help."]])
-bmsg[2] = _([[Draga sits back down with the other officials.
-   "Sirius is officially considering us a threat. As such, we need you to help us defend our system. Our goal here isn't to completely wipe out the Sirius threat, but rather just to drive them off and show them that we mean business. We want them to feel it."]])
-bmsg[3] = _([[Draga leans back and smiles ruefully. 
-   "So, you will be outnumbered, outgunned, and officially declared an enemy of the state. Want in? Please note, however, that if you abort the mission, or jump out-system, you will be dismissed. Permanently."]])
---messages for the choice
-bmsgc = {}
-bmsgc[1] = _([[He snorts derisively at your question.
-   "Why, I mean you will no longer be welcome amongst the Nasin. At least, as a pilot."]])
-bmsgc[2] = _([[Sorrow fills Draga's eyes at the question.
-   "Unfortunately, House Sirius and those claiming to represent Sirichana feel that we are a band of heretics out to destroy the Sirius way of life. We aren't out to destroy it, but rather to bring it to completion. They have decided that we need to be eliminated."]])
-bmsgc[3] = _([[Draga eyes you. You can tell he doesn't like the question.
-   "You really like the money, %s? You know, I'd much prefer it if you were just loyal enough to not worry about the money. We will always pay you well. We take care of our own. We can pay you %s. I hope its good enough"]])
-bmsgc[4] = _([[Draga is quite excited at the news, and the surrounding officers mumble their approval. "Great! You should hurry up and take off, we are expecting them any second now. We already have one defensive element in space."]])
-bmsgc[5] = _([[Obviously annoyed beyod belief, Draga doesn't say a word. He makes a shooing guesture with his hand, and doesn't even look as you go.]])
-draga_chooser = _([[Draga looks at you impatiently. "Any more questions or can we get going?"]])
-choice = {}
-choice[1] = _("What do you mean, permanently?")  --this opens up dialog bmsg[4]
-choice[2] = _("Why are they attacking?") --jumps to dialog bmsg[5]
-choice[3] = _("What are you paying?") --jumps to dialog bmsg[6]
-choice[4] = _("I'm in.") --jumps to dialog bmsg[7], and starts mission.
-choice[5] = _("Gimme a minute. I'll be right back.") --jumps to dialog bmsg[8]
+bmsg[1] = _([[Draga is sitting at a table with a couple other people who appear to be official military types. They look at you as you approach. Draga stands and greets you. "Hello, %s," he says. "We have a situation, and we need your help.
+    "The Sirii are starting to take us seriously as a threat. This isn't what we hoped for; we hoped we could go a little longer underground, but it seems we're being forced into battle. As such, we need you to help us defend our system. Our goal here isn't to completely wipe out the Sirius threat, but rather just to drive them off and show them that we mean business. We want them to feel it.
+    "You will be outnumbered, outgunned, and officially declared an enemy of the state. Will you help us?"]])
+bmsg[2] = _([["Excellent! See, folks? I told you this one was a keeper! Our forces will meet you out there. Ah, and while I'm sure you would never do this, as before, desertion will not be tolerated. Do not land or leave the system until your mission is completed."]])
+bmsg[3] = _([["Do you not understand the seriousness of this situation?! I thought you were better than this!" He grumbles and shoos you away.]])
 
 --ending messages
 emsg = {}
-emsg[1] = _([[As you land, you see people running about frantically. Most look as though they've had some sort of military training, but there are a few scrambling civilians as well. You land, and as soon as your feet hit the deck the now familiar face of Draga comes up to you begins to speak.
-   "Get your crap together, %s, and meet me in the bar as soon as you can. We need you. I've already transferred payment." At this, he runs off to helps a group of elderly citizens who are struggling against the tide of people.]])
+emsg[1] = _([[As you land, you see the Nasin forces desperately trying to regroup. "Hurry and get your ship ready for another battle," he says, "and meet me at the bar when you're ready! Payment has been transferred into your account. More importantly, we have a dire situation!"]])
 
 --misn osd
 osd = {}
-osd[1] = _("Defend %s against the oncoming assault!")
-osd[2] = _("Return to %s.")
+osd[1] = _("Defend %s against the Sirius assault")
+osd[2] = _("Return to %s")
 --random odds and ends
 misn_title = _("The Assault")
 npc_name = _("Draga")
 bar_desc = _("The familiar form of Draga is at a table with some officers. They look busy.")
-return_to_base_msg = _([[A clear voice booms in your ship through the comm system.
-   "%s! We need you to return to %s immediately! We are being overwhelmed and are evacuating! Please hurry!" The voice cuts out in a tumult of static.]])
-p_landing = _([[Draga appears with three armed Nasin carrying some serious weaponry. 
-   He points at you and says "I have been more than accomadating with you. Now, you are dismissed. Take care of your business, and leave. And if you don't, my friends here are more than willing to collect that bounty."
-   Draga strides away, exuding annoyance and rage.]]) 
-oos = _([[A voice comes into your comm system. "We need you back in the system now! Hurry!"]])
-oos_failure = _([[A scratchy voice from what sounds like very far away cut in on your comms priority channel. 
-   "We needed you! We are being overrun by Sirius and we aren't gonna make it. Don't bother coming back to us. Ever." 
-   The voice cuts out, and you feel like you've made a horrible mistake.]])
-misn_desc = _([[A Sirius assault fleet has just jumped into %s. Destroy this fleet. WARNING: DO NOT JUMP OUT-SYSTEM OR LAND ON ANY ASSETS.]])
-time_to_come_home = _([[Your comm squeaks as the voice of Draga comes onto the channel. "%s! This is a lot larger of an assault than we thought. There is no way that we can handle this. We need you to get back to the station now! We are evacuating!" The comm goes silent, and you start heading back.]])
+return_to_base_msg = _([[A clear voice booms in your ship through the comm system. "%s! We need you to return to %s immediately! We are being overwhelmed and are evacuating! Please hurry!" The voice cuts out in a tumult of static.]])
+p_landing = _([[As you land, Draga sees you. He seems just about ready to kill you on the spot. "You abandon us now? When we need you the most?! I should never have put my trust in you! Filth! Get out of my sight before I kill you where you stand!" You do as he says, beginning to question your decision to abandon your mission at the very place Draga was. Nonetheless, you bury your head and make a mental note to get out of here as soon as possible.]])
+oos_failure = _([[You recieve a scathing angry message from Draga chastising you for abandoning your mission. You put it behind you. There's no turning back now.]])
+misn_desc = _([[A Sirius assault fleet has just jumped into %s. You are to assist Nasin in destroying this fleet.]])
+time_to_come_home = _([[You receive a frantic message from Draga. "%s! This is worse than we ever thought. We need you back at the base! Stat!"]])
 misn_reward = _("%s credits")
 
 function create()
@@ -84,44 +59,23 @@ function create()
 end
 
 function accept()
-   -- Only referenced in this function.
-   bmsgc[3] = bmsgc[3]:format(player.name(),numstring(reward))
+   if tk.yesno(misn_title, bmsg[1]:format(player.name())) then
+      tk.msg( misn_title, bmsg[2] )
 
-   tk.msg(misn_title,bmsg[1]:format( player.name() ))
-   tk.msg(misn_title,bmsg[2])
-   while true do --another complicated convo!
-      if checker == nil then
-         chooser = tk.choice(misn_title,bmsg[3],choice[1],choice[2],choice[3],choice[4],choice[5])
-      else
-         chooser = tk.choice(misn_title,draga_chooser,choice[1],choice[2],choice[3],choice[4],choice[5])
-      end
-      if chooser == 1 or chooser == 2 or chooser == 3 or chooser == 4 then
-         tk.msg(misn_title,bmsgc[chooser])
-         if chooser == 3 and rep_check == nil then
-            faction.modPlayer("Nasin",-5) --the nasin prefer loyalty to them over money. rep hurt if player asks about pay.
-            rep_check = 1 --makes sure the rep hit only comes once.
-         end
-      if chooser == 4 then
-         break
-         end
-      else
-         tk.msg(misn_title,bmsgc[chooser])
-         misn.finish()
-         break
-      end
-      checker = _("you been through one time, yo!") --makes sure the intro message to the convos only comes in once
+      misn.accept()
+      misn.setDesc(misn_desc)
+      misn.markerAdd(homesys,"plot")
+      misn.osdCreate(misn_title,osd)
+      misn.osdActive(1)
+
+      --hook time.
+      hook.takeoff("takeoff")
+      hook.jumpin("out_sys_failure")
+      hook.land("return_to_base")
+   else
+      tk.msg( misn_title, bmsg[3] )
+      misn.finish( false )
    end
-
-   misn.setDesc(misn_desc) --convo is over! time to set the last of the mission stuff
-   misn.accept()
-   misn.markerAdd(homesys,"plot")
-   misn.osdCreate(misn_title,osd)
-   misn.osdActive(1)
-
-   --hook time.
-   hook.takeoff("takeoff")
-   hook.jumpin("out_sys_failure")
-   hook.land("return_to_base")
 end
 
 function takeoff() --for when the player takes off from the wringer.
@@ -160,7 +114,7 @@ end
 
 function death(p)
    deathcounter = deathcounter + 1
-   if deathcounter == 9 then --9 ships is all the ships in the first fleet minus the 2 cruisers and the carrier. might adjust this later.
+   if deathcounter >= 9 then --9 ships is all the ships in the first fleet minus the 2 cruisers and the carrier. might adjust this later.
       flee()
    end
 end
@@ -190,7 +144,7 @@ end
 
 function out_sys_failure() --feel like jumping out? AWOL! its easier this way. trust me.
    tk.msg(misn_title,oos_failure) 
-   misn.osdDestroy()
+   faction.modPlayer("Nasin",-50)
    misn.finish(false)
 end
 
@@ -208,21 +162,14 @@ end
 function return_to_base()
    if not returnchecker then --feel like landing early? AWOL!
       tk.msg(misn_title,p_landing)
-      misn.osdDestroy()
+      faction.modPlayer("Nasin",-50)
       misn.finish(false) --mwahahahahaha!
    else
       player.pay(reward)
       tk.msg(misn_title,emsg[1]:format( player.name() ))
       misn_tracker = misn_tracker + 1
-      faction.modPlayer("Nasin",4)
-      faction.modPlayer("Sirius",-5)
+      faction.modPlayer("Nasin",20)
       var.push("heretic_misn_tracker",misn_tracker)
-      misn.osdDestroy()
       misn.finish(true)
    end
-end
-
-function abort()
-   misn.osdDestroy()
-   misn.finish(false)
 end

--- a/dat/missions/sirius/heretic/heretic3.lua
+++ b/dat/missions/sirius/heretic/heretic3.lua
@@ -27,7 +27,6 @@ osd[2] = _("Return to %s")
 misn_title = _("The Assault")
 npc_name = _("Draga")
 bar_desc = _("The familiar form of Draga is at a table with some officers. They look busy.")
-return_to_base_msg = _([[A clear voice booms in your ship through the comm system. "%s! We need you to return to %s immediately! We are being overwhelmed and are evacuating! Please hurry!" The voice cuts out in a tumult of static.]])
 p_landing = _([[As you land, Draga sees you. He seems just about ready to kill you on the spot. "You abandon us now? When we need you the most?! I should never have put my trust in you! Filth! Get out of my sight before I kill you where you stand!" You do as he says, beginning to question your decision to abandon your mission at the very place Draga was. Nonetheless, you bury your head and make a mental note to get out of here as soon as possible.]])
 oos_failure = _([[You recieve a scathing angry message from Draga chastising you for abandoning your mission. You put it behind you. There's no turning back now.]])
 misn_desc = _([[A Sirius assault fleet has just jumped into %s. You are to assist Nasin in destroying this fleet.]])
@@ -64,7 +63,7 @@ function accept()
 
       misn.accept()
       misn.setDesc(misn_desc)
-      misn.markerAdd(homesys,"plot")
+      misn.markerAdd(homesys,"high")
       misn.osdCreate(misn_title,osd)
       misn.osdActive(1)
 
@@ -120,8 +119,6 @@ function death(p)
 end
 
 function flee()
-   tk.msg(misn_title, return_to_base_msg:format( player.name(),homeasset:name() ))
-
    returnchecker = true --used to show that deathcounter has been reached, and that the player is landing 'just because'
    misn.osdActive(2)
    tk.msg(misn_title, time_to_come_home:format( player.name() ))

--- a/dat/missions/sirius/heretic/heretic4.lua
+++ b/dat/missions/sirius/heretic/heretic4.lua
@@ -10,24 +10,20 @@
 
 --beginning messages
 bmsg = {}
-bmsg[1] = _([[You run up to Draga, who has a look of desperation on his face. He talks to you with more than a hint of urgency.
-   "We need to go, now. The Sirius are overwhelming us, they're about to finish us off. Will you take me and as many Nasin as you can carry to %s in %s? I swear, if you abort this and jettison those people into space, I will hunt you down and destroy you."]])
-bmsg[2] = _([[You lead Draga out of the bar and into your landing bay. Refugees are milling about, hoping to get aboard some ship or another. Draga asks you what your tonnage is, and begins directing people on board. Panic erupts when gunfire breaks out on the far end of the bay.]])
-bmsg[3] = _([[As the gunfire gets nearer, Draga yells at you to get the ship going and take off. As you get in the cabin and begin rising into the air you see Draga running back into the bay to help a woman run with her children to a small inter-planetary skiff. Some Sirius soldiers run and catch up with him, giving him three shots in the chest. The last thing you see as you take off was Draga in a pool of blood, and the woman being dragged off by the soldiers. You rocket out of there, and begin prepping to get those people to safety.]])
+bmsg[1] = _([[You run up to Draga, who has a look of desperation on his face. "We need to go, now," he says. "The Sirii are overwhelming us, they're about to finish us off. Will you take me and as many Nasin as you can carry to %s in the %s system? This is our most desperate hour!"]])
+bmsg[2] = _([["Thank you! I knew you would do it!" Draga then proceeds to file as many people as can possibly fit onto your ship, enough to fill your ship's cargo hold to the brim. The number of Nasin members shocks you as they are packed into your ship.
+    As the Sirii approach ever closer, Draga yells at you to get the ship going and take off. As you get in the cabin and begin taking off, you see Draga under fire by a Sirian soldier. The last thing you see as you take off is Draga laying on the ground, lifeless.]])
 
 --ending messages
 emsg = {}
-emsg[1] = _([[You land on %s, and open the bay doors. You are amazed at how many people Draga had helped get into the cargo hold. You help out the last few people, who are grateful to you, and walk down into the bay. A man walks up to you.]])
-emsg[2] = _([[The man offers his hand, and begins to speak. 
-   "Hello, my name is Jimmy. Thank you for helping all these people." He gestures to the refugees, who are being helped by some officials. "I am grateful. I've heard about you, from Draga, and I will be forever in your debt. All I can manage right now is this, so consider me in your debt."
-   He presses a credit chip in your hand, and walks away to help some refugees.]])
+emsg[1] = _([[You land on %s, and you open the bay doors. You are still amazed at how many people Draga had helped get into the cargo hold. As you help everyone out of your ship, a man walks up to you. "Hello, my name is Jimmy. Thank you for helping all of these people. I am grateful. I've heard about you from Draga, and I will be forever in your debt. Here, please, take this." He presses a credit chip in your hand just as you finish helping everyone out of your ship. It seems it was a job well done.]])
 
 --mission osd
 osd = {}
 osd[1] = _("Fly the refugees to %s in the %s system.")
 
 --random odds and ends
-abort_msg = _([[You decide that this mission is just too much. You open up the cargo doors and jettison the %d people out into the cold emptiness of space. The Nasin, and the Sirius, will hate you forever, but you did what you had to do.]])
+abort_msg = _([[You decide that this mission is just too much. You open up the cargo doors and jettison all %s people out into the cold emptiness of space. The Nasin will hate you forever, but you did what you had to do.]])
 misn_title = _("The Egress")
 npc_name = _("Draga")
 bar_desc = _("Draga is running around, helping the few Nasin in the bar to get stuff together and get out.")
@@ -42,7 +38,6 @@ function create()
    reward = math.floor((100000+(math.random(5,8)*2000)*(nasin_rep^1.315))*.01+.5)/.01
    homeasset = planet.cur()
    targetasset, targetsys = planet.get("Ulios") --this will be the new HQ for the nasin in the next part.
-   free_cargo = player.pilot():cargoFree()
    people_carried =  (16 * free_cargo) + 7 --average weight per person is 62kg. one ton / 62 is 16. added the +7 for ships with 0 cargo.
    --set some mission stuff
    misn.setNPC(npc_name,"neutral/thief2")
@@ -69,6 +64,8 @@ function accept()
    tk.msg(misn_title,bmsg[3])
    --convo over. time to finish setting the mission stuff.
    misn.markerAdd(targetsys,"plot")
+   free_cargo = player.pilot():cargoFree()
+   people_carried =  (16 * free_cargo) + 7 --average weight per person is 62kg. one ton / 62 is 16. added the +7 for ships with 0 cargo.
    refugees = misn.cargoAdd("Refugees",free_cargo)
    player.takeoff()
    --get the hooks.
@@ -129,8 +126,7 @@ function misn_over() --arent you glad thats over?
       player.pay(reward)
       misn.cargoRm(refugees)
       misn_tracker = misn_tracker + 1
-      faction.modPlayer("Nasin",8) --big boost to the nasin, for completing the prologue
-      faction.modPlayer("Sirius",-5) --the sirius shouldn't like you. at all.
+      faction.modPlayer("Nasin",25) --big boost to the nasin, for completing the prologue
       var.push("heretic_misn_tracker",misn_tracker)
       misn.osdDestroy()
       player.allowSave(true)
@@ -139,9 +135,10 @@ function misn_over() --arent you glad thats over?
 end
 
 function abort()
-   tk.msg(misn_title,abort_msg)
+   tk.msg(misn_title,abort_msg:format(numstring(people_carried)))
+   misn.cargoJet(refugees)
    var.push("heretic_misn_tracker",-1) --if the player jettisons the peeps, the nasin will not let the player join there ranks anymore.
-   misn.osdDestroy()
+   faction.modPlayerSingle("Nasin",-200) --big boost to the nasin, for completing the prologue
    player.allowSave(true)
    misn.finish(true)
 end

--- a/dat/missions/sirius/heretic/heretic4.lua
+++ b/dat/missions/sirius/heretic/heretic4.lua
@@ -63,7 +63,7 @@ function accept()
    tk.msg(misn_title,bmsg[2])
    tk.msg(misn_title,bmsg[3])
    --convo over. time to finish setting the mission stuff.
-   misn.markerAdd(targetsys,"plot")
+   misn.markerAdd(targetsys,"high")
    free_cargo = player.pilot():cargoFree()
    people_carried =  (16 * free_cargo) + 7 --average weight per person is 62kg. one ton / 62 is 16. added the +7 for ships with 0 cargo.
    refugees = misn.cargoAdd("Refugees",free_cargo)

--- a/dat/missions/sirius/heretic/heretic4.lua
+++ b/dat/missions/sirius/heretic/heretic4.lua
@@ -8,15 +8,17 @@
    to be very hard, and slightly combat oriented, but more supposed to
    involve smuggling elements.]]
 
+include "numstring.lua"
+
 --beginning messages
 bmsg = {}
 bmsg[1] = _([[You run up to Draga, who has a look of desperation on his face. "We need to go, now," he says. "The Sirii are overwhelming us, they're about to finish us off. Will you take me and as many Nasin as you can carry to %s in the %s system? This is our most desperate hour!"]])
 bmsg[2] = _([["Thank you! I knew you would do it!" Draga then proceeds to file as many people as can possibly fit onto your ship, enough to fill your ship's cargo hold to the brim. The number of Nasin members shocks you as they are packed into your ship.
-    As the Sirii approach ever closer, Draga yells at you to get the ship going and take off. As you get in the cabin and begin taking off, you see Draga under fire by a Sirian soldier. The last thing you see as you take off is Draga laying on the ground, lifeless.]])
+    As the Sirii approach ever closer, Draga yells at you to get the ship going and take off. You begin taking off just in time to see Draga under fire by a Sirian soldier who has infiltrated the base. The last thing you see as you take off is him lying on the ground, lifeless.]])
 
 --ending messages
 emsg = {}
-emsg[1] = _([[You land on %s, and you open the bay doors. You are still amazed at how many people Draga had helped get into the cargo hold. As you help everyone out of your ship, a man walks up to you. "Hello, my name is Jimmy. Thank you for helping all of these people. I am grateful. I've heard about you from Draga, and I will be forever in your debt. Here, please, take this." He presses a credit chip in your hand just as you finish helping everyone out of your ship. It seems it was a job well done.]])
+emsg[1] = _([[You land on %s and open the bay doors. You are still amazed at how many people Draga had helped get into the cargo hold. As you help everyone out of your ship, a man walks up to you. "Hello, my name is Jimmy. Thank you for helping all of these people. I am grateful. I've heard about you from Draga, and I will be forever in your debt. Here, please, take this." He presses a credit chip in your hand just as you finish helping everyone out of your ship. It seems it was a job well done.]])
 
 --mission osd
 osd = {}
@@ -41,8 +43,6 @@ function create()
    --set some mission stuff
    misn.setNPC(npc_name,"neutral/thief2")
    misn.setDesc(bar_desc)
-   misn.setTitle(misn_title)
-   misn.setReward(misn_reward:format(numstring(reward)))
 
    osd[1] = osd[1]:format(targetasset:name(),targetsys:name())
 end
@@ -55,16 +55,16 @@ function accept()
       misn.finish ()
    end
    misn.accept()
-   misn.setDesc(misn_desc:format( targetasset:name(), targetsys:name()))
-   misn.osdCreate(misn_title,osd)
-   misn.osdActive(1)
    player.allowSave(false) -- so the player won't get stuck with a mission they can't complete.
    tk.msg(misn_title,bmsg[2])
-   tk.msg(misn_title,bmsg[3])
    --convo over. time to finish setting the mission stuff.
    misn.markerAdd(targetsys,"high")
    free_cargo = player.pilot():cargoFree()
    people_carried =  (16 * free_cargo) + 7 --average weight per person is 62kg. one ton / 62 is 16. added the +7 for ships with 0 cargo.
+   misn.setTitle(misn_title)
+   misn.setReward(misn_reward:format(numstring(reward)))
+   misn.setDesc(misn_desc:format( targetasset:name(), targetsys:name()))
+   misn.osdCreate(misn_title,osd)
    refugees = misn.cargoAdd("Refugees",free_cargo)
    player.takeoff()
    --get the hooks.
@@ -121,7 +121,6 @@ function misn_over() --arent you glad thats over?
    if planet.cur() == planet.get("Ulios") then
       --introing one of the characters in the next chapter.
       tk.msg(misn_title,emsg[1]:format( targetasset:name() ))
-      tk.msg(misn_title,emsg[2])
       player.pay(reward)
       misn.cargoRm(refugees)
       misn_tracker = misn_tracker + 1
@@ -136,8 +135,7 @@ end
 function abort()
    tk.msg(misn_title,abort_msg:format(numstring(people_carried)))
    misn.cargoJet(refugees)
-   var.push("heretic_misn_tracker",-1) --if the player jettisons the peeps, the nasin will not let the player join there ranks anymore.
-   faction.modPlayerSingle("Nasin",-200) --big boost to the nasin, for completing the prologue
+   faction.modPlayerSingle("Nasin",-200)
    player.allowSave(true)
    misn.finish(true)
 end

--- a/dat/missions/sirius/heretic/heretic4.lua
+++ b/dat/missions/sirius/heretic/heretic4.lua
@@ -38,7 +38,6 @@ function create()
    reward = math.floor((100000+(math.random(5,8)*2000)*(nasin_rep^1.315))*.01+.5)/.01
    homeasset = planet.cur()
    targetasset, targetsys = planet.get("Ulios") --this will be the new HQ for the nasin in the next part.
-   people_carried =  (16 * free_cargo) + 7 --average weight per person is 62kg. one ton / 62 is 16. added the +7 for ships with 0 cargo.
    --set some mission stuff
    misn.setNPC(npc_name,"neutral/thief2")
    misn.setDesc(bar_desc)


### PR DESCRIPTION
There were a whole bunch of problems with the "Heretic" campaign that put me off fixing the more serious problems with it for a long time. I've now done it.

The changes are a bit too numerous to list. Basically, the fixes entail dialog fixes, simplifications, and fixes to code that the author of this campaign clearly expected to do differently than it actually does, among other tweaks that make the campaign work decently OK.

This also includes a fix so that the Sirius "preach" event doesn't keep getting activated over and over again (which was happening because the event never "properly" finished even when it should have). It also removes the pirates as enemies of Nasin, mainly because the only kind of player I can ever see possibly wanting to do this campaign is a pirate-aligned player, and the two factions being enemies discourages that. Plus, Nasin is an outlaw organization, so I don't see why they would have time to clash with pirates.