### PR TITLE
Change Travis to use Homebrew SDL2 packages for MacOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,12 @@ before_install:
   - |
     # Install macOS dependencies
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      wget -O ~/SDL2.dmg https://www.libsdl.org/release/SDL2-2.0.5.dmg
-      hdiutil attach ~/SDL2.dmg
-      mkdir -p ~/Library/Frameworks
-      cp -r /Volumes/SDL2/SDL2.framework ~/Library/Frameworks/SDL2.framework
-
       brew update
 
       brew install \
+        sdl2 \
+        sdl2_mixer \
+        sdl2_image \
         fontconfig \
         freetype \
         libpng \

--- a/extras/macos/bundle.sh
+++ b/extras/macos/bundle.sh
@@ -6,8 +6,7 @@
 # This script assumes the environment we set up in Travis, and copies the
 # dependencies to the bundle. These are:
 #
-# - From Homebrew: freetype, libpng, libvorbis, libzip, luajit
-# - SDL2 framework installed in ~/Library/Frameworks
+# - From Homebrew: freetype, libpng, libvorbis, libzip, luajit, sdl2, sdl2_mixer, sdl2_image
 
 set -e
 
@@ -22,10 +21,6 @@ mkdir -p Naev.app/Contents/{MacOS,Resources,Frameworks}/
 cp extras/macos/Info.plist Naev.app/Contents/
 cp extras/macos/naev.icns Naev.app/Contents/Resources/
 cp src/naev Naev.app/Contents/MacOS/
-
-# Bundle the SDL2 framework.
-cp -R ~/Library/Frameworks/SDL2.framework \
-  Naev.app/Contents/Frameworks/SDL2.framework
 
 # Find all Homebrew dependencies (from /usr/local),
 # and descend to find deps of deps.
@@ -67,7 +62,6 @@ for dep in $deps; do
 done
 
 # Apply changes to the Naev executable, and add the rpath entry.
-# (This rpath entry also covers the lookup of the SDL2 framework.)
 install_name_tool $change_args \
   -add_rpath @executable_path/../Frameworks \
   Naev.app/Contents/MacOS/naev


### PR DESCRIPTION
This should fix travis builds for MacOS. 
I keep seeing failed travis builds which pass on linux but fail on MacOS due to missing sdl2, this should at least get builds to actually start on MacOS, to see if there are other issues.