### PR TITLE
Added economy statistics and last purchase price

### DIFF
--- a/src/economy.c
+++ b/src/economy.c
@@ -93,6 +93,12 @@ static int econ_createGMatrix (void);
 credits_t economy_getPrice( const Commodity *com,
       const StarSystem *sys, const Planet *p ); /* externed in land.c */
 
+/*
+ * Externed prototypes.
+ */
+int economy_sysSave( xmlTextWriterPtr writer );
+int economy_sysLoad( xmlNodePtr parent );
+
 /**
  * @brief Converts credits to a usable string for displaying.
  *
@@ -665,7 +671,117 @@ credits_t economy_getPrice( const Commodity *com,
    /* price  = (double) com->price; */
    /* price *= sys->prices[i]; */
    price=commPrice->price + commPrice->sysVariation*sin(2*M_PI*t/commPrice->sysPeriod) + commPrice->planetVariation*sin(2*M_PI*t/commPrice->planetPeriod);
-   return (credits_t) price+0.5;/* +0.5 to round */
+   return (credits_t) (price+0.5);/* +0.5 to round */
+}
+
+/**
+ * @brief Gets the average price of a good on a planet in a system, using a rolling average over the times the player has landed here..
+ *
+ *    @param com Commodity to get price of.
+ *    @param p Planet to get price of commodity.
+ *    @return The average price of the commodity.
+ */
+int economy_getAveragePlanetPrice( const Commodity *com, const Planet *p, credits_t *mean, double *std){
+   int i,k;
+   CommodityPrice *commPrice;
+   printf("Getting averagePlanetPrice for %s\n",com->name);
+   /* Get position in stack */
+   k=com - commodity_stack;
+
+   /* Find what commodity this is */
+   for ( i=0; i<econ_nprices; i++ )
+      if (econ_comm[i] == k)
+         break;
+
+   /* Check if found */
+   if( i>= econ_nprices) {
+      WARN(_("Average price for commodity '%s' not known."), com->name);
+      *mean=0;
+      *std=0;
+      return -1;
+   }
+
+   /* and get the index on this planet */
+   for ( i=0; i<p->ncommodities; i++){
+     if ( !strcmp(p->commodities[i]->name, com->name ))
+       break;
+   }
+   if (i >= p->ncommodities) {
+      WARN(_("Price for commodity '%s' not known on this planet."), com->name);
+      *mean=0;
+      *std=0;
+      return -1;
+   }
+   commPrice = &p->commodityPrice[i];
+   if( commPrice->cnt>0 ){
+      *mean=(credits_t)(commPrice->sum/commPrice->cnt + 0.5); /* +0.5 to round*/
+      *std=sqrt(commPrice->sum2/commPrice->cnt-(commPrice->sum*commPrice->sum)/(commPrice->cnt*commPrice->cnt));
+   }else{
+      *mean=0;
+      *std=0;
+   }
+   printf("commprice average: %ld+-%g\n",*mean,*std);
+   return 0;
+
+}
+
+
+/**
+ * @brief Gets the average price of a good as seen by the player (anywhere).
+ *
+ *    @param com Commodity to get price of.
+ *    @return The average price of the commodity.
+ */
+
+int economy_getAveragePrice( const Commodity *com, credits_t *mean, double *std ){
+   int i,j,k;
+   CommodityPrice *commPrice;
+   StarSystem *sys;
+   Planet *p;
+   double av=0;
+   double av2=0;
+   int cnt=0;
+   /* Get position in stack */
+   k=com - commodity_stack;
+
+   /* Find what commodity this is */
+   for ( i=0; i<econ_nprices; i++ )
+      if (econ_comm[i] == k)
+         break;
+
+   /* Check if found */
+   if( i>= econ_nprices) {
+      WARN(_("Average price for commodity '%s' not known."), com->name);
+      *mean=0;
+      *std=0;
+      return 1;
+   }
+   for ( i=0; i<systems_nstack ; i++){
+      sys=&systems_stack[i];
+      for ( j=0; j<sys->nplanets; j++){
+         p=sys->planets[j];
+         /* and get the index on this planet */
+         for ( k=0; k<p->ncommodities; k++){
+            if ( !strcmp(p->commodities[k]->name, com->name ))
+               break;
+         }
+         if (k < p->ncommodities) {
+            commPrice=&p->commodityPrice[k];
+            if( commPrice->cnt>0){
+               av+=commPrice->sum/commPrice->cnt;
+               av2+=commPrice->sum*commPrice->sum/(commPrice->cnt*commPrice->cnt);
+               cnt++;
+            }
+         }
+      }
+   }
+   if(cnt>0){
+      av/=cnt;
+      av2=sqrt(av2/cnt - av*av);
+   }
+   *mean=(credits_t) (av + 0.5);
+   *std=av2;
+   return 0;
 }
 
 
@@ -1013,7 +1129,10 @@ static int economy_calcPrice( Planet *planet, Commodity *commodity, CommodityPri
    commodityPrice->price *= scale;
    commodityPrice->planetVariation = 0.5;
    commodityPrice->sysVariation = 0.;
-
+   commodityPrice->sum = 0.;
+   commodityPrice->sum2 = 0.;
+   commodityPrice->cnt = 0;
+   commodityPrice->updateTime=0;
    /* Use filename to specify a variation period. */
    base=100;
    period = 32 * (planet->gfx_spaceName[strlen(PLANET_GFX_SPACE_PATH)]%32) + planet->gfx_spaceName[strlen(PLANET_GFX_SPACE_PATH) + 1]%32;
@@ -1091,7 +1210,7 @@ static void economy_modifySystemCommodityPrice(StarSystem *sys){
          
          for( k=0; k<nav; k++){
             if( !strcmp( planet->commodities[j]->name, avprice[k].name ) ){
-               avprice[k].cnt++;
+               avprice[k].updateTime++;
                avprice[k].price+=planet->commodityPrice[j].price;
                avprice[k].planetPeriod+=planet->commodityPrice[j].planetPeriod;
                avprice[k].sysPeriod+=planet->commodityPrice[j].sysPeriod;
@@ -1104,7 +1223,7 @@ static void economy_modifySystemCommodityPrice(StarSystem *sys){
             nav++;
             avprice=realloc( avprice, nav * sizeof(CommodityPrice) );
             avprice[k].name=planet->commodities[j]->name;
-            avprice[k].cnt=1;
+            avprice[k].updateTime=1;
             avprice[k].price=planet->commodityPrice[j].price;
             avprice[k].planetPeriod=planet->commodityPrice[j].planetPeriod;
             avprice[k].sysPeriod=planet->commodityPrice[j].sysPeriod;
@@ -1115,11 +1234,11 @@ static void economy_modifySystemCommodityPrice(StarSystem *sys){
    }
    /* Do some inter-planet averaging */
    for( k=0; k<nav; k++ ){
-      avprice[k].price/=avprice[k].cnt;
-      avprice[k].planetPeriod/=avprice[k].cnt;
-      avprice[k].sysPeriod/=avprice[k].cnt;
-      avprice[k].planetVariation/=avprice[k].cnt;
-      avprice[k].sysVariation/=avprice[k].cnt;
+      avprice[k].price/=avprice[k].updateTime;
+      avprice[k].planetPeriod/=avprice[k].updateTime;
+      avprice[k].sysPeriod/=avprice[k].updateTime;
+      avprice[k].planetVariation/=avprice[k].updateTime;
+      avprice[k].sysVariation/=avprice[k].updateTime;
    }
    /* And now apply the averaging */
    for( i=0; i<sys->nplanets; i++ ){
@@ -1167,9 +1286,9 @@ static void economy_smoothCommodityPrice(StarSystem *sys){
          }
       }
       if(n!=0)
-         avprice[j].temp=price/n;
+         avprice[j].sum=price/n;
       else
-         avprice[j].temp=avprice[j].price;
+         avprice[j].sum=avprice[j].price;
    }
 }
 
@@ -1185,7 +1304,7 @@ static void economy_calcUpdatedCommodityPrice(StarSystem *sys){
    int i,j,k;
    for( j=0; j<nav; j++ ){
       /*Use mean price to adjust current price */
-      avprice[j].price=0.5*(avprice[j].price + avprice[j].temp);
+      avprice[j].price=0.5*(avprice[j].price + avprice[j].sum);
    }
    /*and finally modify assets based on the means */
    for ( i=0; i<sys->nplanets; i++ ){
@@ -1266,4 +1385,208 @@ void economy_initialiseCommodityPrices(void){
          free(this);
       }
    }
+}
+
+void economy_averageSeenPrices( Planet *p ){
+   int i;
+   ntime_t t;
+   Commodity *c;
+   CommodityPrice *cp;
+   credits_t price;
+   t = ntime_get();
+   printf("Averaging prices for planet %s with %d commodities\n",p->name,p->ncommodities);
+   for ( i = 0 ; i < p->ncommodities ; i++ ){
+      c=p->commodities[i];
+      cp=&p->commodityPrice[i];
+      printf("Pointers: %p, %p\n",c,cp);
+      printf("Commodity %s last updated %ld, t=%ld, %s\n",c->name,cp->updateTime,t,cp->updateTime<t?"updating":"not updating");
+      if( cp->updateTime < t ){ //has not yet been updated at present time
+         cp->updateTime = t;
+         /* Calculate a rolling average */
+         cp->cnt++;
+         price = economy_getPrice(c, NULL, p);
+         //printf("Price %ld\n",price);
+         cp->sum += price;
+         cp->sum2 += price*price;
+         /*if ( cp -> cnt == 0 )
+           cp -> average = economy_getPrice( c, NULL, p);
+           else
+           cp->average = 0.75 * cp->average + 0.25 * economy_getPrice( c, NULL, p);*/
+      }
+      if(cp->cnt>0)
+         printf("Av %g +- %g\n",cp->sum/cp->cnt,sqrt(cp->sum2/cp->cnt-(cp->sum*cp->sum)/(cp->cnt*cp->cnt)));
+   }
+}
+/**
+ * @brief Clears all system knowledge.
+ */
+void economy_clearKnown (void)
+{
+   int i, j, k;
+   StarSystem *sys;
+   Planet *p;
+   CommodityPrice *cp;
+   for (i=0; i<systems_nstack; i++) {
+      sys = &systems_stack[i];
+      for (j=0; j<sys->nplanets; j++){
+         p=sys->planets[j];
+         for (k=0; k<p->ncommodities; k++){
+            cp=&p->commodityPrice[k];
+            cp->cnt=0;
+            cp->sum=0;
+            cp->sum2=0;
+            cp->updateTime=0;
+         }
+      }
+   }
+   for (i=0; i<commodity_nstack; i++ ){
+      commodity_stack[i].lastPurchasePrice=0;
+   }
+}
+
+/**
+ * @brief Loads player's economy properties from an XML node.
+ *
+ *    @param parent Parent node for economy.
+ *    @return 0 on success.
+ */
+int economy_sysLoad( xmlNodePtr parent )
+{
+   xmlNodePtr node, cur, nodeAsset, nodeCommodity;
+   StarSystem *sys;
+   char *str;
+   Planet *planet;
+   int i;
+   CommodityPrice *cp;
+   Commodity *c;
+   economy_clearKnown();
+
+   node = parent->xmlChildrenNode;
+
+   do {
+      if (xml_isNode(node,"economy")) {
+         cur = node->xmlChildrenNode;
+         do {
+            if (xml_isNode(cur, "system")) {
+               xmlr_attr(cur,"name",str);
+               sys = system_get(str);
+               free(str);
+               nodeAsset = cur->xmlChildrenNode;
+               do{
+                  if(xml_isNode(nodeAsset, "planet")) {
+                     xmlr_attr(nodeAsset,"name",str);
+                     planet = planet_get(str);
+                     free(str);
+                     nodeCommodity = nodeAsset->xmlChildrenNode;
+                     do{
+                        if(xml_isNode(nodeCommodity, "commodity")) {
+                           xmlr_attr(nodeCommodity,"name",str);
+                           cp=NULL;
+                           for (i=0; i<planet->ncommodities; i++){
+                              if (!strcmp(str,planet->commodities[i]->name)){
+                                 cp=&planet->commodityPrice[i];
+                                 break;
+                              }
+                           }
+                           free(str);
+                           if( cp!=NULL ){
+                              xmlr_attr(nodeCommodity,"sum",str);
+                              if(str){
+                                 cp->sum=atof(str);
+                                 free(str);
+                              }
+                              xmlr_attr(nodeCommodity,"sum2",str);
+                              if(str){
+                                 cp->sum2=atof(str);
+                                 free(str);
+                              }
+                              xmlr_attr(nodeCommodity,"cnt",str);
+                              if(str){
+                                 cp->cnt=atoi(str);
+                                 free(str);
+                              }
+                              xmlr_attr(nodeCommodity,"time",str);
+                              if(str){
+                                 cp->updateTime=atol(str);
+                                 free(str);
+                              }
+                           }
+                        }
+                     }while (xml_nextNode(nodeCommodity));
+                  }
+               } while (xml_nextNode(nodeAsset));
+            }else if(xml_isNode(cur, "lastPurchase")){
+               xmlr_attr(cur, "name", str);
+               if(str){
+                  c=commodity_get(str);
+                  c->lastPurchasePrice=atol(xml_raw(cur));
+                  free(str);
+               }
+            }
+         } while (xml_nextNode(cur));
+      }
+   } while(xml_nextNode(node));
+   return 0;
+}
+
+
+
+/**
+ * @brief Saves what is needed to be saved for economy.
+ *
+ *    @param writer XML writer to use.
+ *    @return 0 on success.
+ */
+int economy_sysSave( xmlTextWriterPtr writer )
+{
+  int i,j,k,doneSys,donePlanet;
+   StarSystem *sys;
+   Planet *p;
+   CommodityPrice *cp;
+   /* Save what the player has seen of the economy at each planet */
+   xmlw_startElem(writer,"economy");
+   for (i=0; i<commodity_nstack; i++){
+      if ( commodity_stack[i].lastPurchasePrice > 0 ){
+         xmlw_startElem(writer, "lastPurchase");
+         xmlw_attr(writer,"name","%s",commodity_stack[i].name);
+         xmlw_str(writer,"%"PRIu64,commodity_stack[i].lastPurchasePrice);
+         xmlw_endElem(writer);
+      }
+   }
+   for (i=0; i<systems_nstack; i++) {
+      doneSys=0;
+      sys=&systems_stack[i];
+      for (j=0; j<sys->nplanets; j++) {
+         p=sys->planets[j];
+         donePlanet=0;
+         for( k=0; k<p->ncommodities; k++){
+            cp=&p->commodityPrice[k];
+            if( cp->cnt > 0 ){/* Player has seen this commodity at this location */
+               if( doneSys==0 ){
+                  doneSys=1;
+                  xmlw_startElem(writer, "system");
+                  xmlw_attr(writer,"name","%s",sys->name);
+               }
+               if( donePlanet==0 ){
+                  donePlanet=1;
+                  xmlw_startElem(writer, "planet");
+                  xmlw_attr(writer,"name","%s",p->name);
+               }
+               xmlw_startElem(writer, "commodity");
+               xmlw_attr(writer,"name","%s",p->commodities[k]->name);
+               xmlw_attr(writer,"sum","%f",cp->sum);
+               xmlw_attr(writer,"sum2","%f",cp->sum2);
+               xmlw_attr(writer,"cnt","%d",cp->cnt);
+               xmlw_attr(writer,"time","%"PRIu64,cp->updateTime);
+               xmlw_endElem(writer); /* commodity */
+            }
+         }
+         if( donePlanet==1 )
+            xmlw_endElem(writer); /* planet */
+      }
+      if( doneSys==1 )
+         xmlw_endElem(writer); /* system */
+   }
+   xmlw_endElem(writer); /* economy */
+   return 0;
 }

--- a/src/economy.c
+++ b/src/economy.c
@@ -1394,12 +1394,9 @@ void economy_averageSeenPrices( Planet *p ){
    CommodityPrice *cp;
    credits_t price;
    t = ntime_get();
-   printf("Averaging prices for planet %s with %d commodities\n",p->name,p->ncommodities);
    for ( i = 0 ; i < p->ncommodities ; i++ ){
       c=p->commodities[i];
       cp=&p->commodityPrice[i];
-      printf("Pointers: %p, %p\n",c,cp);
-      printf("Commodity %s last updated %ld, t=%ld, %s\n",c->name,cp->updateTime,t,cp->updateTime<t?"updating":"not updating");
       if( cp->updateTime < t ){ //has not yet been updated at present time
          cp->updateTime = t;
          /* Calculate a rolling average */
@@ -1413,8 +1410,6 @@ void economy_averageSeenPrices( Planet *p ){
            else
            cp->average = 0.75 * cp->average + 0.25 * economy_getPrice( c, NULL, p);*/
       }
-      if(cp->cnt>0)
-         printf("Av %g +- %g\n",cp->sum/cp->cnt,sqrt(cp->sum2/cp->cnt-(cp->sum*cp->sum)/(cp->cnt*cp->cnt)));
    }
 }
 /**

--- a/src/economy.h
+++ b/src/economy.h
@@ -51,6 +51,7 @@ typedef struct Commodity_ {
    double period; /**< Period of price fluctuation. */
    double population_modifier; /**< Scale of price modification due to population. */
    CommodityModifier *faction_modifier; /**< Price modifier for different factions. */
+   credits_t lastPurchasePrice; /**< Price paid when last purchasing this commodity. */
 } Commodity;
 
 typedef struct CommodityPrice_ {
@@ -59,9 +60,11 @@ typedef struct CommodityPrice_ {
   double sysPeriod; /** Major time period */
   double planetVariation; /**< Mmount by which a commodity price varies */
   double sysVariation; /**< System level commodity price variation.  At a given time, commodity price is equal to price + sysVariation*sin(2pi t/sysPeriod) + planetVariation*sin(2pi t/planetPeriod) */
-  int cnt; /**< used for averaging */
+  int64_t updateTime; /**< used for averaging and to hold the time last average was calculated. */
   char *name; /**< used for keeping tabs during averaging */
-  double temp; /**< used when averaging over jump points during setup */
+  double sum; /**< used when averaging over jump points during setup, and then for capturing the moving average when the player visits a planet. */
+  double sum2; /**< sum of (squared prices seen), used for calc of standard deviation. */
+  int cnt; /**< used for calc of mean and standard deviation - number of records in the data. */
 } CommodityPrice;
 
 /**
@@ -122,6 +125,6 @@ int commodity_compareTech( const void *commodity1, const void *commodity2 );
  * Calculating the sinusoidal economy values
  */
 void economy_initialiseCommodityPrices(void);
-
+int economy_getAveragePrice( const Commodity *com, credits_t *mean, double *std );
 
 #endif /* ECONOMY_H */

--- a/src/land.c
+++ b/src/land.c
@@ -118,6 +118,11 @@ static char *errorlist_ptr;
 static nlua_env rescue_env = LUA_NOREF; /**< Rescue Lua env. */
 static void land_stranded (void);
 
+/*
+ * Averaging of visited commodity prices
+ */
+void economy_averageSeenPrices( Planet *p );
+
 
 /*
  * prototypes
@@ -1096,6 +1101,9 @@ void land( Planet* p, int load )
    if (planet_hasService(land_planet, PLANET_SERVICE_BAR))
       news_load();
 
+   /* Average economy prices that player has seen */
+   economy_averageSeenPrices( p );
+   
    /* Clear the NPC. */
    npc_clear();
 

--- a/src/load.c
+++ b/src/load.c
@@ -68,6 +68,8 @@ extern int pfaction_load( xmlNodePtr parent ); /**< Loads faction data. */
 extern int hook_load( xmlNodePtr parent ); /**< Loads hooks. */
 /* space.c */
 extern int space_sysLoad( xmlNodePtr parent ); /**< Loads the space stuff. */
+/* economy.c */
+extern int economy_sysLoad( xmlNodePtr parent ); /**< Loads the economy stuff. */
 /* unidiff.c */
 extern int diff_load( xmlNodePtr parent ); /**< Loads the universe diffs. */
 /* static */
@@ -584,6 +586,7 @@ int load_game( const char* file, int version_diff )
 
    /* Initialize the economy. */
    economy_init();
+   economy_sysLoad(node);
 
    /* Check sanity. */
    event_checkSanity();

--- a/src/save.c
+++ b/src/save.c
@@ -56,6 +56,8 @@ extern int pfaction_save( xmlTextWriterPtr writer ); /**< Saves faction data. */
 extern int hook_save( xmlTextWriterPtr writer ); /**< Saves hooks. */
 /* space.c */
 extern int space_sysSave( xmlTextWriterPtr writer ); /**< Saves the space stuff. */
+/* economy.c */
+extern int economy_sysSave( xmlTextWriterPtr writer ); /**< Saves the economy stuff. */
 /* unidiff.c */
 extern int diff_save( xmlTextWriterPtr writer ); /**< Saves the universe diffs. */
 /* static */
@@ -80,7 +82,7 @@ static int save_data( xmlTextWriterPtr writer )
    if (pfaction_save(writer) < 0) return -1;
    if (hook_save(writer) < 0) return -1;
    if (space_sysSave(writer) < 0) return -1;
-
+   if (economy_sysSave(writer) < 0) return -1;
    return 0;
 }
 

--- a/src/space.c
+++ b/src/space.c
@@ -175,6 +175,7 @@ int space_sysLoad( xmlNodePtr parent );
  */
 extern credits_t economy_getPrice( const Commodity *com,
       const StarSystem *sys, const Planet *p ); /**< from economy.c */
+extern credits_t economy_getAveragePlanetPrice( const Commodity *com, const Planet *p, credits_t *mean, double *std ); /**< from economy.c */
 
 
 char* planet_getServiceName( int service )
@@ -234,6 +235,15 @@ credits_t planet_commodityPrice( const Planet *p, const Commodity *c )
    return economy_getPrice( c, sys, p );
 }
 
+/**
+ * @brief Gets the average price of a commodity at a planet that has been seen so far.
+ *
+ * @param p Planet to get average price at.
+ * @param c Commodity to get average price of.
+ */
+int planet_averagePlanetPrice( const Planet *p, const Commodity *c, credits_t *mean, double *std){
+  return economy_getAveragePlanetPrice( c, p, mean, std );
+}
 
 /**
  * @brief Changes the planets faction.
@@ -3912,8 +3922,7 @@ int space_rmMarker( int sys, SysMarker type )
  */
 int space_sysSave( xmlTextWriterPtr writer )
 {
-   int i;
-   int j;
+  int i,j;
    StarSystem *sys;
 
    xmlw_startElem(writer,"space");

--- a/src/space.h
+++ b/src/space.h
@@ -350,6 +350,7 @@ char **planet_searchFuzzyCase( const char* planetname, int *n );
 char* planet_getServiceName( int service );
 int planet_getService( char *name );
 credits_t planet_commodityPrice( const Planet *p, const Commodity *c );
+int planet_averagePlanetPrice( const Planet *p, const Commodity *c, credits_t *mean, double *std);
 /* Misc modification. */
 int planet_setFaction( Planet *p, int faction );
 /* Land related stuff. */


### PR DESCRIPTION
This merge request improves on the basic economy stuff.
When a player visits a planet, the commodity price information is collected, as is the price at which a player last purchased each commodity.
This greatly helps game play as it gives the player an idea of whether a certain commodity is more or less expensive than average (of what they have already seen), and also reminds them of what they purchased the commodity for - so that they decide to sell if it makes a profit or not.
For each commodity on each planet so far seen, 4 bits of data are saved, from which the mean and standard deviation of prices can be calculated.
These are displayed in the commodities tab, in the form of average price +- std, for the current planet, and for the galaxy as a whole.
