### PR TITLE
Fixed equipping of Soromid Brigand

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
       * Added the ability to buy "fake IDs" from pirate strongholds
       * Made jammers into activated outfits that increase cloaking
       * Added Soromid organic ships that level up organs
+      * Improved and expanded NPC portraits
       * New and/or improved missions
          * Completed the FLF campaign
          * Fixed up the Collective campaign

--- a/dat/factions/equip/soromid.lua
+++ b/dat/factions/equip/soromid.lua
@@ -2,12 +2,14 @@ include("dat/factions/equip/generic.lua")
 
 
 equip_typeOutfits_weapons["Brigand"] = {
-   varied = true, probability = {
-      ["BioPlasma Organ Stage X"] = 3
-   };
-   "BioPlasma Organ Stage 1", "BioPlasma Organ Stage 2",
-   "BioPlasma Organ Stage 3", "BioPlasma Organ Stage X",
-   "Plasma Blaster MK3"
+   {
+      varied = true, probability = {
+         ["BioPlasma Organ Stage X"] = 3
+      };
+      "BioPlasma Organ Stage 1", "BioPlasma Organ Stage 2",
+      "BioPlasma Organ Stage 3", "BioPlasma Organ Stage X",
+      "Plasma Blaster MK3"
+   }
 }
 
 


### PR DESCRIPTION
Was broken because the table for it was malformed.

I also updated the changelog to mention the changed portraits.