### PR TITLE
Change in .gitignore : ignore datapath.lua and nave-data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ src/shaders_c_gen
 
 /.cproject
 /.project
+
+/datapath.lua
+/naev-data


### PR DESCRIPTION
Make it so that, if someone wants to use a naev-data folder with a datapath.lua file, it is ignored by Git.

Signed-off-by: Benoît 'Mutos' Robin <benoit.robin@hoshikaze.net>