### PR TITLE
Subtract viewport position for mouse events in the GUI.

### DIFF
--- a/dat/gui/brushed.lua
+++ b/dat/gui/brushed.lua
@@ -187,7 +187,8 @@ function create()
 
    bbar_w, bbar_h = bottom_bar:dim()
 
-   gui.viewport( 0, 36, screen_w, screen_h - 72 )
+   yoffset = 36 -- Exclude top and bottom bars from main area
+   gui.viewport( 0, yoffset, screen_w, screen_h - yoffset*2 )
 
    fields_y = tbar_y + 15
    if screen_w <=1024 then

--- a/src/gui.c
+++ b/src/gui.c
@@ -2316,7 +2316,8 @@ int gui_handleEvent( SDL_Event *evt )
          if (!gui_L_mmove)
             break;
          gui_prepFunc( "mouse_move" );
-         gl_windowToScreenPos( &x, &y, evt->motion.x, evt->motion.y );
+         gl_windowToScreenPos( &x, &y, evt->motion.x - gui_viewport_x,
+               evt->motion.y - gui_viewport_y );
          lua_pushnumber( naevL, x );
          lua_pushnumber( naevL, y );
          gui_runFunc( "mouse_move", 2, 0 );
@@ -2329,7 +2330,8 @@ int gui_handleEvent( SDL_Event *evt )
             break;
          gui_prepFunc( "mouse_click" );
          lua_pushnumber( naevL, evt->button.button+1 );
-         gl_windowToScreenPos( &x, &y, evt->button.x, evt->button.y );
+         gl_windowToScreenPos( &x, &y, evt->button.x - gui_viewport_x,
+            evt->button.y - gui_viewport_y );
          lua_pushnumber( naevL, x );
          lua_pushnumber( naevL, y );
          lua_pushboolean( naevL, (evt->type==SDL_MOUSEBUTTONDOWN) );


### PR DESCRIPTION
This causes mouse positions to be identical to graphical positions
from a Lua perspective. (Also fixes a bug where buttons in Brushed were offset.)