### PR TITLE
Fixed biocores using old (no longer available) gfx names

### DIFF
--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_5.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_5.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_6.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_6.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>660</mass>
   <price>1500000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. This brain has reached Stage X, its full potential.</description>
-  <gfx_store>misc05</gfx_store>
+  <gfx_store>core_system_refined_l1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>100</cpu_max>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>50</mass>
   <price>105000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system01</gfx_store>
+  <gfx_store>core_system_basic_s2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>30</cpu_max>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>50</mass>
   <price>105000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system01</gfx_store>
+  <gfx_store>core_system_basic_s2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>30</cpu_max>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>50</mass>
   <price>105000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system01</gfx_store>
+  <gfx_store>core_system_basic_s2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>30</cpu_max>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>50</mass>
   <price>105000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. This brain has reached Stage X, its full potential.</description>
-  <gfx_store>core_system02</gfx_store>
+  <gfx_store>core_system_refined_s2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>30</cpu_max>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>90</mass>
   <price>165000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>90</mass>
   <price>165000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>90</mass>
   <price>165000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>90</mass>
   <price>165000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>90</mass>
   <price>165000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. This brain has reached Stage X, its full potential.</description>
-  <gfx_store>core_system04</gfx_store>
+  <gfx_store>core_system_refined_m1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>200</mass>
   <price>300000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>65</cpu_max>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>200</mass>
   <price>300000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>65</cpu_max>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>200</mass>
   <price>300000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>65</cpu_max>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>200</mass>
   <price>300000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>65</cpu_max>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_5.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_5.xml
@@ -8,7 +8,7 @@
   <mass>200</mass>
   <price>300000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system03</gfx_store>
+  <gfx_store>core_system_basic_m2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>65</cpu_max>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>200</mass>
   <price>300000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. This brain has reached Stage X, its full potential.</description>
-  <gfx_store>core_system04</gfx_store>
+  <gfx_store>core_system_refined_m2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>65</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_5.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_5.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_6.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_6.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_7.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_7.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system05</gfx_store>
+  <gfx_store>core_system_basic_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>1075</mass>
   <price>2000000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. This brain has reached Stage X, its full potential.</description>
-  <gfx_store>misc05</gfx_store>
+  <gfx_store>core_system_refined_l2</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>130</cpu_max>

--- a/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>14</mass>
   <price>60000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system01</gfx_store>
+  <gfx_store>core_system_basic_s1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>20</cpu_max>

--- a/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>14</mass>
   <price>60000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. All brains start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>core_system01</gfx_store>
+  <gfx_store>core_system_basic_s1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>20</cpu_max>

--- a/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>14</mass>
   <price>60000</price>
   <description>The brain is a Soromid bioship's equivalent to core systems in synthetic ships. Possibly the most important organ, the brain provides processing power and allocates energy to the rest of the organism. This brain has reached Stage X, its full potential.</description>
-  <gfx_store>core_system02</gfx_store>
+  <gfx_store>core_system_refined_s1</gfx_store>
  </general>
  <specific type="modification">
   <cpu_max>20</cpu_max>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_5.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_5.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_6.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_6.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
-  <gfx_store>plating_combat</gfx_store>
+  <gfx_store>refined_hull_h</gfx_store>
  </general>
  <specific type="modification">
   <cargo>70</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>60</mass>
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_s</gfx_store>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>60</mass>
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_s</gfx_store>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>60</mass>
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_s</gfx_store>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>60</mass>
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
-  <gfx_store>plating_combat</gfx_store>
+  <gfx_store>refined_hull_s</gfx_store>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_m</gfx_store>
  </general>
  <specific type="modification">
   <cargo>18</cargo>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_m</gfx_store>
  </general>
  <specific type="modification">
   <cargo>18</cargo>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_m</gfx_store>
  </general>
  <specific type="modification">
   <cargo>18</cargo>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_m</gfx_store>
  </general>
  <specific type="modification">
   <cargo>18</cargo>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
-  <gfx_store>plating_combat</gfx_store>
+  <gfx_store>refined_hull_m</gfx_store>
  </general>
  <specific type="modification">
   <cargo>18</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_l</gfx_store>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_l</gfx_store>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_l</gfx_store>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_l</gfx_store>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_5.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_5.xml
@@ -8,7 +8,7 @@
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_l</gfx_store>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
-  <gfx_store>plating_combat</gfx_store>
+  <gfx_store>refined_hull_l</gfx_store>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_3.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_4.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_5.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_5.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_6.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_6.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_7.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_7.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
-  <gfx_store>plating_combat</gfx_store>
+  <gfx_store>refined_hull_x</gfx_store>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_1.xml
@@ -8,7 +8,7 @@
   <mass>30</mass>
   <price>65000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_t</gfx_store>
  </general>
  <specific type="modification">
   <cargo>4</cargo>

--- a/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_2.xml
@@ -8,7 +8,7 @@
   <mass>30</mass>
   <price>65000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
-  <gfx_store>nanobond</gfx_store>
+  <gfx_store>base_hull_t</gfx_store>
  </general>
  <specific type="modification">
   <cargo>4</cargo>

--- a/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_x.xml
@@ -8,7 +8,7 @@
   <mass>30</mass>
   <price>65000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
-  <gfx_store>plating_combat</gfx_store>
+  <gfx_store>refined_hull_t</gfx_store>
  </general>
  <specific type="modification">
   <cargo>4</cargo>


### PR DESCRIPTION
Prevents errors at the start and makes sure they have some sort of graphics in the shop.