### PR TITLE
Updates to NSIS installer, and fixes to allow for cross compile.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -361,11 +361,15 @@ AS_IF([test "$used_csparse" = "internal"], [
     CSPARSE_CFLAGS="-I\"\$(top_srcdir)/lib/csparse\""
     CSPARSE_LIBS="\$(top_builddir)/lib/csparse/libcsparse.a"
 ])
+# OpenAL
+# AS_IF([test "$with_openal" = "yes"], [
+#  AM_PATH_OPENAL([have_openal=yes], [have_openal=no])
+#])
 
 # OpenAL
 AS_IF([test "$with_openal" = "yes"], [
-  AM_PATH_OPENAL([have_openal=yes], [have_openal=no])
-])
+  PKG_CHECK_MODULES([OPENAL], [openal], [have_openal=yes], [have_openal=no])
+], [have_openal=no])
 
 # SDL_mixer
 AS_IF([test "$with_sdlmixer" = "yes"], [
@@ -644,6 +648,7 @@ AM_CONDITIONAL([HAVE_DOCS], [test "x$have_docs" = "xyes"])
 AM_CONDITIONAL([HAVE_MKSPR], [test "x$have_mkspr" = "xyes"])
 AM_CONDITIONAL([LUA_INTERNAL], [test "x$used_lua" = "xinternal"])
 AM_CONDITIONAL([CSPARSE_INTERNAL], [test "x$used_csparse" = "xinternal"])
+AM_CONDITIONAL([HAVE_SHADERS_C_GEN], [test -f "src/shaders_c_gen.c"])
 
 #
 # Output

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -67,7 +67,6 @@ function make_windows {
       get_version
       mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    fi
-
 }
 
 function make_win32 {

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -51,12 +51,14 @@ function make_windows {
    log "Compiling $2"
    make distclean
    ./autogen.sh
-   if [$2 = "win32"] then
+   if [$2 == 'win32'] 
+   then
       mingw32-configure $1
       mingw32-make ${CFLAGS}
       get_version
       mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
-   elif [$2 = "win64"]  
+   elif [$2 == 'win64'] 
+   then
       mingw64-configure $1
       mingw64-make ${CFLAGS}
       get_version

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -6,6 +6,9 @@
 # to the "dist/" directory.
 #
 # Steam sdk should be unpacked, set up, and named "steam/" in the naev directory.
+# For Windows Cross-Compile, it is assumed that a  working MXE environment is configured with all packages required to build.
+# Wine is required at buildtime for Windows builds.
+
 
 if [[ ! -f "naev.6" ]]; then
    echo "Please run from Naev root directory."
@@ -61,11 +64,11 @@ function make_windows {
       make ${CFLAGS}
    fi
    get_version
-   mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
+   mv src/naev.exe "${OUTPUTDIR}/naev-${VERSION}-$2.exe"
 }
 
 function make_win32 {
-   make_windows "--enable-lua=internal --with-openal=no" "win32" # Disabled due to issues while compiling.. not sure what is up.
+   make_windows "--enable-lua=internal" "win32"
 }
 
 function make_win64 {
@@ -121,9 +124,9 @@ make VERSION
 # Make stuff
 make_source          2>&1 | tee -a "${LOGFILE}"
 make_ndata           2>&1 | tee -a "${LOGFILE}"
-make_win32           2>&1 | tee -a "${LOGFILE}"
-make_win64           2>&1 | tee -a "${LOGFILE}"
+#make_win32           2>&1 | tee -a "${LOGFILE}" # Enable if you'd like to cross compile
+#make_win64           2>&1 | tee -a "${LOGFILE}" # Enable if you'd like to cross compile
 make_linux_64        2>&1 | tee -a "${LOGFILE}"
-#make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
+make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
 
 

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -51,22 +51,21 @@ function make_windows {
    log "Compiling $2"
    make distclean
    ./autogen.sh
-   if [ $2 == 'win32' ] 
+   if [ $2 = "win32" ] 
    then
-      mingw32-configure $1
-      mingw32-make ${CFLAGS}
-      get_version
-      mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
-   elif [ $2 == 'win64' ] 
-      mingw64-configure $1
-      mingw64-make ${CFLAGS}
-      get_version
-      mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
+      ./configure --host=i686-w64-mingw32.static $1
+      make ${CFLAGS}
+   elif [ $2 = "win64" ]
+   then
+      ./configure --host=x86_64-w64-mingw32.static $1
+      make ${CFLAGS}
    fi
+   get_version
+   mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
 }
 
 function make_win32 {
-   make_windows "--enable-lua=internal" "win32"
+   make_windows "--enable-lua=internal --with-openal=no" "win32"
 }
 
 function make_win64 {
@@ -116,15 +115,15 @@ touch "${LOGFILE}"
 # Preparation
 make distclean
 ./autogen.sh
-./configure --enable-lua=internal --enable-csparse=internal
+./configure --enable-lua=internal
 make VERSION
 
 # Make stuff
 make_source          2>&1 | tee -a "${LOGFILE}"
 make_ndata           2>&1 | tee -a "${LOGFILE}"
-# make_win32           2>&1 | tee -a "${LOGFILE}" Assumes working mingw cross compile environment exists
-# make_win64           2>&1 | tee -a "${LOGFILE}" Assumes working mingw cross compile environment exists
+make_win32           2>&1 | tee -a "${LOGFILE}"
+make_win64           2>&1 | tee -a "${LOGFILE}"
 make_linux_64        2>&1 | tee -a "${LOGFILE}"
-make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
+#make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
 
 

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -12,11 +12,12 @@ if [[ ! -f "naev.6" ]]; then
    exit -1
 fi
 
+CORECOUNT=$"(cat nproc --all)"
 NAEVDIR="$(pwd)"
 OUTPUTDIR="${NAEVDIR}/dist/"
 STEAMPATH="${NAEVDIR}/steam/tools/linux/"
 LOGFILE="release.log"
-CFLAGS="-j5"
+CFLAGS="-j${CORECOUNT}"
 
 function log {
    echo
@@ -52,14 +53,21 @@ function make_windows {
    ./autogen.sh
    if [$2 = "win32"] then
       mingw32-configure $1
+      mingw32-make ${CFLAGS}
+      get_version
+      mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    elif [$2 = "win64"]  
       mingw64-configure $1
+      mingw32-make ${CFLAGS}
+      get_version
+      mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    else
       ./configure $1
+      make ${CFLAGS}
+      get_version
+      mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    fi
-   make ${CFLAGS}
-   get_version
-   mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
+
 }
 
 function make_win32 {

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -36,7 +36,7 @@ function get_version {
    fi
 }
 
-function make_generic {
+function make_linux {
    log "Compiling $2"
    make distclean
    ./autogen.sh
@@ -46,8 +46,32 @@ function make_generic {
    mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
 }
 
+function make_windows {
+   log "Compiling $2"
+   make distclean
+   ./autogen.sh
+   if [$2 = "win32"] then
+      mingw32-configure $1
+   elif [$2 = "win64"]  
+      mingw64-configure $1
+   else
+      ./configure $1
+   fi
+   make ${CFLAGS}
+   get_version
+   mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
+}
+
+function make_win32 {
+   make_windows "" "win32"
+}
+
+function make_win64 {
+   make_windows "" "win64"
+}
+
 function make_linux_64 {
-   make_generic "--enable-lua=internal" "linux-x86-64"
+   make_linux "--enable-lua=internal" "linux-x86-64"
 }
 
 function make_linux_steam_64 {
@@ -95,6 +119,8 @@ make VERSION
 # Make stuff
 make_source          2>&1 | tee -a "${LOGFILE}"
 make_ndata           2>&1 | tee -a "${LOGFILE}"
+make_win32           2>&1 | tee -a "${LOGFILE}"
+make_win64           2>&1 | tee -a "${LOGFILE}"
 make_linux_64        2>&1 | tee -a "${LOGFILE}"
 make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
 

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -58,7 +58,7 @@ function make_windows {
       mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    elif [$2 = "win64"]  
       mingw64-configure $1
-      mingw32-make ${CFLAGS}
+      mingw64-make ${CFLAGS}
       get_version
       mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    else

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -17,7 +17,7 @@ NAEVDIR="$(pwd)"
 OUTPUTDIR="${NAEVDIR}/dist/"
 STEAMPATH="${NAEVDIR}/steam/tools/linux/"
 LOGFILE="release.log"
-CFLAGS="-j${CORECOUNT}"
+CFLAGS=("-j" + ${CORECOUNT})
 
 function log {
    echo
@@ -51,21 +51,15 @@ function make_windows {
    log "Compiling $2"
    make distclean
    ./autogen.sh
-   if [$2 == 'win32'] 
+   if [ $2 == 'win32' ] 
    then
       mingw32-configure $1
       mingw32-make ${CFLAGS}
       get_version
       mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
-   elif [$2 == 'win64'] 
-   then
+   elif [ $2 == 'win64' ] 
       mingw64-configure $1
       mingw64-make ${CFLAGS}
-      get_version
-      mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
-   else
-      ./configure $1
-      make ${CFLAGS}
       get_version
       mv src/naev "${OUTPUTDIR}/naev-${VERSION}-$2"
    fi

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -70,11 +70,11 @@ function make_windows {
 }
 
 function make_win32 {
-   make_windows "" "win32"
+   make_windows "--enable-lua=internal --enable-csparse=internal" "win32"
 }
 
 function make_win64 {
-   make_windows "" "win64"
+   make_windows "--enable-lua=internal --enable-csparse=internal" "win64"
 }
 
 function make_linux_64 {
@@ -124,11 +124,11 @@ make distclean
 make VERSION
 
 # Make stuff
-make_source          2>&1 | tee -a "${LOGFILE}"
+#make_source          2>&1 | tee -a "${LOGFILE}"
 make_ndata           2>&1 | tee -a "${LOGFILE}"
 make_win32           2>&1 | tee -a "${LOGFILE}"
 make_win64           2>&1 | tee -a "${LOGFILE}"
-make_linux_64        2>&1 | tee -a "${LOGFILE}"
-make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
+#make_linux_64        2>&1 | tee -a "${LOGFILE}"
+#make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
 
 

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -65,7 +65,7 @@ function make_windows {
 }
 
 function make_win32 {
-   make_windows "--enable-lua=internal --with-openal=no" "win32"
+   make_windows "--enable-lua=internal --with-openal=no" "win32" # Disabled due to issues while compiling.. not sure what is up.
 }
 
 function make_win64 {

--- a/extras/release.sh
+++ b/extras/release.sh
@@ -66,11 +66,11 @@ function make_windows {
 }
 
 function make_win32 {
-   make_windows "--enable-lua=internal --enable-csparse=internal" "win32"
+   make_windows "--enable-lua=internal" "win32"
 }
 
 function make_win64 {
-   make_windows "--enable-lua=internal --enable-csparse=internal" "win64"
+   make_windows "--enable-lua=internal" "win64"
 }
 
 function make_linux_64 {
@@ -120,11 +120,11 @@ make distclean
 make VERSION
 
 # Make stuff
-#make_source          2>&1 | tee -a "${LOGFILE}"
+make_source          2>&1 | tee -a "${LOGFILE}"
 make_ndata           2>&1 | tee -a "${LOGFILE}"
-make_win32           2>&1 | tee -a "${LOGFILE}"
-make_win64           2>&1 | tee -a "${LOGFILE}"
-#make_linux_64        2>&1 | tee -a "${LOGFILE}"
-#make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
+# make_win32           2>&1 | tee -a "${LOGFILE}" Assumes working mingw cross compile environment exists
+# make_win64           2>&1 | tee -a "${LOGFILE}" Assumes working mingw cross compile environment exists
+make_linux_64        2>&1 | tee -a "${LOGFILE}"
+make_linux_steam_64  2>&1 | tee -a "${LOGFILE}"
 
 

--- a/extras/win_installer/naev.nsi
+++ b/extras/win_installer/naev.nsi
@@ -4,9 +4,9 @@
 ;Enables Unicode installer to clear ANSI deprecation message 
 Unicode true
 ;Version, Arch, Icon and URL
-!define VERSION "0.8.0"
-!define VERSION_SUFFIX "-beta1" ; This string can be used for betas and release candidates.
-!define ARCH "32"
+;!define VERSION "0.8.0"
+;!define VERSION_SUFFIX "-beta1" ; This string can be used for betas and release candidates.
+;!define ARCH "32"
 !define URL "https://naev.org"
 !define MUI_ICON "..\logos\logo.ico"
 ;!define MUI_UNICON "..\logos\logo.ico"

--- a/extras/win_installer/naev.nsi
+++ b/extras/win_installer/naev.nsi
@@ -1,6 +1,8 @@
 ;For testing the script
 ;SetCompress Off
 
+;Enables Unicode installer to clear ANSI deprecation message 
+Unicode true
 ;Version, Arch, Icon and URL
 !define VERSION "0.8.0"
 !define VERSION_SUFFIX "-beta1" ; This string can be used for betas and release candidates.
@@ -69,7 +71,7 @@ Var StartMenuFolder
 
 !insertmacro MUI_PAGE_INSTFILES
 
-!define MUI_FINISHPAGE_RUN $INSTDIR\naev.exe
+!define MUI_FINISHPAGE_RUN $INSTDIR\naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe
 !define MUI_FINISHPAGE_RUN_PARAMETERS
 !insertmacro MUI_PAGE_FINISH
 
@@ -92,7 +94,7 @@ Section "Naev Engine" BinarySection
 
    SetOutPath "$INSTDIR"
    File bin\*.dll
-   File bin\naev.exe
+   File bin\naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe
    File ..\logos\logo.ico
    
    IntOp $PortID $PortID & ${SF_SELECTED}
@@ -106,12 +108,12 @@ Section "Naev Engine" BinarySection
 
    ;Add uninstall information
    WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "DisplayName" "Naev"
-   WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "DisplayIcon" "$\"$INSTDIR\naev.exe$\""
+   WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "DisplayIcon" "$\"$INSTDIR\naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe$\""
    WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
    WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "QuietUninstallString" "$\"$INSTDIR\Uninstall.exe$\" /S"
    WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "URLInfoAbout" "${URL}"
    WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "DisplayVersion" "${VERSION}${VERSION_SUFFIX}"
-   WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "Publisher" "Naev Project"
+   WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "Publisher" "Naev Team"
    WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "NoModify" 1
    WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Naev" "NoRepair" 1
 
@@ -119,8 +121,8 @@ Section "Naev Engine" BinarySection
 
       ;Create shortcuts
       CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
-      CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Naev.lnk" "$INSTDIR\naev.exe"
-      CreateShortCut "$DESKTOP\Naev.lnk" "$INSTDIR\naev.exe"
+      CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Naev.lnk" "$INSTDIR\naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe"
+      CreateShortCut "$DESKTOP\Naev.lnk" "$INSTDIR\naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe"
 
    !insertmacro MUI_STARTMENU_WRITE_END
    ${Else}
@@ -131,11 +133,12 @@ SectionEnd
 
 Section "Naev Data (Download)" DataSection
    dwn:
-    AddSize 296859 ;Size (kB) of Naev ndata   
-    NSISdl::download "https://github.com/naev/naev/releases/download/naev-${VERSION}${VERSION_SUFFIX}/ndata-${VERSION}${VERSION_SUFFIX}.zip" "ndata.zip"
+    AddSize 331538 ;Size (kB) of Naev ndata
+    ;use inetc due to the fact that NSISdl cannot download via HTTPS   
+    inetc::get "http://github.com/naev/naev/releases/download/naev-${VERSION}${VERSION_SUFFIX}/ndata-${VERSION}${VERSION_SUFFIX}.zip" "ndata.zip"
     Pop $R0 ;Get the return value
-      StrCmp $R0 "success" skip
-        MessageBox MB_YESNO|MB_ICONEXCLAMATION "Download failed due to: $R0$\n$\nPlease note that naev wont work until you download ndata.zip and put it in the same folder as naev.exe.$\n$\nRetry?" IDNO skip
+      StrCmp $R0 "OK" skip
+        MessageBox MB_YESNO|MB_ICONEXCLAMATION "Download failed due to: $R0$\n$\nPlease note that naev wont work until you download ndata.zip and put it in the same folder as naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe.$\n$\nRetry?" IDNO skip
       Goto dwn
    skip:
 SectionEnd
@@ -186,7 +189,7 @@ FunctionEnd
 Section "Uninstall"
 
    Delete "$INSTDIR\Uninstall.exe"
-   Delete "$INSTDIR\naev.exe"
+   Delete "$INSTDIR\naev-${VERSION}${VERSION_SUFFIX}-win${ARCH}.exe"
    Delete "$INSTDIR\logo.ico"
    Delete "$INSTDIR\ndata.zip"
    Delete "$INSTDIR\*.dll"

--- a/src/music.c
+++ b/src/music.c
@@ -16,7 +16,11 @@
 #include "SDL.h"
 
 #include "music_sdlmix.h"
+
+#if USE_OPENAL
 #include "music_openal.h"
+#endif /* Comment out if not using OpenAL*/
+
 #include "nlua.h"
 #include "nluadef.h"
 #include "nlua_var.h"

--- a/src/music_openal.c
+++ b/src/music_openal.c
@@ -4,7 +4,6 @@
 
 #if USE_OPENAL
 
-
 #include "music_openal.h"
 
 #include <math.h>

--- a/src/music_openal.h
+++ b/src/music_openal.h
@@ -2,6 +2,7 @@
  * See Licensing and Copyright notice in naev.h
  */
 
+
 #if USE_OPENAL
 
 #ifndef MUSIC_OPENAL_H

--- a/src/music_openal.h
+++ b/src/music_openal.h
@@ -2,14 +2,10 @@
  * See Licensing and Copyright notice in naev.h
  */
 
-
+#if USE_OPENAL
 
 #ifndef MUSIC_OPENAL_H
 #  define MUSIC_OPENAL_H
-
-
-#if USE_OPENAL
-
 
 #include "SDL_rwops.h"
 
@@ -50,7 +46,7 @@ void music_al_setPos( double sec );
 int music_al_isPlaying (void);
 
 
-#endif /* USE_OPENAL */
-
-
 #endif /* MUSIC_OPENAL_H */
+
+
+#endif /* USE_OPENAL */

--- a/src/nopenal.c
+++ b/src/nopenal.c
@@ -1,6 +1,7 @@
 /*
  * See Licensing and Copyright notice in naev.h
  */
+#if USE_OPENAL
 
 #include "nopenal.h"
 
@@ -31,3 +32,4 @@ ALvoid (AL_APIENTRY *nalEffectiv)(ALuint,ALenum,ALint*);
 ALvoid (AL_APIENTRY *nalEffectf)(ALuint,ALenum,ALfloat);
 ALvoid (AL_APIENTRY *nalEffectfv)(ALuint,ALenum,ALfloat*);
 
+#endif /* USE_OPENAL */

--- a/src/nopenal.h
+++ b/src/nopenal.h
@@ -11,8 +11,8 @@
 
 #include "ncompat.h"
 
-#include OPENAL_ALC_H
-#include OPENAL_AL_H
+#include "alc.h"
+#include "al.h"
 
 /*
  * EFX stuff.

--- a/src/sound_priv.h
+++ b/src/sound_priv.h
@@ -12,7 +12,7 @@
  */
 
 #if USE_OPENAL
-#include OPENAL_AL_H
+#include "al.h"
 #endif /* USE_OPENAL */
 
 #if USE_SDLMIX


### PR DESCRIPTION
I have updated the NSIS installer script to correctly point to github releases, a new plugin is required.
You can find it [here](https://nsis.sourceforge.io/Inetc_plug-in). It allows for fancy proxy downloads and other methods of downloading files, most importantly over HTTPS, which NSISdl lacks in terms of functionality.

When the installer is built, it is bundled with the output, however it is required to be installed in order to build the installer.

It looks like some preprocessor macros weren't set up right in some of the OpenAL headers and source files. This would cause failures when building without OpenAL.

I also tweaked configure.ac to properly check for OpenAL using the autotools PKGCONFIG modules. (I think, I'm still attempting to learn how it works, the GNU documentation sorta blows)