### PR TITLE
Change to .gitignore : ignore bin folder for OOT compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ src/shaders_c_gen
 
 /.cproject
 /.project
+
+bin/


### PR DESCRIPTION
This is so that people makign OOT compile into a bin folder with subfolders for different architectures can do it easily without Git complaining on lots of unstaged files.

For instance, I do the following :
    bin/lin64
    bin/win32
    bin/win64

Signed-off-by: Benoît 'Mutos' Robin <benoit.robin@hoshikaze.net>