### PR TITLE
support for commodities sellable and buyable anywhere

### DIFF
--- a/dat/assets/eiroik.xml
+++ b/dat/assets/eiroik.xml
@@ -15,7 +15,6 @@
   <services>
    <land/>
   </services>
-  <commodities/>
   <description>Eiroik was a former mining planet under Empire rule, known for its toxic atmosphere and difficult, rough terrain produced through millennia of volcanic activity. The few human colonies were eradicated by the Collective. The generators have failed and the former spaceport lies in ruins. All that remains is dust.</description>
  </general>
 </asset>

--- a/dat/assets/vaal.xml
+++ b/dat/assets/vaal.xml
@@ -15,7 +15,6 @@
   <services>
    <land/>
   </services>
-  <commodities/>
   <description>This mysterious, stormy world has a rich amount of minerals and noble gasses in its atmosphere, but seems abandoned of life. It seems that a Za'lek survey once invesigated this world, explaining the small landing pad, but no other sign of their presence or indeed any human presence here at all. Just the sound of the wind and distant thunder as your only companion</description>
  </general>
 </asset>

--- a/dat/commodity.xml
+++ b/dat/commodity.xml
@@ -27,6 +27,7 @@
   <description>Ore is a key material in many industries. Smelted into metals, without ore, the ship-building industry and many others would grind to a halt.</description>
   <price>210</price>
   <gfx_store>base</gfx_store>
+  <standard/>
   <planet_modifier type="2">1.1</planet_modifier>
   <planet_modifier type="H">1.05</planet_modifier>
   <planet_modifier type="I">1.2</planet_modifier>
@@ -50,6 +51,7 @@
   <price>450</price>
   <gfx_store>gold</gfx_store>
   <gfx_space>gold</gfx_space>
+  <standard/>
   <planet_modifier type="0">1.2</planet_modifier>
   <planet_modifier type="1">1.3</planet_modifier>
   <planet_modifier type="2">1.4</planet_modifier>

--- a/src/economy.c
+++ b/src/economy.c
@@ -60,6 +60,11 @@ static Commodity* commodity_stack = NULL; /**< Contains all the commodities. */
 static int commodity_nstack       = 0; /**< Number of commodities in the stack. */
 
 
+/* standard commodities (ie. sellable and buyable anywhere) */
+static int* commodity_standard = NULL; /**< Contains all the standard commoditie's indices. */
+static int commodity_nstandard = 0; /**< Number of standard commodities. */
+
+
 /* systems stack. */
 extern StarSystem *systems_stack; /**< Star system stack. */
 extern int systems_nstack; /**< Number of star systems. */
@@ -247,6 +252,29 @@ int commodity_compareTech( const void *commodity1, const void *commodity2 )
 
 
 /**
+ * @brief Return the list of standard commodities.
+ *
+ *    @param[out] Commodity* List of commodities.
+ *    @return size of the list.
+ */
+Commodity ** standard_commodities( unsigned int *nb )
+{
+   int i;
+   Commodity **com;
+
+   *nb = commodity_nstandard;
+
+   if (commodity_nstandard == 0)
+      return NULL;
+
+   com = malloc( commodity_nstandard * sizeof(Commodity*) );
+   for (i=0; i<commodity_nstandard; i++) {
+      com[i] = &commodity_stack[ commodity_standard[i] ];
+   }
+   return com;
+}
+
+/**
  * @brief Loads a commodity.
  *
  *    @param temp Commodity to load data into.
@@ -261,6 +289,7 @@ static int commodity_parse( Commodity *temp, xmlNodePtr parent )
    memset( temp, 0, sizeof(Commodity) );
    temp->period=200;
    temp->population_modifier=0.;
+   temp->standard = 0;
 
    /* Parse body. */
    node = parent->xmlChildrenNode;
@@ -279,6 +308,13 @@ static int commodity_parse( Commodity *temp, xmlNodePtr parent )
          } else {
             temp->gfx_store = gl_newImage( COMMODITY_GFX_PATH"_default.png", 0 );
          }
+         continue;
+      }
+      if (xml_isNode(node, "standard")) {
+         temp->standard = 1;
+         /* There is a shortcut list containing the standard commodities. */
+         commodity_standard = realloc(commodity_standard, sizeof(int)*(++commodity_nstandard));
+         commodity_standard[ commodity_nstandard-1 ] = commodity_nstack-1;
          continue;
       }
       xmlr_float(node, "population_modifier", temp->population_modifier);
@@ -617,6 +653,8 @@ void commodity_free (void)
    free( commodity_stack );
    commodity_stack = NULL;
    commodity_nstack = 0;
+   commodity_standard = NULL;
+   commodity_nstandard = 0;
 
    /* More clean up. */
    free( econ_comm );
@@ -1176,6 +1214,11 @@ static int economy_calcPrice( Planet *planet, Commodity *commodity, CommodityPri
       Some factions are more stable than others.*/
    scale=1.;
    cm=commodity->planet_modifier;
+
+   /* Check the faction is not NULL.*/
+   if ( planet->faction == -1 )
+      WARN(_("Some commodities are assignated to an asset without owner."));
+
    factionname=faction_name(planet->faction);
    while ( cm!=NULL ) {
      if ( !strcmp( factionname, cm->name ) ){
@@ -1413,7 +1456,7 @@ void economy_averageSeenPrices( const Planet *p ){
    for ( i = 0 ; i < p->ncommodities ; i++ ){
       c=p->commodities[i];
       cp=&p->commodityPrice[i];
-      if( cp->updateTime < t ){ //has not yet been updated at present time
+      if( cp->updateTime < t ){ /* has not yet been updated at present time. */
          cp->updateTime = t;
          /* Calculate values for mean and std */
          cp->cnt++;
@@ -1435,7 +1478,7 @@ void economy_averageSeenPricesAtTime( const Planet *p, const ntime_t tupdate ){
    for ( i = 0 ; i < p->ncommodities ; i++ ){
       c=p->commodities[i];
       cp=&p->commodityPrice[i];
-      if( cp->updateTime < t ){ //has not yet been updated at present time
+      if( cp->updateTime < t ){ /* has not yet been updated at present time. */
          cp->updateTime = t;
          cp->cnt++;
          price = economy_getPriceAtTime(c, NULL, p, tupdate);

--- a/src/economy.h
+++ b/src/economy.h
@@ -43,6 +43,7 @@ typedef struct CommodityModifier_ CommodityModifier;
 typedef struct Commodity_ {
    char* name; /**< Name of the commodity. */
    char* description; /**< Description of the commodity. */
+   unsigned int standard; /**< Wether or not this commodity is standard. */
    /* Prices. */
    double price; /**< Base price of the commodity. */
    glTexture* gfx_store; /**< Store graphic. */
@@ -120,6 +121,7 @@ void credits2str( char *str, credits_t credits, int decimals );
 void price2str( char *str, credits_t price, credits_t credits, int decimals );
 void commodity_Jettison( int pilot, Commodity* com, int quantity );
 int commodity_compareTech( const void *commodity1, const void *commodity2 );
+Commodity ** standard_commodities( unsigned int *nb );
 
 /*
  * Calculating the sinusoidal economy values


### PR DESCRIPTION
It's an xml tag in the commodity definition `<standard/>` that makes the commodities sellable and buyable anywhere there is a commodity market.

The goal is to make stuff like https://github.com/naev/naev/pull/947 easier to manage.

I made Ore and Gold standard (but it's only for demonstration). If people agree on this one, I'll make Food, Ore, Medecine, industrial and luxury goods standard and I'll remove them from the assets definitions.
What is more, if people are interested, I can add a tag to prevent a standard commodity to be sellable/buyable at a particular place.

Note : In order to avoid a crash, I had to remove the `<commodity/>` tag from Eiroik and an other (probably mission-related) not-inhabited asset. I hope this will not break things somewhere else. And I added a warning to help people if they get the same crash as I had (it took me hours to figure out the reason)