### PR TITLE
Standardize commodities

### DIFF
--- a/dat/assets/aillis.xml
+++ b/dat/assets/aillis.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Aillis is the base of operations for miners who mine Koralis VI. Koralis VI itself is highly radioactive so no human habitation is, or will ever be, possible. However, some of the heavy elements within the planet are quite valuable, and so Aillis offers a fair living for those who don't shun heavy, dangerous labor.</description>
   <bar>Though this bar is not exactly inhospitable, it also doesn't make you feel very welcome. Running costs are kept low which means maintenance and service suffer. Nevertheless, it's quite possible to have a good time here.</bar>
  </general>

--- a/dat/assets/akios_station.xml
+++ b/dat/assets/akios_station.xml
@@ -23,10 +23,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Akios Station is a Za'lek border station meant to keep the pirates from the Kretogg system out of Za'lek space. Because of the real threat that the loathsome criminals pose to the great house's security, there is (comparatively) little debate over the necessity over this station's existence.</description>
  </general>
  <tech>

--- a/dat/assets/aldarus.xml
+++ b/dat/assets/aldarus.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Aldarus has vast oceans filled with an organic sludge that has little to do with water. The atmosphere is toxic and will kill an unprotected human within minutes. The sludge in the seas is a good source of raw materials for all sorts of industries though, and the lack of pollution controls on the planet make it very attractive for corporations.</description>
   <bar>The spaceport bar on Aldarus offers a variety of recreational activities, such as gambling and competitive gaming. There are also walled-off booths for private conversations, in case the bar's main area is a little too public for comfort. The music here can also be a bit grating on the ears.</bar>
  </general>

--- a/dat/assets/ambre.xml
+++ b/dat/assets/ambre.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Ambre was one of the planets that played a key role in the workers' revolts that eventually led to the establishment of House Dvaered. In those days the planet was home to a considerable percentage of the Imperial workforce in this sector of space. Without labourers to work the mines and construction yards, the Empire stood to lose astronomical amounts of money each cycle. This was one of the important reasons the Emperor granted House Dvaered its independence.</description>
   <bar>Ambre's spaceport bar is never quiet. At regular intervals all other noise in the bar is drowned out by the sound of cargo pods trundling along the railway just below. The bar was built relatively late in the planet's development; the Imperial government didn't see the need for one when Ambre was little more than a labour camp. After independence the bar was squeezed into one of the only remaining spaces available, which was right over the freight lines.</bar>
  </general>

--- a/dat/assets/amhurst.xml
+++ b/dat/assets/amhurst.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Ore</commodity>
-   
-  </commodities>
+  <commodities/>
   <description>A glorified mining and trading world, this planet is one of the better-off casualties of the brain-drain affecting Za'lek's southern frontier. While it has not been hit as hard as many, it has seen its population dip in recent cycles. Most of the population are miners and other working-class folk. </description>
   <bar>If one didn't know better, they would assume this was a Dvaered bar. The rough aesthetic, the clientele, almost everything. There is little sign of the usual Za'lek trappings here.</bar>
  </general>

--- a/dat/assets/ammu.xml
+++ b/dat/assets/ammu.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Ammu is a generally calm planet, once one is accustomed to the constant rumbling of the lava flows. Lava eruptions are often felt in the subterranean spaceport but the way it doesn't seem to faze the locals reassures you.</description>
   <bar>The Ammu Spaceport Bar, known as "The Heatsink" due to its frigid temperatures, is a contrast to the rest of the station. While primarily known for its temperature, that's not to say you can't get a mean Pan-Galactic Gargle Blaster.</bar>
  </general>

--- a/dat/assets/andors.xml
+++ b/dat/assets/andors.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This barren world has a wealth of minerals buried beneath kilometres of ice, and the Za'lek have deployed considerable resources in order to tap its resources. Unlike more developed Za'lek settlements, there is little in the way of scholarly presence here.</description>
   <bar>This bar serves as a welcome respite from the biting winds and frigid temperatures that pervade the planet. The menu largely consists of hot beverages and hearty food, and the patrons are almost exclusively off-duty Za'lek workers.</bar>
  </general>

--- a/dat/assets/andors_refining.xml
+++ b/dat/assets/andors_refining.xml
@@ -22,10 +22,7 @@
    <refuel/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This simple refining plant is where the ore collected on Andors is turned into a more useful form and shipped out to other worlds to be turned into whatever is needed.</description>
  </general>
  <tech>

--- a/dat/assets/anecu.xml
+++ b/dat/assets/anecu.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Anecu is a completely aquatic planet. Its surface is covered completely by water but in the shallow areas great underwater cities are constructed. The climate above the water can be very harsh; waves been recorded to be up to two kilometres high. The planet boasts extensive ship-design facilities which use the high pressure of the water as a benchmark against which ships can be measured.</description>
   <bar>The spaceport bar is approximately three kilometres below the surface of the planet. The walls are constructed from a hardened, transparent polymer that allows you to see into the darkness of the water. Every so often you can see gelatinous creatures sliding around, barely illuminated by the bar's lighting.</bar>
  </general>

--- a/dat/assets/antica.xml
+++ b/dat/assets/antica.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Though the orbiting military installation is all business, Antica mixes business and pleasure quite readily. Given its location, a vast number of transports stop at Antica to sell their wares before venturing deeper into Empire space.</description>
   <bar>The Antican bar is a rather lavish affair, quite in contrast to the stark exterior of the orbiting military station. Serving some of the Empire's finest food and drink, this Arcturian bar is often a traveller's introduction to Empire cuisine.</bar>
  </general>

--- a/dat/assets/anubis.xml
+++ b/dat/assets/anubis.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Named after the Egyptian god of death, Anubis was established as a mining base by a mining faction even before the Faction Wars. The abundance of radioactive and heavy elements made the planet a good location to produce weapons, a lucrative business given its proximity to Sol. During the Faction Wars, Anubis was annexed by the Empire but the local population subsequently joined the protest movement that eventually led to the establishment of House Dvaered. Today, the Dvaered use Anubis to produce ammunition and light combat ships to supply Raelid Outpost.</description>
   <bar>What is beautiful is often dangerous but sometimes it also works the other way around. The spaceport bar on Anubis has a view over a ravine in the planet's surface and the radioactive storms that frequently rage through it are quite a sight to behold. Only offworlders appreciate it though, most of the locals know how unpleasant it is to have to work in such raging, radioactive conditions.</bar>
  </general>

--- a/dat/assets/anya.xml
+++ b/dat/assets/anya.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Anya is the twin planet to Sabe, orbiting around their shared center of gravity in tandem. Anya is shrouded in a permanent cloud cover of ash and snow however, as a result of geological activity. A small number of Thurions live on the surface of Anya but no large scale colonization effort has commenced as of yet, despite the planet's proximity to Sabe, the Thurian capital world. This is due, at least in part, to the geological instabilities of the planet.</description>
   <bar>The bar on Anya is small and quaint, populated by locals who live here. As is usual for Thurion bars, no alcohol or other substances deemed to be damaging to the brain are served.</bar>
  </general>

--- a/dat/assets/arashu.xml
+++ b/dat/assets/arashu.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Arashu is a peculiar planet, it is both oceanic and highly volcanic. The planet's oceanic crust is prone to earthquakes, this causes tidal waves to wash over the few areas of dry land. A Sirian corporation has invested in harnessing the energies released by this process, turning the planet into a profitable weapons production plant. All manufacturing happens on floating platforms so the workers and equipment are safe from the constant seismic activity.</description>
   <bar>The bar features a big display that shows a geological map of the planet which, due to most of the world being covered in ocean, makes for a rather uninteresting map. The display also shows all the volcanic activity going on at the moment, so it is actually quite fascinating interesting to watch, especially once you can place the spaceport and bar!</bar>
  </general>

--- a/dat/assets/arcadia.xml
+++ b/dat/assets/arcadia.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Rather ironically, yet aptly named, Arcadia is a world bombarded by acidic rains and other, equally nasty weather patterns. As such, it was the core world of a successful experiment to see if such an environment can still support a massive crop growing campaign given the proper insulation technology and procedures. The project was in fact so successful that Arcadia became a hub for food distribution throughout localized Za'lek space.</description>
   <bar>Many freight captains, farmers and scientists mingle peacefully here, discussing new and better ways to improve farming technology and get more and better food for less cost.</bar>
  </general>

--- a/dat/assets/arch_arai.xml
+++ b/dat/assets/arch_arai.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Once an independent world, home to pirates and black market traders, Arch Arai has long since fallen under the spell of the Touched. Now it is a fairly law-abiding Sirius world, earning its existence through trade and industry like almost every other planet.</description>
   <bar>This bar is a quiet place. Though it is certainly not lacking in patronage, the people who come here don't seem about to make a fuss over anything. The effect is contagious making newcomers follow the example of those who are already there, almost instinctively.</bar>
  </general>

--- a/dat/assets/arck.xml
+++ b/dat/assets/arck.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>With nine billion inhabitants, Arck is one of the most densely populated worlds in the galaxy. Most of the planet's surface is covered by a gigantic, sprawling city. Naturally, with so much inhabitation comes massive environmental pollution, many skeptics believe that what the Dvaered are doing here is a form of reverse terraforming - an attempt to turn Arck into an X class planet.</description>
   <bar>The spaceport on Arck is located right in the middle of a particularly densely populated urban hub. The associated bar has been expanded and turned into a general leisure facility for the local inhabitants, something that often irritates traders who come here to do business, only to find themselves in the middle of a Dvaered Turborave party.</bar>
  </general>

--- a/dat/assets/arcturus_gamma.xml
+++ b/dat/assets/arcturus_gamma.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Arcturus Gamma is the Empire's first line of defense when it comes to their core systems. Piracy is nearly non-existent in the core systems due to the large standing force stationed here and their routine patrols.</description>
   <bar>A truly utilitarian place, the Arcturus Gamma bar is metallic grey, meticulously maintained and full of off-duty Empire soldiers - not a place to get into a fight.</bar>
  </general>

--- a/dat/assets/arrakis.xml
+++ b/dat/assets/arrakis.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Arrakis is a desert planet with no natural precipitation and the dust storms can rage for weeks. The locals are continuously discussing sandworms, though you're not sure what to make of it.</description>
   <bar>The Arrakeen canteen is one of the shadier bars in Empire space. Lying on the border of the Empire, few patrols come through and many scoundrels and mercenaries can be found plying their trade. "The spice must flow", they say, it may not, but at least the rum does.</bar>
  </general>

--- a/dat/assets/arrentil.xml
+++ b/dat/assets/arrentil.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>As is typical for Soromid worlds, Arrentil would be considered utterly inhospitable by the rest of humanity. The atmosphere is toxic and the surface unstable, but the Soromid have managed to tame this world. Of course even they need to live in sheltered habitats, but in spite of that the population is thriving and the economy is stable. By all means, Arrentil is an example of Soromid persistence.</description>
   <bar>As the habitats of this inhospitable world were being built little thought was given to less essential amenities. This bar was added by grafting it onto the side of the spaceport. Anywhere else in the galaxy being an afterthought would likely have resulted in a rather cramped, run-down bar but here in Soromid space it has given it a more organic feel, so much so that it almost feels like it is growing.</bar>
  </general>

--- a/dat/assets/atalanta.xml
+++ b/dat/assets/atalanta.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Atalanta is named directly after the colony ship that settled it, Atalanta. Though the planet is too cold to be of any real value, the population is making a decent enough living thanks to the caches of heavy elements trapped under the ice.</description>
   <bar>Like all structures on the planet, Atalanta's bar is built under the ice but it is quite close to the surface. This is because a spectacular lighting effect can be observed overhead when the sun shines directly onto the ice. Atalanta's orbit makes this a rare occurrence but the bar's profits soar every cycle.</bar>
  </general>

--- a/dat/assets/atryssa.xml
+++ b/dat/assets/atryssa.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Atryssa is an economically rich world thanks to Za'lek technology. It is also the closest noteworthy Za'lek planet, where outsiders can land, to Ruadan. Beyond these two things there is little to recommend it (though one of these may, at least, be plenty enough).</description>
   <bar>The archetype of a Za'lek bar, although a very crowded one. The crowd seems to be divided up into groups of people discussing things in hushed tones. There are also one or two people wandering about with notepads, though everyone goes quiet when they approach.</bar>
  </general>

--- a/dat/assets/august.xml
+++ b/dat/assets/august.xml
@@ -24,12 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>August is a fairly standard, if cold, world. Rarely for a Za'lek planet, it doesn't have that many research stations on it. IT is almost purely a residential world, primarily for the scientists working on Warnecke who, after a hard week's work, don't want to see another lab for a while.</description>
   <bar>This bar has the feel of an old-world pub, with plenty of wood furnishing on display, good food and better beer. A great place to relax and unwind.</bar>
  </general>

--- a/dat/assets/avoss.xml
+++ b/dat/assets/avoss.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Avoss was originally a mediocre but habitable world. When the fourteenth colony ship, Petrovsk, arrived, its colonists considered themselves fairly fortunate to have found a place they could call home. However, some fifty years after the expedition had touched down, the world began to change. Seismic activity everywhere began escalating off the charts causing earthquakes and volcanic eruptions the world over. The world is now devastated, a mere shadow of its former self. The colonists have managed to survive, however, and the hardy remain even today.</description>
  </general>
 </asset>

--- a/dat/assets/bastion_station.xml
+++ b/dat/assets/bastion_station.xml
@@ -23,10 +23,7 @@
    <missions/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Bastion Station is one of the two primary defense, border guard, and patrol base stations leading into Za'lek space. As such, it is one of the few military expenditures that goes (largely) unchallenged even by the notorious Za'lek political scene. The House Za'lek Defense Force conducts most of their foreign contact here, where they can keep an eye on affairs.</description>
  </general>
  <tech>

--- a/dat/assets/bedimann_shipyards.xml
+++ b/dat/assets/bedimann_shipyards.xml
@@ -23,10 +23,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>These shipyards are one of the places where Za'lek vessels are built and sent out to the defense forces. It also maintains a small contingent of Za'lek vessels at home to serve as a in-system guard.</description>
  </general>
  <tech>

--- a/dat/assets/beene.xml
+++ b/dat/assets/beene.xml
@@ -26,9 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Beene is rich in all sorts of common minerals, so the Soromid are using this world the same way anyone would: as a source of raw materials. The elements mined here are processed into standard packages that are used by the Soromid bioships. This supply of minerals means Beene is quite an important strategic location for Soromid fleets.</description>
   <bar>Pilots are advised to wear air-sealed suits when visiting Beene's bar. The planet's atmosphere can cause serious problems for normal humans and the Soromid haven't bothered installing decontamination filters for the local population. As such, having a drink in Beene's bar is a bit of an ordeal. It's one of the less popular places among traders looking for a drink.</bar>
  </general>

--- a/dat/assets/benedict.xml
+++ b/dat/assets/benedict.xml
@@ -22,13 +22,11 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Another gas giant, another Soromid outpost. This particular outpost is rather larger than some due to the large amount of mineral and element extraction performed here. The planet is high in organic matter as well as elements used to produce them, this makes it an, almost literal, gold mine for Soromid building materials.</description>
   <bar>As per the case for many Soromid bars in less than hospitable places, the atmosphere in this bar is rather stuffy with an element of danger for non-Soromids, the air isn't too great either. Most of the drinks here are served with straws, which is a thoughtful touch for those traders who are forced to wear air-breathers.</bar>
  </general>

--- a/dat/assets/berkhere.xml
+++ b/dat/assets/berkhere.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Most of Berkhere's surface is rock, dust and sand. But under that surface lie rare and valuable gems and minerals. The colony here relies on this mineral wealth for survival. Crops will not grow on this arid planet, so all food has to be imported.</description>
   <bar>The spaceport bar is arranged around a central area that serves as a showcase for the single largest uncut gem ever found under the sands of Berkhere. It is a reminder to both visitors and the local populace that Berkhere is still wealthy. So long as the gem on display doesn't have to be sold, the reasoning goes, Berkhere's future isn't in peril. Needless to say, the gem is heavily protected by security systems.</bar>
  </general>

--- a/dat/assets/bon_sebb.xml
+++ b/dat/assets/bon_sebb.xml
@@ -27,10 +27,7 @@
    <shipyard/>
   </services>
   <commodities>
-   <commodity>Food</commodity>
    <commodity>Gold</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
   </commodities>
   <description>Bon Sebb is a mysterious place. Objects from all over the galaxy have a habit of turning up here. In fact, a large area of the planet's surface is a gigantic junk yard, known as the "Junkle", where the locals "hunt" for useful equipment they can sell to each other, or to passing travellers.</description>
   <bar>The bar on Bon Sebb is built out of things scavenged from the Junkle. The walls and furniture are all patchworks of various designs and materials. The only somewhat symmetrical feature of the bar is a holoportrait of the Creator of the Universe, hanging over the lopsided bar.</bar>

--- a/dat/assets/brooks.xml
+++ b/dat/assets/brooks.xml
@@ -24,10 +24,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Brooks is a bustling, highly populated Imperial civilian planet. With the decline of the Empire, it has found itself on the border of dangerous space, a rather uncomfortable position. As Brooks is a rich planet with a lot of economic and political weight within the Empire, the Imperial Navy protects Arcturus for Brooks' sake, as much as for the Imperial core systems.</description>
   <bar>On Brooks everything is expensive, something that comes with most economically booming worlds. However, most traders put up with the inflated prices for refreshments and services at the spaceport bar, Brooks, after all, is a boom world and where profit is to made.</bar>
  </general>

--- a/dat/assets/buritt.xml
+++ b/dat/assets/buritt.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Not as nice as Varia in the Darkstone system, Buritt is, never the less, a reasonably habitable world. You will find much of the Dvaered middle class here, such as it is. You will also find a large-scale pollution of the natural environment but, with the Dvaered being Dvaered, no attempt is being made to address this.</description>
   <bar>If this spaceport bar didn't play a locally produced, incessant, droning, brain-melting music, it would be quite a comfortable place to be. But it does, so it isn't.</bar>
  </general>

--- a/dat/assets/burnan.xml
+++ b/dat/assets/burnan.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Burnan counts as the unofficial local capital. Aesir is far away and many government services are better rendered locally than over a distance of many hyperspace jumps. Burnan has a large political district in its primary city, this also houses one of the largest Sirian temples in all of Sirius space.</description>
   <bar>Burnan doesn't have a separate spaceport bar in the way many other worlds do. The spaceport bar and the main spaceport hall are, instead,  one and the same thing. There are exits to terminals on all sides and the central area is dominated by an island of service interfaces and counters. There is an elevated area that has tables for visitors to sit down at, where they won't get in the way of the bustle and traffic of the main floor.</bar>
  </general>

--- a/dat/assets/caladan.xml
+++ b/dat/assets/caladan.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>The surface of the planet is predominantly covered with water and the planetary climate is characterized by abundant precipitation and strong winds, though sufficiently tolerable to make costly weather modification equipment unnecessary. Habitable land is often characterized by soft meadows, swamps and dense forests. The resource base of Caladan consists mainly of agriculture and biomass, with the locally bred and grown pundi rice being its main export, and fishing, a traditional source of sustenance for its people. Other traditional products include wine and various livestock, most prominently cattle.</description>
   <bar>The bar is just off the starport with a great view of the harbor. You could watch the fishermen run frantically about attending their duties for hours. You could also tuck into some of the local cuisine which is rather refined, with most dishes containing meat.</bar>
  </general>

--- a/dat/assets/cantina_station.xml
+++ b/dat/assets/cantina_station.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This station is primarily a trade center for western Za'lek space. Many deals are made here, and given the frequent and transitory foot traffic, it makes for a good place to meet someone.</description>
   <bar>This bar lives up to the name of the station itself. Indeed, it seems to be the main attraction, being a massive ring-shaped casino-esque room with many bartenders treating the patrons, music in the background, and good food. The only sign of being Za'lke in origin is the casual use of bafflingly advanced technology and the fact that at least half of the populace look like scientists, researchers, or engineers.</bar>
  </general>

--- a/dat/assets/cetrat.xml
+++ b/dat/assets/cetrat.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Cetrat is an aquatic planet known for its medical algae. No one has been able to reproduce it exactly as it is in the wild but, with the abundance of it throughout the planet's massive ocean, there has been little effort in that field. Cetrat was colonized by the eighth colony ship launched during the First Growth, Brooklyn.</description>
   <bar>The bar is very large and yet has fairly few patrons. You notice the drinks list has a "living" menu. When you ask the bartender about them, he says they specialize in drinks containing living creatures. Generally jellyfish, but sometimes small cephalopods or more exotic beings. As exotic cultures go, Cetrat is among the stranger.</bar>
  </general>

--- a/dat/assets/chriik.xml
+++ b/dat/assets/chriik.xml
@@ -25,11 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Chriik is a dead world. Like most desert planets it has no bodies of water and a hot climate but, unlike most desert planets, it doesn't have any indigenous life, what-so-ever. Indeed, there is no reason why anyone or anything would want to live here in the first place. This makes it a perfect planet for heavy industries to set up shop since they can pollute all they want without repercussions.</description>
   <bar>The spaceport bar is a popular place on Chriik, even inside the habitation complexes the air is so dry it will parch you out in record time. The large number of manual workers also contributes to the busy crowd.</bar>
  </general>

--- a/dat/assets/corax.xml
+++ b/dat/assets/corax.xml
@@ -21,13 +21,11 @@
    <land/>
    <refuel/>
    <bar/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Though the world of Corax might, in the distant future, become a semi-inhabitable world there will be precious few ores and minerals left (baring iron) by that point. The Soromid's ability to withstand unusual levels of environmental discomfort has given them a head start on this world in terms of resource extraction. Other life, it seems, will have to wait its turn.</description>
   <bar>Given the relative stability of this world the bar looks rather more Empire standard-issue than on many Soromid worlds. There are tables, chairs, dispensers, a barman and, most importantly, drinks. These there are in profusion, though, this being a smaller world, not in any great variety. If you ask for a cocktail though, you'll likely be directed to one of the local sulphurous hot-water geysers.</bar>
  </general>

--- a/dat/assets/corinth_foods.xml
+++ b/dat/assets/corinth_foods.xml
@@ -23,9 +23,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This new type of agristation serves as the primary food producer for the Procyon enclave and beyond. The station is designed in a multi-tiered way to produce more food in a better-controlled environment using less materials and maintenance. So far it seems to be working, as Corinth Foodsproduces enough food to be exported from Za'lek space entirely.</description>
  </general>
 </asset>

--- a/dat/assets/crow.xml
+++ b/dat/assets/crow.xml
@@ -22,14 +22,11 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Despite bordering on a dangerous sector of space, the Corvus system, and Crow in particular, are thriving. The planet is a frontier of culture, commerce and prosperity. Even for the Soromid, one of the youngest societies in the galaxy, being away from the core worlds can give people the breathing room to live on the edge.</description>
   <bar>This bar was designed with acoustics in mind. The background music is pervasive, yet unobtrusive and conversations held at one table won't disturb those at another. Given some of the newer customs cropping up here a lot of out-of-system traders are thankful for this.</bar>
  </general>

--- a/dat/assets/crylo.xml
+++ b/dat/assets/crylo.xml
@@ -25,11 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Crylo is an oceanic world with very little land surface, but it sports a surprising number of inhabitants. As it happens, the aquatic life found on this world is considered a delicacy in large parts of the galaxy, this has attracted people to settle and spawned a flourishing fishing industry.</description>
   <bar>Fishing is the name of the game on Crylo and the spaceport bar is nothing if not in character. Almost everything in here is fish-themed, including the bar, which has been made out of the spine of some gargantuan aquatic creature. Some of the more experimental drinks might also be better avoided unless you like your ingredients very fresh indeed.</bar>
  </general>

--- a/dat/assets/culex.xml
+++ b/dat/assets/culex.xml
@@ -23,6 +23,7 @@
    <bar/>
    <missions/>
   </services>
+  <commodities/>
   <description>Culex is the moon of planet Myonei. Myonei itself is a factory world, but it's too unpleasant for even the genetically altered Soromid to live on. Fortunately, Culex is quite suitable for habitation and so the workers who labour on the surface have their homes here. Culex is little more than a habitat with no economy of its own. It's fairly uninteresting to most people who don't actually live here.</description>
   <bar>As Culex sees little traffic other than commuters to and from Myonei, the spaceport bar has been repurposed as a community centre by the locals. The standard facilities are still present and operational but in a minimal fashion. Most of the facility is filled with recreational facilities and even a dance floor.</bar>
  </general>

--- a/dat/assets/curie.xml
+++ b/dat/assets/curie.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This planet is still in its infancy, and is a primary source of geological research for Za'lek scientists. This, and the high density of rare and valuable heavy metals makes it a potentially valuable Za'lek world despite the unpleasantness of its environment.</description>
   <bar>The bar has pictures of the famous scientists that the planet was named after, as well as various pictures and holopaintings of some of the phenomena on the planet that those whose interests in geology might find interesting.</bar>
  </general>

--- a/dat/assets/cutha.xml
+++ b/dat/assets/cutha.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Cutha is a marvel of planetary engineering. It started out as a fairly hostile world, its atmosphere filled with toxic substances, but the Soromid have tamed it and turned it into a pretty decent place to live. Of course, even Soromid engineering has its limits, so Cutha isn't quite as nice a world as Turawee in Sarcophagus, but the result is still impressive. Nowadays, Cutha houses most of the Soromid involved in the military operations at Heronus.</description>
   <bar>Cutha's bar is very close to being an open-air bar. The airspace is still fully enclosed but most of the surfaces, that aren't the actual floor, are transparent. The ceiling, in particular, is made of a material that's all but invisible to the naked eye, with the artificial breeze that blows through the bar it's very easy to believe the illusion that one is actually outside. Only on rainy days is the effect spoiled, something the regular patrons, if not the outworlders, appreciate.</bar>
  </general>

--- a/dat/assets/daahrax.xml
+++ b/dat/assets/daahrax.xml
@@ -23,6 +23,7 @@
    <bar/>
    <missions/>
   </services>
+  <commodities/>
   <description>When the Soromid claimed the barren world of Hadosh I, they had the privilege of naming it and its moon. The planet came to be known as Daahrax. However, in an impressive display of bureaucratic indecision, the planet's moon remains unnamed. There is constant debate in the various government institutions and, time and again, naming committees are created whose suggestions are promptly rejected. It doesn't seem the Soromid are going to come up with a good name anytime soon.</description>
   <bar>Hello, traveller, welcome to the Daahrax spaceport bar. A word of advice, don't ask about the moon. Trust me, don't do it. The locals are a little touchy on the subject. How about a drink instead?</bar>
  </general>

--- a/dat/assets/daal.xml
+++ b/dat/assets/daal.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The small moon orbiting Rhu IV, named Daal, is easily overlooked but, as it happens, it is quite an important piece of realestate for the Sirii. The people who live here are particularly zealous in their beliefs and most of them end up serving a lifetime in the Sirius army. The Fyrra are especially well represented on this world.</description>
   <bar>On Daal, people like to be reminded that they are part of a large galactic faction. The tables in this spaceport bar have low-tech displays incorporated in their surfaces, each table displays one of the Sirian worlds, as well as up-to-date information about that world. Naturally, Mutris is displayed on the largest table, but Daal itself comes a good second.</bar>
  </general>

--- a/dat/assets/darkshed.xml
+++ b/dat/assets/darkshed.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Renowned for its outfit market and shipyards, nearly the entirety of the Darkshed station is dedicated to trading outfits and ships. Mercenaries and bounty hunters from all over the galaxy come here to see and try the newest enhancements available on the market. It also tends to attract many of the shadier characters in the universe, leading to frequent fights in which they test their newly bought outfits.</description>
   <bar>The Darkshed canteen is decorated with all sorts of odd artifacts that chronicle trends in spaceship outfitting over the years since the station was established. Scale models of many popular ships hang from the ceiling.</bar>
  </general>

--- a/dat/assets/dawn.xml
+++ b/dat/assets/dawn.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Gilligan's Light was one of the first systems to ever be chosen for a colonisation project. Dawn was the first world on which humans set foot in this sector of space, despite the fact that the colony ship sent here, Mythril, was only the fifth to be launched. Nevertheless, Dawn proved to be one of the most fertile expeditions in the First Growth and its development outstripped that of most other worlds. With the advent of hyperspace travel, Dawn found itself the local capital of the Frontier worlds and so is graced by the Frontier Council hanging overhead. This status is strictly symbolic but it explains why the FLF have chosen to rally around Gilligan's Light.</description>
   <bar>Dawn's bar has a rustic feel to it, the locals have made a point of keeping the style close to what was the prevalent design in the early expansion era. Other than that, this bar doesn't have much to set it apart from others. The noise, the smell and the drunks are features that are commonplace throughout the galaxy.</bar>
  </general>

--- a/dat/assets/donnar.xml
+++ b/dat/assets/donnar.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Despite not having been officially classified as habitable, Donnar has been settled by sufficient numbers of Dvaered to give the planet civilian world status. Though the soil is barely fertile and the atmosphere is less than pleasant for even the most hardy plant life, Donnar has the major advantage of having almost no seismic activity at all. As many a colony prospector would tell you, a stable planet is a good planet.</description>
   <bar>Donnar has something unusual to offer to offworlders. The spaceport bar is constructed as an arena, with the spectator area fulfilling the functions that most other spaceport bars do. The central area serves as a stage for entertainment of all kinds, ranging from fights to displays of art. The concept is rather ingenious and many a spacer is as astonished by the display as they are by the fact that the Dvaered came up with this idea.</bar>
  </general>

--- a/dat/assets/dono.xml
+++ b/dat/assets/dono.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Dono is one of the more laid-back Soromid worlds. It is quite Earth-like and the Soromid make use of the strange properties of the local flora and fauna in their genetic experiments. It is a quiet world, with little that stands out about it.</description>
   <bar>The bar's patrons are scientists, labourers and regular civilians, mingling with little conflict. The service is acceptable and the food and drink average. A sleepy little bar, that's for sure.</bar>
  </general>

--- a/dat/assets/doranthex_prime.xml
+++ b/dat/assets/doranthex_prime.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Doranthex Prime is a mostly-molten planet. One of the few pieces of solid land is a small island drifting around the northern polar region. On this island the Dvaered have established a small base, primarily for research and military prototyping, though civilians are allowed in the main facilities. Due to the intense temperatures, the base is shielded by over 50m of temperature isolation plating, which affords no view of the planet itself once a ship has landed.</description>
   <bar>The drinks served in 'The Furnace', as the bar calls itself, are a rather curious sort. They are generally very strong and served lukewarm. The house specialties also contain volcanic ash which is harvested from the planet's surface. A strange bar indeed.</bar>
  </general>

--- a/dat/assets/dowue.xml
+++ b/dat/assets/dowue.xml
@@ -25,12 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Dowue is a planet known for the infamous "Dowue Syndrome", a condition where patients will temporarily go insane with hysteria due to prolonged exposure to certain visual wavelengths. This was at first attributed to a contaminated shipment of food, but later it was found that the sun in the Apez system emitted abnormal wavelengths whose effects were multiplied by particulate in Dowue's atmosphere. Shortly thereafter, it became mandatory for all personnel to wear special goggles designed to filter out the harmful light.</description>
   <bar>The Dowue Spaceport Bar is better known as the 'Frozen Shrimp' after some ancient crustaceans found during the construction of the spaceport. It is a place where most of the personnel spend their time. Even with protective goggles, the dangers of Dowue Syndrome persuade most people to stay indoors and the bar lies at the heart of the spaceport.</bar>
  </general>

--- a/dat/assets/draconis_epsilon.xml
+++ b/dat/assets/draconis_epsilon.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Draconis Epsilon is a densely populated Imperial world. It grew rich in the days before the Incident, when Draconis was still a core system, not at the outer fringes of Imperial controlled territory. The inhabitants here have suffered from the change, but not as much as you might expect. The world maintains a solid consumer base.</description>
   <bar>The spaceport bar on Draconis Epsilon is circular in shape, with exits all around leading to the various spaceport platforms. The place is gigantic, providing seats for up to ten thousand customers at the same time, and more at the bar. Most spacers who have visited Epsilon Draconis agree that few spaceport bars are quite as impressive as this one.</bar>
  </general>

--- a/dat/assets/draconis_omega.xml
+++ b/dat/assets/draconis_omega.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Draconis Omega was one of the old Empire's best colonies. The planet is large compared to Earth, yet its gravity is comparable. This made it ideal as a population base, which it remains today. Draconis Omega remains firmly loyal to the Empire, despite its now isolated position. The people here believe that the after effects of the Incident are only temporary and that the Empire will, one day, regain its former glory, in which Draconis Omega will, of course, feature prominently.</description>
   <bar>Ever the optimists, the people of Draconis Omega have decorated their spaceport bar with displays of past Imperial power, portraits of former Emperors and charts that show the size of the Empire when it was at its peak. It's certainly a good lesson in history and it's clear that the inhabitants truly believe that the good times will one day return.</bar>
  </general>

--- a/dat/assets/drognain.xml
+++ b/dat/assets/drognain.xml
@@ -22,12 +22,7 @@
    <refuel/>
    <missions/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Dronain is an example of the Za'lek intellectual elite's more excessive traits and occasional flamboyant failures.. The planet is an abysmal hell that has only gotten worse thanks to being the foreground of various terraforming experiments that failed. However, the Za'lek still maintain a presence on the world despite this, mostly through borderline force.</description>
  </general>
 </asset>

--- a/dat/assets/dundrop_station.xml
+++ b/dat/assets/dundrop_station.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Dundrop Station is a commerce oriented station. Traders usually come here to buy and sell goods and then take them elsewhere. Some traders rent out cargo bays to store non-perishable goods, however, then they can be the first to capitalise when a neighbouring planet develops a high demand for them.</description>
   <bar>All the tables in this bar have multiple displays for tracking economic information for the whole of known space. The patrons are mostly engrossed in absorbing the graphs and charts displayed. There is little room for social interaction on Dundrop.</bar>
  </general>

--- a/dat/assets/duran_shipyard.xml
+++ b/dat/assets/duran_shipyard.xml
@@ -24,10 +24,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Duran Shipyard produces light support craft used by the Dvaered military machine. It also has a line of civilian and cargo ships which it makes available to retailers and consumers. Since the ships produced here are combat-ready and the facility always has at least one completed squadron standing by, Duran Shipyard is an important contributor to the stability in the region.</description>
   <bar>The spacedock bar provides visitors with a view over part of the assembly line. It is quite impressive to see a spacecraft being built, even if it is only a relatively small one.</bar>
  </general>

--- a/dat/assets/durea.xml
+++ b/dat/assets/durea.xml
@@ -23,10 +23,7 @@
    <bar/>
    <missions/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Durea is not a terribly pleasant place to live, as it orbits its star a little too distantly for comfort, which leaves most of the planet covered in snow and ice. Only a small portion of the surface thaws far enough in summer for mining operations, but despite that the riches underneath the crust compel a hardy population to dig. Indeed, if one day resources in the galaxy grow sparse enough, Durea may well find itself in an economically superior position.</description>
   <bar>This bar is the standard-issue model that can be found on unpopular mining colonies throughout the galaxy. It's essentially a regular prefab habitation unit converted into a bar. It has all the amenities and features you might expect in a public facility but it offers none of the comfort that bars on metropolis planets tend to sport. The liquor served here is often pretty strong, this is, in no small part, due to the planet's harsh environment.</bar>
  </general>

--- a/dat/assets/durumdra.xml
+++ b/dat/assets/durumdra.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>While Durumdra technically classifies as a P-class ice world, the place can be quite comfortable to live on. Some regions near the equator melt during part of the planet's solar cycle and during this period there is an outburst of life, ranging from vegetation to small hibernating animals. By Dvaered standards, the planet is not so bad at all.</description>
   <bar>Durumdra doesn't have much to distinguish itself by in the galaxy but the spaceport bar goes a long way to helping. It has drinks from all over the galaxy, though Draygar's awkward location means that most of them are rather pricey. Nevertheless, Durumdra has earned itself a footnote in several noted galactic tourist guides.</bar>
  </general>

--- a/dat/assets/dvaer_prime.xml
+++ b/dat/assets/dvaer_prime.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Dvaer Prime is the capital world in Dvaered space. It was the world on which the Old Empire granted House Dvaered its status as a Great House and the Dvaered chose to name their people after it. However, iconic though the planet may be, it is of little actual consequence. At best it is fought over jealously by the Dvaered Warlords, who consider ownership of the world a matter of great prestige, otherwise there is nothing that sets Dvaer Prime apart from other planets. After all, the decisions are all made in Dvaered High Command, which floats in high orbit over Dvaer Prime.</description>
   <bar>Dvaer Prime sports a well appointed spaceport bar. It is not so much luxurious as it is grimy, but at least all necessary facilities are present and in working order and the drinks are decent enough by Dvaered standards. A holopainting on the wall commemorates the inauguration ceremony of House Dvaered but it is faded and warped in places, a testament to the fact that most Dvaered citizens have long ago forgotten that they are technically still part of the Empire.</bar>
  </general>

--- a/dat/assets/eenerim.xml
+++ b/dat/assets/eenerim.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>With over 80% of its surface covered in water, Eenerim teeters on the brink of classes M and O. The population here is spread out over many small or medium sized islands scattered evenly across the globe. The Sirius government has divided up the land between the three echelons, with each island predominantly inhabited by either Shaira, Fyrra or Serra.</description>
   <bar>The spaceport bar here is utterly unremarkable. That's not a bad thing though because bars that distinguish themselves, more often than not, do so in an unpleasant way.</bar>
  </general>

--- a/dat/assets/eiger.xml
+++ b/dat/assets/eiger.xml
@@ -23,12 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>The Salvador system has little of worth or use to the Empire but it still has valuable minerals that it needs to mine. Hence a group of intrepid miners and traders have made this place their base of operations. Minerals are mined and refined here and traders buy it cheap and sell it dear in the deeper reaches of the Empire.</description>
   <bar>This bar is home to several miners and their trade partners haggling and making deals over beer and coffee. The bar is large but it is still filled almost to the point of standing room only.</bar>
  </general>

--- a/dat/assets/eist_shipyard.xml
+++ b/dat/assets/eist_shipyard.xml
@@ -23,10 +23,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Eist Shipyard is one of the primary ship construction facilities in Dvaered space. Most of the Dvaered's heavy military vessels are produced here, though production of the lighter ships is taken care of by shipyards beyond Dvaer. Eist Shipyard also supplies civilian models to some individuals and organisations.</description>
  </general>
  <tech>

--- a/dat/assets/em_1.xml
+++ b/dat/assets/em_1.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Em 1 is a completely unremarkable world. It's just one of those places that contributes to the Empire's treasury and serves no other purpose of note.</description>
   <bar>The bar exclusively plays local music, serves local food and drink and provides mainly local news. The people here apparently seem to want to cling on to what little personality the world still has, for fear that Em 1 has really become just an extension of the Imperial economy.</bar>
  </general>

--- a/dat/assets/em_5.xml
+++ b/dat/assets/em_5.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Deep within Empire space, Em 5 is a quiet world. Few would have ranked it highly in the spectrum of galactic politics, yet after the Incident it gained notability when it became a temporary refuge of the Emperor. In the time since it's become a popular place for the aristocracy to meet.</description>
   <bar>The Drunken Lobster has a plaque commemorating the time the Emperor spent on Em 5. It seems unlikely he ever visited this bar, though, given its less than refined patrons and threadbare furniture.</bar>
  </general>

--- a/dat/assets/ember.xml
+++ b/dat/assets/ember.xml
@@ -25,12 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Ember, like its primary Forge, is a hot world. Its surface is molten in places, its atmosphere will burn an unprotected human to a crisp in seconds, and seismic activity makes the planet a death trap even in a protected environment. Despite all this, the Sirii have established a sizeable industry on Forge's moon. Located on a relatively stable plate, this complex collects the rare materials produced by Ember's volcanic activity and turns them into raw materials for ship building. The business is quite lucrative, supplying a significant portion of all the materials for Sirius' ships.</description>
   <bar>Ember's spaceport bar is frequented by workers from the industrial complex, most of them from the Shaira echelon. They have many tales to tell of the dangers of their job and the brutal nature of Ember's weather. None of them seem to be discontent with their lives though.</bar>
  </general>

--- a/dat/assets/europea.xml
+++ b/dat/assets/europea.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Europea is almost completely covered in water, which was considered undesirable in the early days of the Second Growth. However, it was soon discovered that Europea's biosphere contained many organisms that were useful in the production of high-grade medicine and an exception was made. This means that Europea is one of the earliest O-class planets that were ever colonised. Today the world still thrives on its medical exports, though advances in pharmaceutical technology since the days of the Second Growth have rendered a considerable portion of it obsolete.</description>
   <bar>Perhaps uniquely in the galaxy, both the spaceport and its associated facilities are afloat without tethers. This means that the location of the spaceport itself changes over time as the platform is carried on the major currents that span the face of the planet.</bar>
  </general>

--- a/dat/assets/excelcior.xml
+++ b/dat/assets/excelcior.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The seat of the infamously rancorous Procyon Enclave of House Za'lek, this world also happens to be one of House Za'lek's richest and most productive worlds, which is what allows Procyon its hold on much of House Za'lek. Many scientific organizations and universities operate out of this planet and its Earth-like environment, helped along by Za'lek terraforming, makes it a popular site for retirees and vacationers.</description>
   <bar>This bar is full of shouting and arguments, with the occasional fist-fight, all based on matters that most laymen find difficult to understand, let alone pick a side on. There is a large quantity of food and drink spilled on the floors as a result of this and the harried staff seem relieved when you make sure to avoid provoking anyone or making eye contact.</bar>
  </general>

--- a/dat/assets/facett_outpost.xml
+++ b/dat/assets/facett_outpost.xml
@@ -20,8 +20,8 @@
   <services>
    <land>srm_mil_restricted</land>
    <refuel/>
-   <missions/>
    <bar/>
+   <missions/>
   </services>
   <commodities/>
   <description>Facett Outpost is little more than a local police station. It was created as a precaution against the pirate threat coming from Khaas, but the Soromid know that no single station could withstand a coordinated attack. Facett is mostly a visible sign of Soromid presence in Hatter. It puts the local population at ease. The real security has to come from Hartwell Station in the neighboring system of Father's Pride.</description>

--- a/dat/assets/ferrungir.xml
+++ b/dat/assets/ferrungir.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Ferrungir is a fairly low-profile industrial world. Raw materials are being mined here and then either shipped offworld immediately or processed into low-level components before heading the same way. There is not much else of value on this planet. The people who live here tend to be Shaira echelon who haven't been able to find a job anywhere else.</description>
   <bar>The bar on Ferrungir is simple and grim. It's little more than a storage unit converted into a makeshift drinking establishment. It's to be expected from a world as run down as this one.</bar>
  </general>

--- a/dat/assets/flach.xml
+++ b/dat/assets/flach.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Quite a lot of Soromid live on Flach. Where normal humans would have built a mining colony at best, the Soromid found a planet good enough to build extensive megacities and suburban industries.</description>
   <bar>The spaceport bar is one of the few places on the planet that is environmentally conditioned to suit normal humans. Any non-Soromid wishing to visit the actual population centers will need to wear protective clothing ... or suffer the consequences.</bar>
  </general>

--- a/dat/assets/fort_sirius.xml
+++ b/dat/assets/fort_sirius.xml
@@ -23,11 +23,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Fort Sirius is the primary military hub of the Sirius army. It serves as the gatekeeper for Aesir, making sure no threats will ever reach Mutris. The station has hundreds of hangars in all sizes, allowing a full contingent to be stationed and ready at all times.</description>
  </general>
  <tech>

--- a/dat/assets/freshwater_station.xml
+++ b/dat/assets/freshwater_station.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>After the success of the Empire's experimental INNS-1, the Sirii saw potential for off-world crop growing in the Anarbalis system. Aptly named, Freshwater Station produces carefully engineered bumper crops for consumption by Sirian worlds in the immediate vicinity.</description>
   <bar>The bar is dominated by the likeness of the Touched who officially blessed the station. The local Sirian workers seem to take particular pride in the visit since the Touched usually operate only in population centers.</bar>
  </general>

--- a/dat/assets/fuzka.xml
+++ b/dat/assets/fuzka.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Fuzka is a fairly typical Imperial civilian world. It has a good atmosphere, stable tectonics and a large population. The world grows most of its own food but still needs imports to make ends meet. The local population is as well off as can be expected from a middle-class Imperial colony. Otherwise, there is little to note about Fuzka.</description>
   <bar>The bar caters to its clientele with considerable efficiency. Since Fuzka has quite a high amount of civilian traffic, its bar needs to handle the many passengers who are waiting for their transport to depart.</bar>
  </general>

--- a/dat/assets/gastan.xml
+++ b/dat/assets/gastan.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Gastan is one of House Za'leks research worlds that moonlights as a mining world for valuable materials. Many of the labs here are off-limits to outsiders, but the main city and space-port is a popular hub for internal trade and commerce.</description>
   <bar>There is nothing particularly note-worthy about this bar other than the complex machinery on display through meter-thick translucent plasteel. The bar is built underground in a long-drained mining shaft, and the equipment seems to be of interest to many of the patrons.</bar>
  </general>

--- a/dat/assets/gaula.xml
+++ b/dat/assets/gaula.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Soromid space is low on worlds suitable for agriculture, so the Soromid need to rely on alternative food production. Gaula, an aquatic planet, is one such alternative. Vast stretches of the ocean floor are taken up by enormous submarine farms where certain kinds of underwater flora are cultivated and harvested, to be processed into food by the factory station up above.</description>
   <bar>The spaceport and its accompanying support facilities are floating on a platform above one of the primary farms on Gaula. The water is strictly off-limits, and anyone foolish enough to dump waste into the ocean is harshly penalized.</bar>
  </general>

--- a/dat/assets/gaula_foods.xml
+++ b/dat/assets/gaula_foods.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Gaula Foods is the food factory that processes the produce grown on Gaula into human digestible meal units. The station outputs an amazing variety of foodstuffs considering the limited diversity of the plants they are made from.</description>
   <bar>The bar offers samples of most of the products made in the factory complex. The taste is generally not bad, although after a while it starts to get a little samey.</bar>
  </general>

--- a/dat/assets/gayathi.xml
+++ b/dat/assets/gayathi.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The colony on Gayathi has been around since before Sirichana settled on Mutris. In those days it was an outpost of one of the Factions that were destroyed in the Faction Wars, forgotten and overlooked by all. With its source of funding and supplies gone, Gayathi never had a chance to fully develop its economic infrastructure. Then, when Sirius rose as a galactic power, Gayathi came to fall under its influence. Now it is home to some of the most devout believers found in Sirius space.</description>
  </general>
 </asset>

--- a/dat/assets/gerhart_station.xml
+++ b/dat/assets/gerhart_station.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Gerhart Station was built by the Za'lek Central Council in response to the Empire building Outbound Station. The Za'lek felt miffed that the Empire would step in on what they saw as their land and instead of meekly backing down or risking military conflict, merely built a larger and better-equipped station. The fact that it would be an ideal location for defending the Za'lek from Imperial treachery, or launching an attack into the Empire itself, is a bonus that is an open secret.</description>
   <bar>There are many Za'lek military officials, scientists, and traders from all over in this large and clean bar. It is much nicer than the one on Outbound Station. Quite a pointed snub.</bar>
  </general>

--- a/dat/assets/geron.xml
+++ b/dat/assets/geron.xml
@@ -24,11 +24,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Geron was once an Imperial colony, but when House Goddard was established and granted full authority over the system, it also acquired jurisdiction over Geron. In the decades that followed the Imperial bureaucracy was largely dismantled and replaced by a more gubernatorial arrangement. That improved the efficiency at which the world was run, but without its Imperial status the economy took a serious hit. Nowadays, Geron is a fairly average civilian world that houses the majority of Goddard's citizens.</description>
   <bar>Like many spaceport bars, this one is loud, crowded and a little smelly. In other words, it's a home away from home for those who make their living in space.</bar>
  </general>

--- a/dat/assets/gilligans_memory.xml
+++ b/dat/assets/gilligans_memory.xml
@@ -23,9 +23,7 @@
    <bar/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Wilibrord Gilligan was a famous explorer of space in the times of the Second Growth. He is responsible for charting many of the currently known jump routes, having a knack for spotting the areas in space that allowed entry into hyperspace for prolonged periods. In those days this was exceptional, since scanning technology was nowhere near as advanced as now. In honor of Gilligan's services to the old Factions, he was granted his own star system and settlement therein. After the Faction Wars, Gilligan's Memory came to fall under Sirian rule, though the Sirii have chosen to uphold Gilligan's memory.</description>
   <bar>Predictably, the spaceport bar is themed on Wilibrord Gilligan, showing his likeness in several places and displaying a map of his travels through the galaxy on the wall. A popular topic in this bar is the dwarf planets in Gilligan's Memory, particularly speculations on why Gilligan chose to name them the way he did.</bar>
  </general>

--- a/dat/assets/ginni.xml
+++ b/dat/assets/ginni.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Somewhat unusual in Dvaered space, Ginni is primarily a crop growing world. Though most Dvaered worlds trace their lineage to either mining or industrial roots, Ginni was a food producer even in the days when the Empire was still in control. However, with the change in political influence throughout the region, Ginni's government wisely chose to ally with the Dvaered movement.</description>
   <bar>A lot of planetside spaceport bars have windows that give visitors a glance of the immediate environment, but the one on Ginni does not. This is because the sunlight on Ginni can get rather intense, and it was cheaper to build a wall than an automatically adjusting viewport. Besides, there's not too much to see anyway.</bar>
  </general>

--- a/dat/assets/godtra.xml
+++ b/dat/assets/godtra.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Godtra is a reasonably balanced world, with a sizeable civilian population, a fair amount of heavy industry and some farming for internal consumption, though the population largely depends on Torg Crops for sustenance. As Godtra is one of the wealthiest Dvaered systems within a few jumps, it is a popular target for Warlords to conquer.</description>
   <bar>A pretty decent place as far as spaceport bars go, Godtra's bar is well equipped to facilitate traders and other offworlders. The data uplinks are decently speedy, which is rare on a Dvaered world. Clearly, the local infrastructure has been well designed.</bar>
  </general>

--- a/dat/assets/greenberg.xml
+++ b/dat/assets/greenberg.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This world has suffered from the centralization of Za'lek space particularly hard. With the effective abandonment by the Za'lek authorities beyond a skeleton government, this world has fallen into hard times and struggles to remain afloat.</description>
   <bar>This bar seems very shabby and run-down. It has mismatching furniature and the walls ahve been visibly repaired more than once. THere are few people, and most of them seem to be the types too old and stubborn to leave.</bar>
  </general>

--- a/dat/assets/greis.xml
+++ b/dat/assets/greis.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Greis has a tradition, and that tradition is that whichever Warlord controls the planet renames it after himself. This often causes confusion among spacers everywhere, who will refer to the world by names that have been rendered obsolete. The current warlord is a man named Harmstadt Greis. His rule isn't particularly benevolent, but he at least doesn't seem worse than most Dvaered Warlords.</description>
   <bar>At the center of this spaceport bar stands a pillar, on which are displayed all the names that the planet has been known by, including the name of one unfortunate Warlord named Clerke, who was in control of this world for a little under four hours.</bar>
  </general>

--- a/dat/assets/haldr.xml
+++ b/dat/assets/haldr.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Haldr ranks quite high on the official list of "most unpleasant inhabited planets in the galaxy", which is compiled at regular intervals by the Gilligan Foundation. Indeed, even the most optimistic space traveller would be hard pressed to find a good reason why anyone would want to come to Haldr, let alone stay there. As it turns out, Dvaered High Command has such a reason: Haldr serves as a training grounds for Dvaered military recruits. Though many an upcoming soldier finds death on the radioactive surface of Haldr, those who survive make for tough fighters indeed.</description>
   <bar>To get into Haldr's bar, you first have to undergo a rigorous decontamination procedure, even when you're coming straight from the spaceport dock. This fact has made more than a few visitors so uneasy that they never want to visit Haldr again.</bar>
  </general>

--- a/dat/assets/halir.xml
+++ b/dat/assets/halir.xml
@@ -26,9 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Before there was Emperor's Fist, before there was even the Incident, there was Halir, located in the Gamma Polaris system. While near the outskirts of the Empire, it served as one of the largest local civilian hubs, with a strong economy and considerable political influence. Then, one day, the new Emperor had Polaris Prime built, renamed most of the worlds in the system, and subsequently started the Emperor's Fist project. Halir was reduced to an economic support role. However, the local government has stubbornly clung on to the right to sovereignty, and so Halir remains a civilian world.</description>
   <bar>Halir's bar has everything the weary traveller could hope for, from drinks to data uplink terminals to per-table sound dampening fields and music generators. In short it is a luxurious place, which is largely due to Halir's long history of economic success. Anything you can't find in the bar you can find in the pleasure district, which is just a single tube station away.</bar>
  </general>

--- a/dat/assets/hankies.xml
+++ b/dat/assets/hankies.xml
@@ -23,11 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Hankies is something of a holiday resort as well as retreat for the wealthy. It is mainly a consumer world, having neither the land for agriculture nor the resources for industry. It does, however, have a pleasant ecosystem and a wealth of beautiful geography.</description>
   <bar>Since Hankies doesn't have much to offer, the bar is almost entirely an import product. The architecture, the facilities and the drinks can all be traced offworld. The only thing that is truly authentic to this world is the view from the windows - a mountain range stretching away into the distance.</bar>
  </general>

--- a/dat/assets/harnaar.xml
+++ b/dat/assets/harnaar.xml
@@ -22,13 +22,11 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Though officially classified as a wintery P class planet, Harnaar isn't all that cold. Temperatures in most areas don't dip below human tolerable levels, and to the local Soromid it is actually quite comfortable. The planet's population isn't immensely high, but Harnaar still has the characteristics of a low-density residential world.</description>
   <bar>As Harnaar isn't an intolerably cold world, conditions lend themselves well to outdoor winter recreation. Tourists from all over Soromid space and beyond visit this planet to indulge in winter sports or outdoor relaxation. The spaceport bar welcomes them with open arms.</bar>
  </general>

--- a/dat/assets/hassak.xml
+++ b/dat/assets/hassak.xml
@@ -23,10 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Not exactly unhabitable and not exactly habitable, Hassak is one of those places where the less fortunate in society end up. The people here have it hard, with storms of almost every variety plagueing the landscape on a regular basis. The population feeds itself with the sale of raw minerals to the Nexus corporation, which buys well under the market price, because it can.</description>
   <bar>The bar on Hassak is a lousy affair. The planet is poor, and so can't afford any luxury, least of all for offworlders. The Empire has provided the world with basic facilities and equipment because it is bound to do so by intergalactic treaties, but most of it is old and run-down.</bar>
  </general>

--- a/dat/assets/haurn.xml
+++ b/dat/assets/haurn.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Haurn is a small planet with mild planetary conditions. The Soromid have designated it a dedicated farming world. Apart from a few small settlements, most of the planet's land surface is given to agriculture.</description>
   <bar>This bar is arranged in a coliseum fashion. The facility is circular, with several concentric rings leading down to the center, where the bar is located. The stairways that lead from the center to the upper rings are not gravity conditioned, so moving up them isn't so tiresome.</bar>
  </general>

--- a/dat/assets/heii.xml
+++ b/dat/assets/heii.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Heii is the rather unattractive moon of Juran. Juran itself is a natural M-class, so first time visitors often wonder why the Soromid chose to settle here and not down below. The reason is actually quite interesting. Juran is home to many amazing life forms, including large creatures not at all unlike the dinosaurs that once roamed ancient Earth. Settling down on Juran would not only be dangerous, it would also mean a disturbance in the natural ecosystem. Thus, the Soromid chose not to inhabit Juran, but instead tap its natural animal life by selling specimens as exotic pets throughout the galaxy.</description>
   <bar>Visitors to Heii spaceport bar can use special consoles to access video feeds from survey satellites deployed all around Juran, to observe the life forms on the surface and perhaps even pick one to take back to their own world.</bar>
  </general>

--- a/dat/assets/hikatalat.xml
+++ b/dat/assets/hikatalat.xml
@@ -23,9 +23,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Hikatalat used to be a resource world, before the rise of the Empire. But over time the colony was deemed to be unprofitable, and operations ceased. The world is still inhabited today, but its only value now lies in territorial control for Dvaered Warlords. The population is poor and lives in bad circumstances. There's nothing much to do here for offworlders.</description>
  </general>
 </asset>

--- a/dat/assets/house_zalek_central_station.xml
+++ b/dat/assets/house_zalek_central_station.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This station was once the nerve center of the entirety of House Za'lek. It still is to an extent, but with the move of much the Za'lek government to Ruadan, this station's become something of a secondary capital. Most day to day business of running the Great House still takes place here.</description>
   <bar>This bar seems to double as a conference hall, with many Za'lek university deans and government officials (more often than not being represented by the same people) meeting with each other as well as foreign trade leaders and dignitaries. The food and drink here is of course top notch, but not extravagant.</bar>
  </general>

--- a/dat/assets/hs224.xml
+++ b/dat/assets/hs224.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
   <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>

--- a/dat/assets/hs232.xml
+++ b/dat/assets/hs232.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
   <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>

--- a/dat/assets/hs24.xml
+++ b/dat/assets/hs24.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
   <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>

--- a/dat/assets/hs37.xml
+++ b/dat/assets/hs37.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
   <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>

--- a/dat/assets/hs54.xml
+++ b/dat/assets/hs54.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This is a Thurion habitation station, which provide the living space for the biological Thurians who have yet to be uploaded. While not opulent by any extent, they are not at all an unpleasant place to live.</description>
   <bar>The Thurion "bar" is really not so much of a bar, considering that no alcohol is sold. Still, this is a place where biological Thurions socialize and enjoy foods and drinks safe for the brain.</bar>
  </general>

--- a/dat/assets/hs__5_1.xml
+++ b/dat/assets/hs__5_1.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>This airless, low-gravity moon serves as a modest civilian spaceborne shipyard. It was dubbed cheaper and less effort to get ships to and from the surface of Jurai. There is little of interest to experienced captains, but younger pilots, primarily from Jurai, flock here.</description>
   <bar>This bar is even more of a mess than usual for a Za'lek world. The clientele are young, and congregate around the randomly-placed tables and chairs enthusiastically arguing over a myriad of subjects. Unlike most Za'lek worlds, there are few scientists here.</bar>
  </general>

--- a/dat/assets/huanxi.xml
+++ b/dat/assets/huanxi.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Huan'xi may be a relatively remote planet, but it has a thriving agriculture. The planet's soil is extremely fertile, allowing for multiple crops per cycle. The planet also exports unique foodstuffs that are difficult to produce elsewhere. Indeed, one can find "genuine Huan'xi products" in food outlets all over the galaxy.</description>
   <bar>The rustic feel of this bar is the product of a careful choice of appointments, music and holographic illusions. The owner clearly feels that customers will be attracted by the atmosphere of his establishments, rather than by the drinks he serves.</bar>
  </general>

--- a/dat/assets/hurada.xml
+++ b/dat/assets/hurada.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>A formerly-promising world; following intense volcanic activity, Hurada's orbit decayed, increasing surface temperatures severely and all but eradicating natural surface life. Hurada only maintains a population due to its proximity to Arcturus, providing affordable housing for reserve military troops.</description>
   <bar>The Hurada bar is large, yet nearly deserted. The booth seats in the back have long been unused, and have collected a layer of dust in that time. The brews are stale, and the bartender doesn't look like he wants to be here.</bar>
  </general>

--- a/dat/assets/hurne_station.xml
+++ b/dat/assets/hurne_station.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Hurne Station is a commercial center for this region of Sirius space. It serves as a local commodity exchange as well as a warehouse for traders with a long-term strategy. Traders coming from the Frontier often stop by this place, as it is the closest commerce station to the Frontier-Sirius border.</description>
   <bar>As is common on commerce stations, the spacedock bar is both a place to do business and a place to hear the latest rumors about the state of the galaxy.</bar>
  </general>

--- a/dat/assets/hzmm01.xml
+++ b/dat/assets/hzmm01.xml
@@ -23,9 +23,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>This small moon is a mining world run by House Za'lek; it is regarded as so insignificant that it does not even have a formal name yet, and likely never will.</description>
  </general>
 </asset>

--- a/dat/assets/hznss1.xml
+++ b/dat/assets/hznss1.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>This agri-station is the first in a series of stations built by House Za'lek to mimic the successful INSS system in the Empire. Because there are so many Za'lek worlds that are incapable of supporting themselves without outside assistance, the stations become mandatory to feed the people there.</description>
   <bar>This bar has a series of botanists and scientists arguing over some degree of minutia while several of the laymen around the edges of the bar ignore them, occasionally rolling their eyes at the louder declarations. Even so, none of it seems to make sense to you.</bar>
  </general>

--- a/dat/assets/hznss2.xml
+++ b/dat/assets/hznss2.xml
@@ -23,9 +23,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Another entry in the House Zalek Nutrition Space Station program. Nothing of note really exists here; it is solely an extension of the House's economy.</description>
  </general>
 </asset>

--- a/dat/assets/hznss3.xml
+++ b/dat/assets/hznss3.xml
@@ -23,9 +23,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>One of House Za'leks nutrition stations, this simple agristation services the local sector, augmenting what worlds are unable to feed themselves.</description>
  </general>
 </asset>

--- a/dat/assets/ian.xml
+++ b/dat/assets/ian.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Serving as the main consumer world on the Western fringe of Empire space, Ian makes up for its small size by its wealth. The little sphere is quite a pleasant place to live and many retiring Imperial officials and aristocrats have made the place their home. And where wealth goes, industry follows - Ian has its own modest ship construction facilities.</description>
   <bar>On Ian, it's all about being seen. The bar never goes quiet, though the level of noise also never grows to uncivilized proportions. Both the gentry and the rich up-starts come to the recreational facilities to mingle and to strut their stuff to the offworlders who come here on business.</bar>
  </general>

--- a/dat/assets/idio.xml
+++ b/dat/assets/idio.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Idio is a densely populated world, but not a particularly rich one. It just so happens that the planet offers a lot of buildable terrain and little in the way of natural hazards, so it's an attractive place to live.</description>
   <bar>For some reason, whenever you order a drink here, you always get a different one. It seems to be some kind of running joke.</bar>
  </general>

--- a/dat/assets/inios_station.xml
+++ b/dat/assets/inios_station.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Inios Station is something like a border guard between Sirius and Dvaered controlled territories. Though officially not a military complex, Inios does garrison far more combat capable ships that one might expect of a commercial station. Whenever the Dvaered send in skirmish fleets to try the Sirius defenses, it is Inios Station that sends them on their way home.</description>
   <bar>The bar is built against an outer wall. Several large windows allow patrons to look out on the frozen wastes of Eye of Night III, the planet around which the station orbits. Not coincidentally, the windows also allow people to see the Sirius armed forces docking and taking off, emphasizing the military capacity of the station.</bar>
  </general>

--- a/dat/assets/inss1.xml
+++ b/dat/assets/inss1.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>INSS-1, or Imperial Nutrient Supply Station 1, was the first in a number of Imperially funded space-side crop growing projects. The main purpose of the station is to grow food for nearby colonies and stations at extreme efficiency.</description>
   <bar>Trim and functional, the bar here is situated in the central growing dome of INSS-1. The windows look out on vast stretches of multi-layered crop beds, and there's always a harvester to be seen at work somewhere out there.</bar>
  </general>

--- a/dat/assets/inss2.xml
+++ b/dat/assets/inss2.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>INSS-2, or Imperial Nutrient Supply Station 2, was built in this remote section of space to compensate for the lack of farming output in the sector. Food is not a very profitable commodity to trade over long distances, and the colonies in Nartur found themselves limited in their growth due to chronic shortages. INSS-2 has allowed them to grow.</description>
   <bar>Trim and functional, the bar here is situated in the central growing dome of INSS-2. The windows look out on vast stretches of multi-layered crop beds, and there's always a harvester to be seen at work somewhere out there.</bar>
  </general>

--- a/dat/assets/inss3.xml
+++ b/dat/assets/inss3.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Somewhat curiously, Imperial Nutrient Supply Station 3 is actually owned by House Dvaered. Though initially constructed by the Empire, the station was ceded to House Dvaered as part of its official inception. INSS-3 still provides food for the Imperial colonies at Tau Prime and Draconis, though the price of food there has gone up by a fair margin ever since the change in ownership.</description>
   <bar>The bar is not much to speak of. The Dvaered have shown a greater interest in farming than in public relations, so the spaceport bar has been largely neglected. It's a wonder the basic facilities are even functional at all.</bar>
  </general>

--- a/dat/assets/jaan.xml
+++ b/dat/assets/jaan.xml
@@ -24,11 +24,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Jaan is one of the most densely populated planets in this corner of the galaxy. The world benefits greatly from nearby Nexus operations, which makes it a popular place to live despite the environmental issues that inevitably come with a large population, and the problems with security that have arisen in recent cycles.</description>
   <bar>Jaan has a big spaceport, and to facilitate the many pilots and crews that pass through it has multiple spaceport bars. Each spaceport bar is exactly the same as all the others, though. Not even the people who frequently visit Jaan can tell them apart. This regularly causes problems for unsuspecting people who promised to meet at the spaceport bar.</bar>
  </general>

--- a/dat/assets/jaegnhild.xml
+++ b/dat/assets/jaegnhild.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>There can almost be no greater contrast than there is between Jaegnhild and its primary, Uuries. One is an ocean world, filled with all kinds of unlikely forms of life, while the other is a lifeless chunk of coalesced dust. Jaegnhild was one of the last colonies established in the First Growth, but among all the chosen worlds it was perhaps the most suitable to life when the colony ship arrived. Though not many call the floating cities their home, the standard of living is unusually high for a Frontier world.</description>
   <bar>Jaegnhild's bar is built into an ancient compartment of the colony ship Pristine, which brought the first human settlers to this world so long ago. Though most of the structure has been rebuilt using newer materials, the original plating can still be seen in places.</bar>
  </general>

--- a/dat/assets/janus_farming_station.xml
+++ b/dat/assets/janus_farming_station.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This station is a high-yield crop growing facility. While most farm stations are always facing the local star to make optimal use of its light, this station slowly rotates, exposing both of its sides to the star in turns. One side of the station is used for crop fields while the other side is used to breed livestock. The artificial day-night cycle is found to have a positive effect on the animals.</description>
  </general>
 </asset>

--- a/dat/assets/jaqeline.xml
+++ b/dat/assets/jaqeline.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Though technically an oceanic world, Jaqueline's oceans are filled with algae that absorb light and release toxic fumes into the planet's atmosphere. The organic soup is so thick that the planet appears purple when seen from space. The Soromid, true to form, have taken a great interest in the local ecosystem. Some people believe they are conducting bio-experiments here, treating the whole planet as a laboratory.</description>
   <bar>Though Jaqueline is a fascinating world (according to the Soromid anyway), little can be seen of it for an ordinary ship captain visiting here. The spaceport and its neighboring habitation complex are completely shielded from the outside environment, and any windows would soon be rendered opaque, crusted over with residue from the toxic gases outside.</bar>
  </general>

--- a/dat/assets/jaxheen.xml
+++ b/dat/assets/jaxheen.xml
@@ -22,13 +22,11 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Jaxheen was established in a time when the Soromid had already settled many of the worlds that make up the Soromid core today. The colonization effort was focused more on building a smoothly functioning society than on pioneering, a mentality that paid off in the long run. Jaxheen doesn't suffer from many of the inefficiencies found in societies that evolved by building on themselves. This has made the world quite powerful economically.</description>
   <bar>There are four main portals leading into and out of this spaceport bar. One leads to the spaceport facility. The second leads to the central public transit hub in this area of the metroplex that spans much of the continent. The third leads directly to the local commercial node, and the final portal is connected to the emergency service network, a separate infrastructure completely dedicated to emergency vehicles.</bar>
  </general>

--- a/dat/assets/jemard.xml
+++ b/dat/assets/jemard.xml
@@ -22,12 +22,10 @@
    <refuel/>
    <bar/>
    <missions/>
-   <shipyard/>
    <commodity/>
+   <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Jernard is the moon orbiting the first planet of the Kansas system. It's a hot place, but despite that it's remarkably stable. That, combined with the low gravity, has prompted a commercial producer of starships to set up a manufacturing plant here.</description>
   <bar>Though the spaceport bar is constantly air conditioned, the temperature is still uncomfortably high. Some visitors have voiced concerns about the reliability of the cooling system. Should it ever fail, pilots may not make it back to their ships before being cooked alive.</bar>
  </general>

--- a/dat/assets/jeronon.xml
+++ b/dat/assets/jeronon.xml
@@ -22,13 +22,10 @@
    <refuel/>
    <bar/>
    <missions/>
-   <outfits/>
    <commodity/>
+   <outfits/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Jeronon is a cold, lifeless ball of rock. Geologists claim it was rather cool even in its early days, and now its core barely has any heat left. Worlds like this are not unheard of, but Jeronon is an unusually large specimen. A mining corporation and a spaceship peripheral manufacturer have set up a joint enterprise here, extracting the vast amounts of base metals from the planet's interior and fashioning them into equipment for use on ships.</description>
   <bar>The spaceport bar is probably the most luxurious public facility on the planet. Not that it's a particularly nice spaceport bar, it's just that all the other facilities are even danker and grubbier than it.</bar>
  </general>

--- a/dat/assets/jorcan.xml
+++ b/dat/assets/jorcan.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Jorcan is a very barren, dull planet, like most mining worlds. Having been mined for decades, its resources have been nearly exhausted. However, mining corporations are known to persist until there's no longer a profit to be made, leaving depleted, dead planets.</description>
   <bar>The one word that would describe the Jorcan spaceport bar would be dust. It's everywhere: on the seats, on the counter, in the drinks, on everyone's faces. A coarse soot has coated your palm just holding your drink. You wonder if it will ever wash off.</bar>
  </general>

--- a/dat/assets/jorla.xml
+++ b/dat/assets/jorla.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This Class-O planet is another purely residential planet in Za'lek space, with a rather large population and several university campuses. The standard of living is rather high, and life expectancy is long, making it a popular place to live out a retirement. Other than that, there isn't much to recommend it to adventurers. Which is just how many of the inhabitants like it.</description>
   <bar>This bar bears a closer resemblance to a family restaurant, with the average patron being about late middle age.</bar>
  </general>

--- a/dat/assets/jorlan.xml
+++ b/dat/assets/jorlan.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Jorlan is one of the least successful Frontier worlds. Its colony ship, Santa Maria, arrived to find a barren, desolate rock that had next to no potential for human inhabitants. But with the only other reachable planet being a gas giant, Santa Maria's captain was faced with the choice to settle or perish. Somehow, his expedition has managed to eke out an existence on Jorlan.
 Jorlan's inhabitants are mostly part of the ore refining process, as it supplies most of the Frontier with all sorts of alloys. Gas miners are also sent to Haleb IV every few dozen decaperiods when the weather conditions are favorable.</description>
   <bar>Rather atypically for a heavy-industry world, the people of Jorlan don't really have a habit of drinking. You see numerous other spacefarers, but no natives.</bar>

--- a/dat/assets/jurai.xml
+++ b/dat/assets/jurai.xml
@@ -25,13 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Jurai is a humble and pleasantly liveable class M world. It is a population center for the Za'lek, and is dotted with universities and laboratories. Many younger people on this world yearn to leave to more exciting worlds, while older Za'lek tend to retire here.</description>
   <bar>The bar is as rambling as many Za'lek institutions, yet seems cozy all the same with booths sunken into the floor and soft lighting. The patrons are disproportionately older.</bar>
  </general>

--- a/dat/assets/kanar.xml
+++ b/dat/assets/kanar.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Kan'ar is a class-O world with a large population and an extensive marine biology research community. A lot of underwater research and study goes on here, and like many class-O worlds, it is a large producer of medicine.</description>
   <bar>This bar is a fairly typical underwater bar with built-in overhead aquarium. Plenty of scientists inside of it arguing and talking about what they see, however.</bar>
  </general>

--- a/dat/assets/kataka.xml
+++ b/dat/assets/kataka.xml
@@ -24,6 +24,7 @@
    <missions/>
    <outfits/>
   </services>
+  <commodities/>
   <description>With the loss of Sorom, the Soromid had to decide on a new political capital. After some debate, it was decided that Kataka would fill this position. Kataka is by no means a pleasant world, but the Soromid being the Soromid, that made no difference. Present day, Kataka is home to most if not all of the influential Soromid citizens. Authorities on all aspects of Soromid can be found here.</description>
   <bar>It's quite unusual for a non-Soromid to be granted landing rights on Kataka. And even when this happens, offworlders are usually restricted to the spaceport facility, and if they have business with planetside officials then those officials come to them. The spaceport bar is built for such occurrences, providing private booths where people may converse in private.</bar>
  </general>

--- a/dat/assets/kaulas.xml
+++ b/dat/assets/kaulas.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Volcanic A class planets aren't usually prime candidates for colonization. But sometimes it can be advantageous for an industry to put a factory or two on a planet like Kaulas. Geothermal energy is available in plentiful supply, and some select spots on the planet's surface are stable enough to set up a natural furnace for producing things that require a lot of heat in their production process.</description>
   <bar>Some spacers are uneasy when coming to Soromid worlds that are inhospitable to normal humans. They fear that the conditions within the public facilities will be unhealthy to them. They have no reason to fear though. The Soromid realize full well that unmodified humans make their economy tick, so they make sure to clearly mark all hazardous areas and keep public spaces unmodified-friendly. This bar, for example, is completely safe.</bar>
  </general>

--- a/dat/assets/khelim.xml
+++ b/dat/assets/khelim.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Khelim was the target world for Majestic, the eleventh colony ship sent from Earth in the First Growth. Majestic was populated chiefly by people from India and the Middle East, and though interstellar traffic has been commonplace for many cycles now, the characteristic features of that area can still be seen on the faces of the people of Khelim.</description>
   <bar>The Crescent Blade bar is about as respectable as low-profile bars come. It has all the standard facilities the galactic traveller has come to rely on, and the service leaves nothing to be desired. Other than that, the place is unremarkable.</bar>
  </general>

--- a/dat/assets/laarss.xml
+++ b/dat/assets/laarss.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Laarss is a resource world. Before the inception of House Dvaered, it used to supply the Imperial economy with raw materials at bottom prices. Nowadays, its chief export market is Eist Shipyard, which is in constant need of ship building resources. Though Laarss is largely the same mining colony it was before, working here is considered something of a privilege among Dvaered citizens, considering its location in Dvaer.</description>
   <bar>Though technically this place is the spaceport bar, its main function is a place of leisure for the local population. At all times, you can find large groups of Dvaered workers here, spending their off-time and their credits on booze and entertainment.</bar>
  </general>

--- a/dat/assets/lapra.xml
+++ b/dat/assets/lapra.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Though Coriolis was the second colony ship, it arrived at Lapra well after New Dortmund had been colonized due to technical difficulties and unforeseen incidents during the journey. When it finally did establish orbit around Lapra, it found a world so low on potential for life that the trip almost seemed like a lost cause. However, upon touchdown the colonists found that there were many useful minerals hidden below the surface of the planet. The colony on Lapra has survived, first out of sheer necessity and later by virtue of its exports.</description>
   <bar>Lapra's bar looks more like a market than a place for relaxation, and indeed that is exactly what it is. Not only do traders come here to make transactions, the local population also uses the bar as a center for commerce. That said, one can still find a drink and a news terminal, if one looks hard enough.</bar>
  </general>

--- a/dat/assets/larling.xml
+++ b/dat/assets/larling.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Larling is a popular world for businesses and industries to settle. Sergio Vix is located close to a number of important Soromid systems, and the price of real estate on Larling is low. In addition, the world has quite relaxed environmental legislation, which means industries can cut on emission reduction costs.</description>
   <bar>You won't find Larling's spaceport bar in any top 100 list, but that doesn't mean it's bad. There's just nothing particularly exceptional about it.</bar>
  </general>

--- a/dat/assets/long_rock.xml
+++ b/dat/assets/long_rock.xml
@@ -23,9 +23,7 @@
    <bar/>
    <missions/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Long Rock is a mining world, where the Soromid harvest most of the resources they need. Their thirst for raw materials is considerably small due to the semi-organic nature of their ships, but there is still a demand, and Long Rock is here to deliver.</description>
   <bar>The bar is virtually as harsh as the planet outside. The Soromid miners don't mind the conditions nearly as bad as outsiders. Given Long Rock's near isolation and the rarity of visits from non-Soromid, that suits the locals just fine.</bar>
  </general>

--- a/dat/assets/loramor.xml
+++ b/dat/assets/loramor.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The second moon of Druss' only gas giant, Lora-Mor is a small but pleasant luxury resort. The low gravity has given rise to fantastic plant life, with trees that reach almost 400 meters in height and whose crowns can span over a kilometer from one end to the other. Together with the giant shape of Druss II in the sky, it makes for one of the more exotic places in the galaxy to spend a vacation.</description>
   <bar>Most of Lora-Mor's surface is given over to spacious vacation residences and nature parks. The majority of the planet's permanent population lives around the spaceport, and the spaceport bar is their chief recreational facility. This generally works out, as not many spacers visit Lora-Mor other than to ferry tourists to and fro.</bar>
  </general>

--- a/dat/assets/lorelei.xml
+++ b/dat/assets/lorelei.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Churchill's economic position has turned Lorelei into a well developed world. The constant trade revenues have allowed for large habitation complexes and underground factories that wouldn't look out of place on a Dvaered industrial world. However, unlike the Dvaered, the Sirii have put some thought into their infrastructure, and pollution is kept to a minimum.</description>
   <bar>Because the Sirii didn't want to waste space on a full-fledged spaceport bar, the bar on Lorelei is a virtual one. Visitors enter a VR booth and are given the illusion of being in a large, luxurious spaceport bar, where they can interact with other visitors and the uplink avatars. It is even possible to consume beverages in the virtual bar, as the VR booth is capable of stimulating the part of the human brain that deals with food and drink.</bar>
  </general>

--- a/dat/assets/lugun.xml
+++ b/dat/assets/lugun.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Lugun is a research hub where a large amount of the data from surrounding laboratories and universities is kept for storage and use for other researchers. As such, it is regarded as an important asset to House Zalek in the area and is guarded.</description>
   <bar>This bar is full of chatting scientists and a few military personnel; though with Za'lek's society, the two are not always readily apparent. It is very clean and orderly however, with server droids handing out drinks and food.</bar>
  </general>

--- a/dat/assets/maatsu.xml
+++ b/dat/assets/maatsu.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Though Maatsu's surface was never truly tamed, there is a fairly substantial population here. The larger population centres are kept climate neutral by localized weather control systems, while some of the more remote regions are left to the elements. This has made Maatsu a bit of an attraction to adventurous types who like to go out into the wild.</description>
   <bar>Maatsu sees a fair bit of commerce traffic, so its spaceport bar thrives. Prices of food and drink are exorbitant as a result, but that's nothing new to the average interplanetary trader. So long as the basic facilities are present and readily available, bars can get away with quite a lot.</bar>
  </general>

--- a/dat/assets/madria.xml
+++ b/dat/assets/madria.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Madria is one of the few immigration worlds in Sirius space. Colonists from the Frontier constantly trickle into Esker, and they all end up here. The new arrivals are immediately converted and incorporated into the Shaira echelon, which is why that group is over-represented on this world. Only after several cycles of life on Madria do the immigrants get permission to move to other Sirius worlds or serve in the Sirius military.</description>
   <bar>There are two spaceport bars on Madria, one for regular visitors and one for immigrants. The one for immigrants is more or less a portal into Sirius society - a one way portal. Normal spacers stay away from it.</bar>
  </general>

--- a/dat/assets/manis.xml
+++ b/dat/assets/manis.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Manis is a cool world, though it still counts as earthlike. Unlike many other class M planets in the galaxy, no terraforming was ever performed here, so the world has almost the same ecosystem it did when it was first settled during the Second Growth. Many people are attracted to this "authentic" feel of the planet, which accounts for a significant portion of its popularity.</description>
   <bar>Perhaps uniquely in the entire galaxy, Manis' spaceport bar doesn't serve alcohol. It has any amount of sodas and herbal teas available, but they don't seem as effective at attracting customers to the bar as would your ordinary spacer's swill.</bar>
  </general>

--- a/dat/assets/mannannan.xml
+++ b/dat/assets/mannannan.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Mannannan is one of the more frequently visited Dvaered worlds. Uncharacteristically for a Dvaered planet, its political policies and its economy have remained fairly stable, since none of the Warlords controlling the planet have ever bothered to change the local laws in major ways. This has made Mannannan a favorable place to trade for foreigners. Of course, the Dvaered Warlords seem to be oblivious to this, so Mannannan will likely continue to be a unicum.</description>
   <bar>This bar is one of many. The increase in trade has also brought an increase in tastes, so there are several places that cater to particular tastes, even some very unsavory ones. Fortunately, the most accessible bar seems to be as respectable as bars come.</bar>
  </general>

--- a/dat/assets/manuel_station.xml
+++ b/dat/assets/manuel_station.xml
@@ -25,10 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Manuel Station is named after Eduard Manuel Goddard, the man to which House Goddard owes its existence. The station is primarily a shipyard, and thus contributes a great deal to House Goddard's local economy. Its position around Goddard III is no coincidence, as the lifeless planet provides many of the raw materials needed to produce space ships.</description>
   <bar>The station's bar is more businesslike than recreational. The people who come here are either traders who came to load or unload goods, or potential customers looking for a Goddard-made ship. Nobody is really interested in just passing the time, because time is money on Manuel Station.</bar>
  </general>

--- a/dat/assets/mastodon_station.xml
+++ b/dat/assets/mastodon_station.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Mastodon Station is a power generator, supplying the local planets with energy cells. It also produces power cores and low power energy weapons for the ships produced at Orville Shipyard.</description>
   <bar>The spacedock bar is constantly filled with the low hum of heavy machinery. The entire station reverberates with it, which really gives you the impression that the place is active.</bar>
  </general>

--- a/dat/assets/mendez.xml
+++ b/dat/assets/mendez.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>From space, Mendez looks like a dustball. Its surface is mostly brown and the only visible clouds are dust storms. It is therefore rather surprising that the Soromid use this planet as a major food growing world. The Soromid have developed a kind of crop that will grow in the harsh conditions of Mendez. Unfortunately, the leaves are brown and tough and, while nutritious, don't taste very good.</description>
   <bar>When there's a dust storm raging outside, the spaceport bar is filled with an eerie noise. This happens quite a lot, but despite the local authorities' best efforts, the sound refuses to be blocked out completely.</bar>
  </general>

--- a/dat/assets/mk.xml
+++ b/dat/assets/mk.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>M.K., a rather oddly named planet, holds a special place in many Soromid's hearts. It is the closest inhabited world to Sorom that survived the Incident. It has little else to set it apart, however. The local economy is operating along predictable lines, and the population is no better off than on most Soromid worlds. To most traders, M.K. is just another market to make profit in.</description>
   <bar>Both Soromid and non-Soromid frequent this spaceport bar. As Wildwood Station is more of a service utility than a real community, M.K. is often the first real Soromid port most new traders visit. It is therefore here they get their first taste of a full-fledged Soromid society. It's not uncommon to find young pilots looking at the surroundings with a mixture of wonder and nervousness.</bar>
  </general>

--- a/dat/assets/modus.xml
+++ b/dat/assets/modus.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Modus is an unstable world, but it is surprisingly well populated. Something about the planet is greatly beneficial to human fertility, which makes it a popular destination for couples trying to conceive a child the natural way. Of course this is not without risk, as the planet's volatile nature claims a considerable number of lives each cycle.</description>
   <bar>This bar has chosen to constantly play a heavy beat music track. This is not because people like heavy beat music, but rather to mask the tremors the planet's unstable crust sometimes creates.</bar>
  </general>

--- a/dat/assets/mouddar.xml
+++ b/dat/assets/mouddar.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Mouddar is a bit of a leisure resort, in all but name. While the planet does have a resident population, most of its income is from tourism. The planet is speckled with tiny coral peninsulae, which are perfect for all kinds of water sports. Unfortunately, the enthusiasm of the Imperial adolescents who come here has had a detrimental effect on the environment.</description>
   <bar>Nobody really cares about Mouddar's spaceport bar, apart from the traders who only stop here to load and unload. Most civilian visitors, though, immediately head for the sun, sand and surf that they came here to enjoy.</bar>
  </general>

--- a/dat/assets/mutris.xml
+++ b/dat/assets/mutris.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Mutris. The very heart of Sirius space. This is where Crater City is to be found, home of Sirichana and the many Sirii pilgrims who will one day become the Touched. Crater City being the most holy of places, the airspace in a wide area around it is closed. The spaceport is located thousands of kilometers away. All approaches happen under a tight escort, and non-Sirii are confined to the commercial district of the planet's political capital.</description>
   <bar>The spaceport bar is the primary meeting place for offworlders on Mutris. Since only Sirii may venture beyond the commercial district, all others are either conducting business or relaxing here. As far as bars go, Mutris' is a fairly accomodating one, though the various religious references make it somewhat uncomfortable to some.</bar>
  </general>

--- a/dat/assets/myonei.xml
+++ b/dat/assets/myonei.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Myonei is an industry planet supplying many of the surrounding Soromid worlds with basic necessities. The atmosphere is so dense that it can actually be tapped for raw materials. Most of the infrastructure on the planet is dedicated to the industry, with all of the permanent workforce living up on the moon of Culex.</description>
   <bar>As Myonei has quite a lot of goods to transport offworld at any given time, there is never a lull in the bustle of the spaceport bar. Freighter captains make up most of the clientele, as the workers tend to work continuous shifts and head straight to Culex when they get off.</bar>
  </general>

--- a/dat/assets/myuirr_station.xml
+++ b/dat/assets/myuirr_station.xml
@@ -23,9 +23,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>The Dvaered war machine relies a lot on flinging chunks of matter at enemy ships, and those chunks of matter have to come from somewhere. Myuirr Station is one of the most productive ammunition production facilities in Dvaered space. It produces ordinance for a variety of ballistic and missile weaponry. The portion of its produce that isn't claimed by Dvaered High Command in tax is sold to Warlords, retailers and civilians for profit.</description>
  </general>
  <tech>

--- a/dat/assets/naga.xml
+++ b/dat/assets/naga.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Naga is a purely aquatic planet. The land closest to the surface is under more than a mile of water. The planet is teeming with life of mind-bogling variety and type. The planets scientific and aesthetic value makes it one of the most favored Za'lek worlds.</description>
   <bar>This bar is built on one of the upper decks of the underwater cities, with the entire ceiling being a window out into Naga's oceans. The sight is nothing short of breathtaking.</bar>
  </general>

--- a/dat/assets/nappi.xml
+++ b/dat/assets/nappi.xml
@@ -23,10 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Nappi is one of those names that gets chuckled over in distant spaceport bars. The world is home to a small population that moves across the face of the planet as the seasons progress, living a semi-nomadic life. The capital city is always populated though, because it is the only link to the rest of the galaxy.</description>
   <bar>Few offworlders venture beyond the spaceport bar. There is little to do in the capital city other than to conduct trade, and the outside air becomes unpleasant after only minutes of exposure. Besides, there's very little to see, unless you enjoy looking at endless stretches of rock and sand.</bar>
  </general>

--- a/dat/assets/neo_pomerania.xml
+++ b/dat/assets/neo_pomerania.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Although the Bedimann Enclave is not as powerful as the Procyon Enclave, it is still powerful enough, and Neo Pomerania is very much the reason for this. This Earth-like Class-M has a large population, thriving industry, and the Za'lek's intellectual elite have a strong presence here. Over and all, it is a fully self-sufficient world that serves as the metropolis planet for the local sector of systems.</description>
   <bar>This bar has a brace of scientists of all types loudly arguing over this or that subject. Most of what they are sayin escapes you, and many of the laymen in the bar do not seem fazed by them a bit. A Za'lek bar to the core.</bar>
  </general>

--- a/dat/assets/neurri.xml
+++ b/dat/assets/neurri.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Though life on Neurri is tough, the planet has nevertheless evolved to one of the most prominent pieces of real estate in Soromid space. Kataka's presence implies that Feye gets a lot of traffic, so economically Neurri is in a good position. The world mostly subsists on rendering services to Kataka, though a modest private ship building company has settled here as well.</description>
   <bar>For many non-Soromid, Neurri's bar is a home away from home. Quite a lot of traders come to this planet, so the spaceport bar always has a high number of "regulars" in it. Not that they really mind being around the Soromid, of course. Fine people, the Soromid. They just start giving you the creeps after a while, know what I mean?</bar>
  </general>

--- a/dat/assets/new_dortmund.xml
+++ b/dat/assets/new_dortmund.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>New Dortmund was founded by the very first colony ship to leave Earth, Genesis. The planet itself was known only by its systematic designation for a long time, New Dortmund being the name of the settlement. However, since the settlement was the only thing the colonists knew for many years, its name became synonymous with the world. The moon Folevo was named after the leader of the Genesis expedition, who sadly perished only a few years after the initial touchdown.
 New Dortmund was never very successful in any sense of the term, but it is still pulling its weight in the overall Frontier economy.</description>
   <bar>New Dortmund's spaceport bar is mostly deserted, the locals frequenting their own establishments and offworlders preferring to stay with their ships. The only reason the place is still running is because the Frontier Council subsidizes it, on the basis that a spaceport bar will help attract people to New Dortmund. So far, it hasn't.</bar>

--- a/dat/assets/new_haven.xml
+++ b/dat/assets/new_haven.xml
@@ -27,11 +27,7 @@
    <shipyard/>
    <blackmarket/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>New Haven is a planet located beyond the boundaries of law and justice. Founded by Bartax the Great, one of the most successful pirates to ever live, after Haven was annihilated. The planet's atmosphere is highly toxic and has high levels of radiation outside of the stronghold. These very features are what made the Empire classify it as uninhabitable, as it lacks strategic resources necessary to justify the cost of terraforming. Its distance from other civilized worlds affords it protection from prying eyes.</description>
   <bar>The Slop and Grill is one of the nastiest taverns in the universe. The food and drink don't help matters. Most of it is brewed on New Haven and wouldn't pass any minimal health insurance tests anywhere. Some of the booze even doubles as ship fuel, in times of need. The clients are also deep space thugs, pirates, black marketeers, mercenaries and other shady folk that insist on keeping the ground coated with blood and broken teeth. Not a great place to bring your family.</bar>
  </general>

--- a/dat/assets/niflheim.xml
+++ b/dat/assets/niflheim.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Although not a large installation by any measure, Niflheim is the main commercial station in the southwestern quadrant of Empire space. Though it doesn't see as much traffic as the more centrally located trade hubs, it provides a good opportunity for traders between the Empire, the Za'lek and the Consortium to meet and greet. Of course, the Imperial Navy also uses this station as a base of operations.</description>
   <bar>On Niflheim, space is at a premium. As such there is not much room to spare for leisure, which shows in the spaceport bar. All tables are stand-up arrangements, and there is not much room to maneuver. Any visitor will have to be prepared for some necessary intimacies if he wants to frequent this establishment.</bar>
  </general>

--- a/dat/assets/nixa.xml
+++ b/dat/assets/nixa.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Nixa is a young colony. It was first settled mere years before the Incident occurred. With the galaxy-wide economic collapse that followed in its wake, Nixa's budding growth came close to a halt. The population struggles to make the colonization project a success even so, but now that Dune has become a fringe system, chances of that seem remote.</description>
   <bar>Nixa's bar is still the makeshift affair it was when the planet was first colonized. There haven't been the resources nor the time to replace it with something more solid.</bar>
  </general>

--- a/dat/assets/nonuri.xml
+++ b/dat/assets/nonuri.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Nonuri is a world with an under-developed economy, even by Frontier standards. It barely manages to keep itself from going bankrupt. The people who live here stay mainly out of a sense of belonging, a feeling that Nonuri is their birthright. In fact, Nonuri was colonized by the colony ship Wendigo, which makes Nonuri one of the oldest extrasolar human settlements. Unfortunately for the locals, most of the galaxy doesn't care quite as much as they do.</description>
   <bar>The spaceport bar is humble, yet tidy and functional. The Nonurians may not enjoy a rich life, but they make the most of what they've got. Though the equipment is outdated, in some cases by several generations, this bar has most of the things an intergalactic traveller needs to keep abreast of events.</bar>
  </general>

--- a/dat/assets/nor.xml
+++ b/dat/assets/nor.xml
@@ -24,12 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Nor was one of the first Dvaered worlds to be terraformed. Its abundance of gas and ore make it a strategic location and a prime target for the FLF. Due to repeated attacks and sabotage attempts, the Dvaered military has increased the frequency of patrols.</description>
   <bar>Typical of poorer Dvaered mining worlds, the Nor spaceport bar is cavernous, sparsely decorated and full of drunken Dvaereds trying to forget their hard labour.</bar>
  </general>

--- a/dat/assets/norpin_ii.xml
+++ b/dat/assets/norpin_ii.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Norpin II is truly at the edge of the frontier, a barely-habitable world being mined and terraformed, though the latter is being done as cheaply as possible, resulting in very poor conditions. The Dvaered are loathed here, and it's rumored that the local shipyard is a major source of FLF vessels.</description>
   <bar>The Norpin II bar isn't the safest place around. With a deep-seated loathing of the Dvaered, the local citizens have brawled with Dvaered soldiers on numerous occasions.</bar>
  </general>

--- a/dat/assets/nova_shakar.xml
+++ b/dat/assets/nova_shakar.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Nova Shakar was an utterly unremarkable Empire planet until the Emperor's Fist project began. Increasingly, Empire officials are settling here, given its close proximity to Gamma Polaris. In the time since then, it's become a supplier of many materials for the project, gaining importance within the Empire.</description>
   <bar>While not a grandiose affair, the spaceport bar is reasonably sized and immaculately clean. Due to the increasing number of Empire officials making their home here, it remains busy throughout the day.</bar>
  </general>

--- a/dat/assets/ohon.xml
+++ b/dat/assets/ohon.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Ohon is far from Mutris, but the hearts of its people are not. As devout as Sirians come, they labor in Sirichana's name and never miss a prayer.</description>
   <bar>The bar is fairly tidy. It doubles as a small place of worship for Sirian spacers who haven't got time to travel to the urban centers and still want to practise their spirituality.</bar>
  </general>

--- a/dat/assets/olario.xml
+++ b/dat/assets/olario.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This world is the location of several harsh environment testing facilities, used by the military and civilian interests alike. Aside from that, there is little else of interest here.</description>
  </general>
 </asset>

--- a/dat/assets/oma.xml
+++ b/dat/assets/oma.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Oma is one of the harsher desert worlds. The external temperature varies nearly 400 degrees each day, making it completely incapable of sustaining human life outside of climate-controlled bases. The lack of proper terraforming equipment also makes it hard on the visitors by the drastic temperature changes they endure across the base.</description>
   <bar>The Lost Drunk isn't much of a bar. The high price of most beverages and the low population results in few customers. From what you can see it's mainly shipping pilots and the odd mercenary sitting apart from each other. Not a jolly place.</bar>
  </general>

--- a/dat/assets/omega_station.xml
+++ b/dat/assets/omega_station.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Built to defend the Empire from the Collective, the Omega Station has observed countless battles fought in its sector. Its presence has helped stem the flow of Collective drones into Empire space.</description>
   <bar>The Omega Canteen is a dark place that seems calm, although every time a robotic drone approaches an alarm sounds sending pilots to man their ships to fight off the menace.</bar>
  </general>

--- a/dat/assets/onar.xml
+++ b/dat/assets/onar.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Onar serves as one of House Dvaered's foremost weapons development facilities. The planet has a peculiar characteristic that causes its gravity to fluctuate from region to region, which makes for an ideal testing environment to test ballistic weaponry.</description>
   <bar>Every visitor to Onar is required to check in at the spaceport bar immediately after landing. Nobody is allowed off the premises of the spaceport without a good reason, and even then they will be accompanied by an official Dvaered chaperone. Most visitors therefore find themselves confined to the spaceport bar.</bar>
  </general>

--- a/dat/assets/onyx_shipyard.xml
+++ b/dat/assets/onyx_shipyard.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The Onyx Shipyard is a modern, high-tech shipyard. At least by Dvaered standards. The place builds both combat and trade vessels, and commissions a portion of the Dvaered fleet. Several Warlords also have personal contracts at Onyx, drawing ships for their private fleets from here.</description>
   <bar>Each table in the spaceport bar is themed around a ship design that is manufactured here. Some are even built out of old or faulty components of the ships in question. Of course it's not very artistic, considering that a Dvaered came up with it, but there's still a certain class to it that gets potential buyers in the mood.</bar>
  </general>

--- a/dat/assets/oort_farming_station.xml
+++ b/dat/assets/oort_farming_station.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The Oort Farming Station is one of the farming complexes that supply citizens throughout Sirius space with food. Much of the station is automated, but maintaining any space facility requires many workers on site at any given time. Most of the workers on this station are commuters who live on the nearby planet of Wikon.</description>
  </general>
 </asset>

--- a/dat/assets/opal_station.xml
+++ b/dat/assets/opal_station.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Since Varaati is located in a rather isolated corner of the galaxy, the local government decided to invest in a trade station within the system, to attract more traffic. Though the station is a far cry from commercial powerhouses like Darkshed, Opal Station must be considered a good effort by Frontier standards.</description>
   <bar>The spacedock bar is geared towards trading. There are private booths, tables with integrated data uplinks, a ship outfitting service and charts on the walls showing nearby trade opportunities. The place is never quite packed with people, but there is enough activity in the bar to indicate that Opal Station is slowly returning on its investment.</bar>
  </general>

--- a/dat/assets/oring.xml
+++ b/dat/assets/oring.xml
@@ -24,6 +24,7 @@
    <missions/>
    <outfits/>
   </services>
+  <commodities/>
   <description>The Soromid have only started challenging Oring as recently as 30 cycles ago. Though the planet has no soil suitable for cultivation and is constantly plagued by rust winds, the Soromid intend to one day house a large population on this world. Right now, there is a modest number of colonists living in underground habitats while the terraforming complexes on the surface labor to alter the atmospheric makeup. It's quite fascinating, to someone who's into this sort of thing.</description>
   <bar>The spaceport bar is not too remarkable, as you might expect from a colonist world. The place is functional and simple. There is, however, a public display that shows the current state of the terraforming operation. It never visibly changes, but the graphs show that over the cycles, progress is being made.</bar>
  </general>

--- a/dat/assets/orville_shipyard.xml
+++ b/dat/assets/orville_shipyard.xml
@@ -24,9 +24,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Orville Shipyard is a relatively modest ship building facility, though it is invaluable to Inios Station and Brandt Station, as most of their reinforcements come from here. The station relies on Mastodon Station for the ships' energy cores and weaponry, as Rhu is too far removed from Aesir to send the ships to be outfitted at Sirius Ordnance.</description>
   <bar>Over the bar in this facility, there is a counter display that keeps track of the amount of ships that have been produced at Orville Shipyard since it was commissioned. Clearly, the people here at Rhu take pride in being able to contribute to the Sirian military effort.</bar>
  </general>

--- a/dat/assets/outbound_station.xml
+++ b/dat/assets/outbound_station.xml
@@ -24,10 +24,7 @@
    <missions/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>The last bastion of Imperial control before entering Za'lek space, this station is meant to patrol and tax traffic between the Empire and its supposedly subservient great house. In theory, the system is owned by the Empire. However, the Za'lek have a strong presence here thanks to the Gerhart Station, and the debate over who truly owns the Ganth system and its tolls is a tense one.</description>
   <bar>The bar is staffed with traders and Imperial Military officials. It is noteworthy that there is no Za'lek in sight here.</bar>
  </general>

--- a/dat/assets/passir.xml
+++ b/dat/assets/passir.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Passir is an aquatic world. A lot of the inhabited areas are under the surface of the ocean. But even there, suitable living space is scarce. Passir's oceans run so deep that large areas of the ocean floor are out of reach even for modern day submarine technology.</description>
   <bar>The spaceport is situated on dry land, and so is the spaceport bar. The bar overlooks the main hall of the spaceport, which is dominated by the massive mega-escalators that take people and goods to and from the nearby submarine settlements.</bar>
  </general>

--- a/dat/assets/paul_2.xml
+++ b/dat/assets/paul_2.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Paul 2 is a planet of merchants and entrepreneurs. Though the planet doesn't have a global government as such, the population has agreed on a number of general rules that count as law of some sort. It works surprisingly well.</description>
   <bar>Like many planets in the galaxy nowadays, Paul 2's economy relies heavily on interplanetary trade. The spaceport bar doubles as a trade center, allowing traders to buy and sell wares without ever leaving the spaceport.</bar>
  </general>

--- a/dat/assets/pauldur.xml
+++ b/dat/assets/pauldur.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Pauldur is a small Sirius community, the only inhabited planet in a remote area of Sirius space. Though economically struggling at the best of times, the people here make the most of their situation. Life isn't bad, but it's hard to get the latest fashion items sometimes.</description>
   <bar>This bar is fairly quiet. Not many people stop by Pauldur who aren't from the moon to begin with, and those who are from here don't usually stop by the spaceport bar.</bar>
  </general>

--- a/dat/assets/paxadon.xml
+++ b/dat/assets/paxadon.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Paxadon's population has been estimated at an impressive ten billion in the latest census. For a world not much larger than old Earth, that's a hefty number. Over the cycles, the local authorities have found it necessary to banish all heavy industry from the planet's surface to combat the rapidly increasing levels of pollution. The world's air is cleaner these days, but it's not quite at a comfortable, or even healthy level.</description>
   <bar>This is the main Paxadon spaceport bar. Paxadon has several secondary spaceports, because traffic to and from the world is rather heavy. The main spaceport remains the port of choice for most spacers, though, because it alone offers the various utilities that many need in everyday space life. The spaceport bar is one such utility.</bar>
  </general>

--- a/dat/assets/paxsor.xml
+++ b/dat/assets/paxsor.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Paxsor is a mining planet within Empire space, supplying ore to the shipyards in the system and sending surplus ore to help with the Emperor's Fist project.</description>
   <bar>The Paxsorian bar is a rather simple one, patronized mostly by traders trafficking ore. Given the limited nature of the planet's public facilities, it's impossible to know whether the Nexus employees are hard at work or drinking at a bar of their own.</bar>
  </general>

--- a/dat/assets/percola.xml
+++ b/dat/assets/percola.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Percola is a small world, but it is a rather major producer of food within Soromid space. The planet is rich in carbon and gets a lot of sun, so plant life thrives here. The planet sometimes manages as many as four harvests a cycle. About seventy per cent of the land surface is used for agriculture, ten per cent is used for livestock and the remaining twenty per cent is for the residents and supporting infrastructure.</description>
   <bar>This spaceport bar has a view on one of the nearby mega-meadows that sprawl across Percola. The endless sea of uniform vegetation is impressive to behold, but it's only really a small part of what's out there.</bar>
  </general>

--- a/dat/assets/petaat.xml
+++ b/dat/assets/petaat.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Petaat can be called a civilian Dvaered world, if you're feeling nice. Fact is that people live here, and a Dvaered Warlord controls the local government. But that's about as far as it goes. Petaat is a very unpleasant world, its surface constantly plagued by dust storms and its soil unfit for crop growing. The people living here only do so because they don't have the means to leave.</description>
   <bar>Amazingly, Petaat does have a spaceport bar, despite the fact that this is, well, Petaat. It's rather a dump, though. If you didn't know better you'd think yourself in a decaying slum. Most people here look like they belong in one, too.</bar>
  </general>

--- a/dat/assets/phee.xml
+++ b/dat/assets/phee.xml
@@ -26,9 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Phee is a tad hot, but it's still habitable. The people who live here have to be healthy and robust to stand the environment, and that's the reason why Dvaered High Command likes to conscript new soldiers from this world. But rather than feel dissatisfied about this, the population takes pride in its history of military service. These people are true Dvaered.</description>
   <bar>The owner of the bar has served in several Dvaered campaigns in his day, and it shows. The bar is decorated with trophies and other memorabilia from those days, and the man will tell anyone who will listen about what he calls his glory days.</bar>
  </general>

--- a/dat/assets/phosarrus.xml
+++ b/dat/assets/phosarrus.xml
@@ -22,15 +22,11 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Phosarrus is a pristine civilian world inhabited by the Soromid. The biosphere is very mild even by non-modified standards, so for the Soromid it is a rare gem. The population is estimated at an impressive ten billion, but despite this the planet's ecological system remains in balance. This is in no small thanks to Soromid bioengineering - modified microbiological and plant life help keep the balance from breaking down.</description>
   <bar>For a world as nice as Phosarrus, the spaceport bar is a surprisingly simple affair. The reason for this is that the planet's civilian offworld mass transit is handled via a different terminal, so the only people who use this section of the spaceport are traders and civilians who own their own ships. Lavish recreational facilities would be wasted on them, the thought must have been.</bar>
  </general>

--- a/dat/assets/point_zero_station.xml
+++ b/dat/assets/point_zero_station.xml
@@ -23,6 +23,7 @@
    <bar/>
    <missions/>
   </services>
+  <commodities/>
   <description>Acting as the primary gateway for goods traveling to and from Father's Pride, Point Zero Station is a busy commercial port. Many traders are willing to trade here rather than take the trouble of visiting the systems beyond Point Zero themselves, though there's always the entrepreneur who believes the extra jumps will be worth the payout.</description>
   <bar>Reminiscent of the stock markets on pre-Federation Earth, the spacedock bar of Point Zero Station is one of the biggest and most important facilities aboard. People come here on business just as much as to socialize. Commodity exchange rates are displayed on big screens along the walls, and for a small fee a pilot can make use of a private trade booth.</bar>
  </general>

--- a/dat/assets/polaris_prime.xml
+++ b/dat/assets/polaris_prime.xml
@@ -25,13 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Polaris Prime is the service station for the Emperor's Wrath. Normal people are not allowed to set foot on the gargantuan ship, so all official business has to happen on Polaris Prime. The station is a trade hub as well as a center of government, serving as the civilian end of the Empire's capital.</description>
   <bar>A simple, utilitarian bar patronized largely by off-duty dock workers and terraformers, this bar is nonetheless kept immaculately clean. It clearly means to set the... bar for all bars in Empire space.</bar>
  </general>

--- a/dat/assets/praxis.xml
+++ b/dat/assets/praxis.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Praxis is an anomaly in Dvaered culture, known for its commerce rather than production of materials. Beginning as a small colony, it has become increasingly important since the Incident. Praxis is now considered one of the core Dvaered worlds, the gateway through which Dvaered ore and materials flow into Empire space.</description>
   <bar>While not nearly as pristine as many Empire bars, the Praxis bar is remarkably well-kept for a Dvaered bar.</bar>
  </general>

--- a/dat/assets/protera_sigma.xml
+++ b/dat/assets/protera_sigma.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Protera Sigma is the only Proteron colony known to have survived the Incident. One of the earlier Proteron settlements, it has an established shipyard and access to the original blueprints, so Proteron shipbuilding traditions live on.</description>
   <bar>Rather distinct from traditional Empire bars, the Protera Sigma bar is entirely open and without seats, as the Proteron believe one should stand while eating and drinking. Despite this curiosity, their brews don't stray far from typical Empire faire.</bar>
  </general>

--- a/dat/assets/prp1.xml
+++ b/dat/assets/prp1.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>One of four stations devoted to houses much of the research and knowledge that House Za'lek has accumulated and continues to accumilate. Many of the the most prestigious scientific organizations make its main headquarters on these stations.</description>
   <bar>A rather eclectic bar with various 'enhancements' and upgrades that make it into a mad scientist's dream and a neat freak's nightmare.</bar>
  </general>

--- a/dat/assets/prp2.xml
+++ b/dat/assets/prp2.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>One of four stations devoted to houses much of the research and knowledge that House Za'lek has accumulated and continues to accumilate. Many of the the most prestigious scientific organizations make its main headquarters on these stations.</description>
   <bar>A rather eclectic bar with various 'enhancements' and upgrades that make it into a mad scientist's dream and a neat freak's nightmare.</bar>
  </general>

--- a/dat/assets/prp3.xml
+++ b/dat/assets/prp3.xml
@@ -23,11 +23,7 @@
    <bar/>
    <missions/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>One of four stations devoted to houses much of the research and knowledge that House Za'lek has accumulated and continues to accumilate. Many of the the most prestigious scientific organizations make its main headquarters on these stations.</description>
   <bar>A rather eclectic bar with various 'enhancements' and upgrades that make it into a mad scientist's dream and a neat freak's nightmare.</bar>
  </general>

--- a/dat/assets/prp4.xml
+++ b/dat/assets/prp4.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>One of four stations devoted to houses much of the research and knowledge that House Za'lek has accumulated and continues to accumilate. Many of the the most prestigious scientific organizations make its main headquarters on these stations.</description>
   <bar>A rather eclectic bar with various 'enhancements' and upgrades that make it into a mad scientist's dream and a neat freak's nightmare.</bar>
  </general>

--- a/dat/assets/qoral.xml
+++ b/dat/assets/qoral.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Qoral is primarily a resource-producing world. The terrain is mostly barren and unfit for human habitation, so most of the population is concentrated on a few stretches of suitable land, scattered around the globe, while the rest of the land mass is littered with strip mines.</description>
   <bar>This is a fairly typical spaceport bar. The clientele consists mostly of merchants, though some locals come here also, if not for the drinks then for the chance to talk to people who come from more interesting places than Qoral.</bar>
  </general>

--- a/dat/assets/racheka.xml
+++ b/dat/assets/racheka.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Racheka is a relatively young Sirius colony. Where most Sirius planets are converted planets that once belonged to another faction, Racheka was actually established by Sirius colonists a considerable time after Sirichana settled on Mutris. Perhaps for this reason the Sirian religion can be felt very strongly here, as there are no remnants of other cultures mingling in the lives of the population.</description>
   <bar>The first thing anyone notices when they step into the bar is the ceiling, which is a holographic display of the galaxy, centered around Anarbalis. Though an impressive display as well as a marvel of technology, the bar's proprietor apparently doesn't realize that many of his customers spend all day looking at the stars, and therefore have little desire to look at them when onworld.</bar>
  </general>

--- a/dat/assets/reidd.xml
+++ b/dat/assets/reidd.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Some planets just don't have the capacity to feed their own populations, despite advanced crop-growing techniques. Reidd is not one of those planets. In fact, Reidd's orbit and axial inclination make it such a good farming world that it can supply many worlds in nearby systems. The local government acknowledges this, and has dedicated 97% of Reidd's land surface to agricultural operations.</description>
   <bar>In what might be a slight case of overreaction, Reidd's bar is underground, so as not to have to sacrifice any land surface. Still, the primary difference between this bar and most others in the galaxy is that pilots have to take an elevator to reach this one.</bar>
  </general>

--- a/dat/assets/rin.xml
+++ b/dat/assets/rin.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Rin is a quiet world, far away from the turmoil that plagues most of the galaxy. The inhabitants are friendly, always happy to help a beginning captain get his space legs.</description>
   <bar>If space is just getting a bit too much for you, the spaceport bar on Rin is the place to take a load off. It's a tidy place, and the clientele is well behaved. You will find no unsavory figures here.</bar>
  </general>

--- a/dat/assets/rionna.xml
+++ b/dat/assets/rionna.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Rionna is a cold world, but it was not always so. Only a hundred years ago, it was classified as a class M planet, though even then it was on the chilly side. The reason why the face of the planet is covered in ice now is that the local star is going through a dim phase. Astronomers have predicted that in another century and a half, the star will brighten up again, and Rionna will once again be green. The population has dug in, preferring to wait for better years than to move offworld and leave their homes behind.</description>
   <bar>This spaceport bar is wholly unremarkable. It could be any other bar on any other planet. The only thing that reminds you that you're still on Rionna is that the patrons are all wearing warm clothes.</bar>
  </general>

--- a/dat/assets/rodney.xml
+++ b/dat/assets/rodney.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Rodney is a world where precious gems are mined and sold further south to bolster the Soromid economy. The planet also grows several valuable crops, and is mined for valuable minerals. While this makes it a valuable addition to the Soromid economy, it makes it an aggressively dull place to live.</description>
   <bar>You see several rich magnates and merchant lords in this bar, talking business or making small talk. The sheer pompousness of the scene makes you want to run out the door screaming.</bar>
  </general>

--- a/dat/assets/rostra.xml
+++ b/dat/assets/rostra.xml
@@ -26,13 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Rostra is another enclave core world. The Straight Row is the largest of the enclaves, but also the weakest, with a divided agenda and the burden of dealing with pirates trying to break into Za'lek space. As such, Rostra does not have quite the same amenities as the other enclave cores, and the intellectual elite here live here primarily to avoid the politics in other enclaves and the capital.</description>
   <bar>This bar is loud and dirty with arguing researchers, drinking workers, and stressed out and overworked bar staff. Combined with the cramped quarters and mediocre service, the result is not likely to impress.</bar>
  </general>

--- a/dat/assets/rudderfern.xml
+++ b/dat/assets/rudderfern.xml
@@ -21,14 +21,10 @@
    <land>land_hiclass</land>
    <refuel/>
    <bar/>
-   <outfits/>
    <commodity/>
+   <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Rudderfern is a small but wealthy Soromid colony. Its primary, Father's Pride III, is far too hostile for even the Soromid to utilize, but its moon has very Earth-like properties, apart from its low gravity. Many well-to-do Soromid have settled here, enjoying the pleasant environment and the high level of security offered in Father's Pride.</description>
   <bar>Most planets have spaceport bars. Not Rudderfern. It has a spaceport lounge. It has classy furniture, richly decorated walls and ceilings, and even actual Soromid serving personnel. Rudderfern rather takes pride in officially having the highest class spaceport bar in the known galaxy.</bar>
  </general>

--- a/dat/assets/rulkar.xml
+++ b/dat/assets/rulkar.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Rulk'ar is a mining-world with a strong presence of Za'lek universities thanks to its rather isolated nature aesthetic view. It is a center of terraforming research, turning an already inhabitable planet into a full class-M world.</description>
   <bar>This bar has holopaintings of some of Rulk'ar's breathtaking canyons, mountains, and skyline, as well as the progress on the world's terraforming.</bar>
  </general>

--- a/dat/assets/sabe.xml
+++ b/dat/assets/sabe.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Sabe and Anya are a pair of planets tidally locked to each other, rotating around their shared center of gravity. Sabe is the center of the Thurian government, housing the largest population of both uploaded and biological Thurions, acting as the de-facto capital. The majority of the planet's surface is untouched, as virtually all its inhabitants reside in the multitude of arcologies spread across its surface.</description>
   <bar>The bar here is extremely active, with many biological and uploaded Thurions alike. Of course, as is the custom, biological Thurions do not eat or drink any substances that could harm the brain, meaning that the bar doesn't even offer alcoholic drinks on the menu.</bar>
  </general>

--- a/dat/assets/samell.xml
+++ b/dat/assets/samell.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Samell is a predominantly industrial world. Heavy industry is often not welcome on densely populated M class planets, so it tends to settle on planets with hostile environments. Samell is no exception to that trend.</description>
   <bar>Whoever designed the spaceport placed the spaceport bar at the outside, adding windows so visitors could look out over the frozen landscape. He didn't realize that the windows would soon become frozen over themselves, making them completely useless.</bar>
  </general>

--- a/dat/assets/sander.xml
+++ b/dat/assets/sander.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Griffin III's sister world is Sander. Owing to its largely aquatic surface, its population is significantly lower than Griffin III's, but its oceans provide food to many nearby planets, and Imperial mining operations are able to harvest many valuable materials from the sea floor.</description>
   <bar>This underwater bar is quite the spectacle. Large marine creatures swim by the windows, and the main lobby is designed to enhance the aesthetic. A little overdone, but pleasant overall.</bar>
  </general>

--- a/dat/assets/saraab.xml
+++ b/dat/assets/saraab.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Saraab is a small mining colony. The planet's core is comprised of valuable metals and has almost completely cooled, which makes this world one giant strip mine. The planet is slowly being dismantled and taken to various manufacturing plants elsewhere in the galaxy. In fact, since the planet was first settled around the end of the Imperial Golden Age, its gravity has decreased by 17%.</description>
   <bar>Like on many low-gravity worlds, Saraab's spaceport bar has artificial gravity generators installed in various places. The bar is no exception. However, the generators are old and sometimes break down, which can cause serious discomfort for the patrons. The workers don't seem to mind however - they are used to gravitational shifts.</bar>
  </general>

--- a/dat/assets/scorch.xml
+++ b/dat/assets/scorch.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>This world is teeming with volcanos and rivers of lava, punctuated with frequent earthquakes and acid rains. It is possibly one of the most hostile enviroments to be found in space. So naturally, there is a sizable presence of scientists and geologists who find it to be a treasure trove. The Za'lek authorities use it as a hostile enviroment training center as well.</description>
   <bar>The bar overlooks Scorch's lively weather. The glass is at least a meter thick. The patrons to not seem to mind the visible havoc going on outside, tending to their drinks and conversations with reassurring casualness.</bar>
  </general>

--- a/dat/assets/seanich.xml
+++ b/dat/assets/seanich.xml
@@ -24,10 +24,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>On the edge of the Delta Pavonis system, unnoticed by all but a few, orbits the tiny world of Seanich. Though technically a registered Imperial colony, this backwater planet does not receive the attention that should come with its status. The population is decidedly upset about this, to the point that the local administration has stopped paying taxes to the central Imperial government in protest. The Imperial government hasn't noticed.</description>
   <bar>Seanich has a pretty well-appointed spaceport bar. It has all the facilities a spacer could need, and many are quite up to date. Sadly, this hasn't helped to make the unfortunate colony more conspicuous in the galaxy. Most of the tables are empty.</bar>
  </general>

--- a/dat/assets/selphod.xml
+++ b/dat/assets/selphod.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Selphod is a harsh and barren ice planet. Most of the locals have never ventured outside the established bases. Outdoor travels require heavy thermal protection with a personal generator to keep the wearer from succumbing to hypothermia. Many have met a swift, excruciatingly painful end by venturing out in ill-sealed thermal suits.</description>
   <bar>Most of the drinks served at the bar are served very warm with heavy infusions of all kinds of spices. They are meant to bring warmth and energy in the cold corridors of the base.</bar>
  </general>

--- a/dat/assets/semper.xml
+++ b/dat/assets/semper.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Though Semper is slightly on the poor side by Imperial standards, the people who live here at least have the comfort of tight Imperial security. For that reason, it is quite popular among immigrants into the Empire, who usually don't have the means to settle on the richer civilian worlds.</description>
   <bar>Semper is an immigrant world, which is reflected in its spaceport bar. The design betrays influences from all over the galaxy, such as a holograph of a Dvaered cruiser, a Sirius crest on some of the furniture and even some Soromid-oriented drinks.</bar>
  </general>

--- a/dat/assets/sevlow.xml
+++ b/dat/assets/sevlow.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Sevlow is one of the few truly inhabited Thurian worlds. Sevlow is an uneventful planet, as it serves primarily as an agricultural world producing algae, and as a living place for biological Thurions.</description>
   <bar>This bar is crowded with biological Thurions socializing and drinking non-alcoholic beverages. Just like every other Thurion bar, no alcohol is sold as that is believed to damage the brain.</bar>
  </general>

--- a/dat/assets/shade__sunshine_station.xml
+++ b/dat/assets/shade__sunshine_station.xml
@@ -23,10 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>When the Soromid do something to do with biology, you can assume they do it really well. Shade &amp; Sunshine is a crop growing station with an amazing output. Between the eternal day granted by the station's alignment with the sun and the Soromid's skill with genetic manipulation, crops here are among the most bountiful in the entire galaxy.</description>
   <bar>Shade &amp; Sunshine rotates the crops it grows on a regular basis. The spacedock bar is themed on the currently cultivated crops, using subtle lighting and holopaintings along the walls.</bar>
  </general>

--- a/dat/assets/sheik_hall.xml
+++ b/dat/assets/sheik_hall.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Since well before the rise of House Dvaered, Sheik Hall has been an important exporter of precious metals and valuable minerals. The people on this planet make their living by mining those resources, and crafting jewellery out of them. Though the planet's raw output isn't very high by any standard, the amount of money involved is on par with a medium-sized mining colony.</description>
   <bar>The bar is ornately decorated with all that glitters and gleams. Of course, everything you can see here is a replica, as the real valuables are all shipped offworld. Nevertheless, it's attractive to pretend that you're surrounded by riches for a moment.</bar>
  </general>

--- a/dat/assets/shiarta.xml
+++ b/dat/assets/shiarta.xml
@@ -24,11 +24,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Where Oma is too hot, Shiarta is too cold for comfort. Still, the Empire is always in need of raw materials, and Shiarta is rich in same.</description>
   <bar>The spaceport bar sells only a select number of drinks. Like most mining worlds, there is not much in the way of luxury to be found on Shiarta. There is, however, one small piece of good news: ice cubes are free of charge.</bar>
  </general>

--- a/dat/assets/silverstone.xml
+++ b/dat/assets/silverstone.xml
@@ -26,9 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Silverstone is one of the Soromid's greatest producers of ships and weapons. Growing bioships is only useful if those ships can be equipped with guns, as the local governor argues.</description>
   <bar>As Silverstone is a semi-military business world, the locals take security seriously. All visitors to the spaceport bar must relinquish any weapons on their persons, and submit to a scan upon entry.</bar>
  </general>

--- a/dat/assets/simoen.xml
+++ b/dat/assets/simoen.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Simoen is the only habitable planet in the Kraft system, just barely. Crops don't grow well here and life is hardly luxurious, but there are reasons for humans to live here all the same. Like many desert planets, Simoen has a lot of space for solar power, which makes energy prices here very low. This makes the world interesting for all kinds of manufacturing operations.</description>
   <bar>This spaceport bar is fairly sandy and grubby. Not that it isn't being kept clean, it's just one of those things you see on most G class worlds. Fortunately all of the facilities here are in working order, and the drinks available at the bar are decent enough, if a bit modest in selection.</bar>
  </general>

--- a/dat/assets/sinass.xml
+++ b/dat/assets/sinass.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Sinass is a fairly typical civilian Sirius world. Sirii of all echelons make their home here. Sinass provides most of the supplies needed by Fort Sirius.</description>
   <bar>This bar is divided into three sections. One is blue, one is green and the other is purple. It seems to have some significance, but nobody seems to know exactly what it is. The locals get very upset when you're sitting in the wrong section, though.</bar>
  </general>

--- a/dat/assets/sinclair.xml
+++ b/dat/assets/sinclair.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Sinclair was named after one of the more renowned nobles in House Dvaered, Godfried Sinclair. Like all Dvaered nobles he was a Warlord, and his victories in battle as well as the manner in which he won them earned him the respect in his House as well as the rest of the Empire. The planet that came to bear his name was the last of his conquests, and ultimately became his final resting place. The tomb is a popular destination for Dvaered pilgrims.</description>
   <bar>Sinclair's spaceport bar is run by entrepreneurs, not warriors. But being entrepreneurs, they recognize the value of catering to the locals and to those that pass through, and so it is that this bar has a large holoportrait of Godfried Sinclair hanging over the bar, and his family's weapon can be seen on various decorative fixtures.</bar>
  </general>

--- a/dat/assets/sindbad.xml
+++ b/dat/assets/sindbad.xml
@@ -27,9 +27,7 @@
    <shipyard/>
    <blackmarket/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>From the outside, FLF station Sindbad looks like a piece of junk. This suits the FLF, as their base isn't meant to stand out. The more travellers believe that the station is just another carcass floating in space, the better. On the inside however, Sindbad looks, well, it still looks like a piece of junk. The FLF have limited resources, and the fact that they have a secret, autonomous outpost at all must be considered an achievement. Still, Sindbad is more than a token resistance. The base has all the facilities and defensive capabilities that befit a structure its size, and while stealth remains the FLF's best protection from their Dvaered oppressors, Sindbad can defend itself if need be.</description>
   <bar>The FLF don't have much use for leisures, so it's debatable whether this place can be called a bar. Still, it provides space to sit and talk, and it serves a liquid that seems different from industrial acid, in that it doesn't burn a hole through your stomach. The people here are mostly hard-faced men, and the topics of conversation are limited to the Dvaered and the FLF's cause.</bar>
  </general>

--- a/dat/assets/sirius_ordnance.xml
+++ b/dat/assets/sirius_ordnance.xml
@@ -23,10 +23,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>As with most of the Sirius fleet, the equipment installed on the ships is produced right here at Aesir. As a general rule, no finished ship leaves the system without being fully equipped first.</description>
  </general>
  <tech>

--- a/dat/assets/sirius_shipyards.xml
+++ b/dat/assets/sirius_shipyards.xml
@@ -23,10 +23,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Sirius Shipyards is where most of the Sirius fleet is built, though some of the smaller support ships are actually constructed elsewhere. Though Aesir is not an ideal location for mass producing warships, the Sirii believe that building ships in proximity to Mutris will endow some small portion of Sirichana's power on the ships produced.</description>
  </general>
  <tech>

--- a/dat/assets/sixbat_station.xml
+++ b/dat/assets/sixbat_station.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Sixbat Station is a marvel of technology. It's not so much a station as it is a gigantic mass replicator, capable of replicating entire spaceships given design blueprints and enough raw materials. The facility is of unknown origin. Some believe it to be alien, but there is no proof of this. So far, mankind has yet to design a ship too big for Sixbat to handle.</description>
   <bar>The bar is where customers come to enjoy a few drinks and pleasant conversation while they select which ship they want and in what color, and then wait for it to finish replicating.</bar>
  </general>

--- a/dat/assets/smaal.xml
+++ b/dat/assets/smaal.xml
@@ -22,13 +22,10 @@
    <refuel/>
    <bar/>
    <missions/>
-   <outfits/>
    <commodity/>
+   <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Smaal is right in Malebolge's sweet spot - the orbital distance that's ideal for the development of life. The planet is covered with plant life and even has a few indigenous species of insects. However, Smaal is a very small world, and so the colony here is inhabited by Soromid who have adapted themselves to the low gravity. These Soromid can't ever set foot on another world - their bodies are no longer capable of withstanding higher gees.</description>
   <bar>Smaal isn't very popular with traders. Life in space inevitably involves periods of working outside the gravity controlled areas of the ship, and the last thing a captain wants when coming to port is to have to deal with low gravity.</bar>
  </general>

--- a/dat/assets/solpere.xml
+++ b/dat/assets/solpere.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Solpere is a cold planet with a relatively small population. It only has three seasons: spring, winter, and deep winter. However, there are perks to such a harsh climate. The sky is quite frequently lit up by auroras, and for those who can endure the cold the icy landscape is a magnificent sight to behold.</description>
   <bar>This is a fairly average bar. The service quality is decent enough and all facilities are available. It's not a big place though, since Solpere isn't a very frequently visited port.</bar>
  </general>

--- a/dat/assets/solvac_crops.xml
+++ b/dat/assets/solvac_crops.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Solvac Crops is an agricultural station. Its main purpose is to supply nutrients to satisfy the demand for food on nearby planets. The crops here are genetically modified by the Soromid, and are grown in zero-G conditions, which allows for much more potent yields. Unfortunately, the produce is often structurally unsound, collapsing under its own weight in even low-gravity environments. This is why it us usually processed into liquid or dried foods before being sent to the consumer market.</description>
   <bar>The entire station is zero-G, including the spacedock bar. This can be inconvenient, but most spacers worth their salt know how to deal with it.</bar>
  </general>

--- a/dat/assets/soromid_wards_alpha.xml
+++ b/dat/assets/soromid_wards_alpha.xml
@@ -22,9 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>As everyone knows, the Soromid are exporters of genetic treatment services. People from all over the galaxy travel to Soromid space to have their natural abilities enhanced, diseases cured or appearances improved. All of these people need to be treated somewhere, and this is one such place. Soromid Wards Alpha is a massive medical facility, the largest of all the Soromid Wards. Thousands of clients can be treated here at any one time. Most of the station's volume is taken up by personal treatment tanks, where clients spend anywhere from a 5 to 65 decaperiods in an artificial coma while their genetic code is rewritten.</description>
  </general>
 </asset>

--- a/dat/assets/soromid_wards_beta.xml
+++ b/dat/assets/soromid_wards_beta.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>While Soromid Wards Alpha in Shikima handles seven out of ten gene therapy clients, it is ill equipped for some of the more invasive operations. Soromid Wards Beta, on the other hand, has several facilities that make such operations possible. Of course these advanced procedures come at a higher cost, so the clients visiting Beta tend to be from the upper classes of galactic society.</description>
   <bar>The spacedock bar, which doubles as a waiting room for clients, provides its visitors with information on the services that are rendered on Beta, such as ocular augmentation, bone and muscle reinforcement, disease immunities and reproductive facility expansion.</bar>
  </general>

--- a/dat/assets/soromid_wards_gamma.xml
+++ b/dat/assets/soromid_wards_gamma.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Soromid Wards Gamma can be considered a private facility. While Alpha and Beta cater to the gene treatment needs of the rest of the galaxy, Gamma is for Soromid only. The operations here are geared toward a higher tolerance for modification that normal humans would likely not survive. The patients here are usually colonists or working personnel who need to adapt themselves to a particular climate.</description>
   <bar>Unlike Alpha and Beta, the spacedock bar on Gamma does not offer much information on what goes on in the facility. The Soromid learn about their genes and the modifications in youth education. They know what they're coming for.</bar>
  </general>

--- a/dat/assets/sroolu.xml
+++ b/dat/assets/sroolu.xml
@@ -23,9 +23,7 @@
    <bar/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Sroolu is the lone moon orbiting An'ku II. The colony here mostly concerns itself with harvesting the resources that can be found in An'ku, refining them for processing and even producing some low-level end products out of them. The operation seems to be making profit, though it seems it is fated to remain a minor player in the Sirian economy.</description>
   <bar>Sroolu is only a small colony, but its bar is huge, even by intergalactic standards. It seems whoever built it intended for the entire workforce to fit inside at once. Suffice to say only part of the bar's floor surface is actually in use, the remaining space being screened off by mobile panels.</bar>
  </general>

--- a/dat/assets/stalwart_station.xml
+++ b/dat/assets/stalwart_station.xml
@@ -23,9 +23,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Since well-to-do Dvaereds have laid complete claim to Varia's surface, all industrial and military enterprises have been moved offworld to Stalwart Station. While two-thirds of the station's decks are in use by major Dvaered corporations, there is enough space left for a respectable military wing. In fact, Stalwart Station features as the base of most military operations in the surrounding systems.</description>
  </general>
  <tech>

--- a/dat/assets/stein.xml
+++ b/dat/assets/stein.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Probably the largest Za'lek presence left in the south of their space. A moderately prosperous oceanic world with a diverse economy and several prestigious universities. This world has resisted the entropy that has gripped much of this region of Za'lek space.</description>
   <bar>A ramshakle, rather cheerful place. It has several large aquariums showing off the local marine life. Tables are placed with little rhyme or reason, and the chatter of the patrons adds to the somewhat energetic feel.</bar>
  </general>

--- a/dat/assets/stormy.xml
+++ b/dat/assets/stormy.xml
@@ -26,9 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This gas giant serves as a resource gathering and advanced atmospheric research node. With stations dotting its orbit as low as is safe (and perhaps a biut lower than that). The facilities here are frequently used in the construction of advanced beam weaponry, allowing a larger-than-usual presence of the Za'lek militiary.</description>
   <bar>This bar is signifigantly neater than most Za'lek spaceport bars. That is not to say it's orderly. The patrons are overwhelmingly gas miners, manufacturers and a few militia. The drinks glow suspiciously and the bartender smirks as you side-eye them.</bar>
  </general>

--- a/dat/assets/stutee.xml
+++ b/dat/assets/stutee.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Stutee is a former prison world of the Old Empire. Since it had a breathable atmosphere and little else, it was deemed perfect for dropping off criminals and then forgetting about them. However, as the lower class workers rebelled against the Empire, resulting in the inception of House Dvaered, Stutee came to fall under the jurisdiction of the new Great House. House Dvaered decided to settle Stutee more permanently, bringing the former convicts under their rule and setting them to work. Though Stutee is still of little material value, its location one jump off Dvaer makes up for that.</description>
   <bar>Stutee's bar is located right off the spaceport. Though the planet has been settled and proper infrastructure is now present, the world is not very appealing to any who visit. As such, the spaceport bar is arguably the most important meeting place on the face of the moon.</bar>
  </general>

--- a/dat/assets/sudra.xml
+++ b/dat/assets/sudra.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Located on the fringes of Dvaered-controlled territory, Sudra has a relatively high amount of illegal activity going on. Though the Dvaered authorities actively try to stamp out criminal elements and make arrests almost every week, they are fighting a futile battle.</description>
   <bar>This spaceport bar is unsavory. No other word will describe the place with the same accuracy. A good portion of the bar's clientele are wearing hoods, masks, or other garments to hide their personal features. The lighting is set to quite a dim level, allowing customers to find corners as dark as they please. Despite these obvious signs, the Dvaered officials that sometimes visit the bar don't seem very keen to investigate.</bar>
  </general>

--- a/dat/assets/suoer.xml
+++ b/dat/assets/suoer.xml
@@ -23,9 +23,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Though Suoer classifies as a moon, it is technically a sister planet to Esker IV. Its superdense core gives it so much gravity that it significantly affects its primary, so both planets orbit each other. Suoer's high gravity also makes it a comfortable world to live on for humans.</description>
  </general>
  <tech>

--- a/dat/assets/takeru.xml
+++ b/dat/assets/takeru.xml
@@ -23,10 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>The colony on Takeru was founded as part of an Imperial colonization program. However, the government at the time deemed the colony to be a failure, and refused to grant it Imperial status. Since then, the colonists have governed themselves.</description>
   <bar>What is a spaceport bar? A miserable pile of drink, noise, data terminals, and of course the occasional fight. Takeru's bar has all of these components, which makes it a comfortable place to be for anyone with more than a few lightyears under their belt.</bar>
  </general>

--- a/dat/assets/tankard_station.xml
+++ b/dat/assets/tankard_station.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Tankard Station is a Sirius economical space facility. It processes a large portion of all trade transactions made within An'ku, and also serves as a terminal for the materials produced by Sroolu. There is also a small security detail stationed here, but this is merely for the purpose of customs, not so much the repulsion of hostile elements.</description>
   <bar>Serving both as a trading hub and an outlet of consumer end products, the spacedock bar on Tankard Station is always a bustle of activity. In fact, the actual bar seems more like a section of a larger commerce center than the other way around.</bar>
  </general>

--- a/dat/assets/tau_station.xml
+++ b/dat/assets/tau_station.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Tau Station was constructed with the sole purpose of exploiting the algae produced on Tau Prime. Being a completely oceanic world with a highly corrosive atmosphere, it was deemed more profitable to build an orbiting station, rather than a platform city on the surface. From the station windows you can see heavy algae collectors flying to and from the surface on their endless algae runs.</description>
   <bar>The Tau Prime algae has a powerful odour which pervades the bar. The air is wreathed in the smell, such that you can taste it. It doesn't taste nearly as good unprocessed. Most algae runners stop to grab drinks between runs to try to get the taste of the algae out of their mouth, though the liquors the bar serves happen to be made with processed algae.</bar>
  </general>

--- a/dat/assets/tenalp.xml
+++ b/dat/assets/tenalp.xml
@@ -22,9 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Tenal-P was once a prosperous trade station between the Empire and the Soromid, surviving the initial blast simply because of Iris' distance from Sol. Since then, many residents have left the station, though a couple hundred stubborn individuals have kept the station going.</description>
  </general>
 </asset>

--- a/dat/assets/terminus.xml
+++ b/dat/assets/terminus.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>A small, volcanic world on the edge of the Uridhrion system, Terminus provides Heronus with raw materials needed to grow new ships.</description>
   <bar>Terminus' bar is permanently sooty because of the volcanic activity going on all around outside. The facility does have air filters, but the stuff always manages to get in anyway.</bar>
  </general>

--- a/dat/assets/thar.xml
+++ b/dat/assets/thar.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Thar is a simple mining world owned by the Dvaered. It has a very variable atmosphere that can rapidly alternate from several kilometres wide to barely existent. The pressure changes are harmful to most lifeforms, making it an almost completely sterile planet. With the advent of terraforming techniques it was finally made habitable for humans so they could exploit some of its many resources.</description>
   <bar>"The bar has a strange old meter on one of the walls that seems to dance erratically. When you ask the bartender about it he mentions it measures the current pressure outside.</bar>
  </general>

--- a/dat/assets/thosson.xml
+++ b/dat/assets/thosson.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Thosson is mostly a normal aquatic world, capitalizing on its abundant supply of water. However, a small Soromid community on this world has taken it upon itself to evolve into water-dwelling creatures through genetic manipulation. So far they haven't had much success, and their position on the planet is rather marginal. By and large, the Soromid believe in space more than in oceans.</description>
   <bar>The architect of this spaceport placed the designated area for the spaceport bar a little too close to the landing platforms. From time to time, the music in the bar is drowned out by the engines of an arriving or departing space vessel.</bar>
  </general>

--- a/dat/assets/three_and_a_half_kings.xml
+++ b/dat/assets/three_and_a_half_kings.xml
@@ -25,9 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>It's a nickname, of course. How could it not be? Trouble is, nobody remembers where the name came from, and, bizarrely, there are no records of the station's original name. It's quite a famous story, both within Hekaras and elsewhere. Meanwhile, all involved simply call it Three and a Half Kings. It seems to work for them.</description>
   <bar>This is a typical stationside bar. It has viewports looking into space, which are of course ignored by everyone, since anyone who comes to a station like this has seen all the space they could possibly want to.</bar>
  </general>

--- a/dat/assets/thymo.xml
+++ b/dat/assets/thymo.xml
@@ -24,6 +24,7 @@
    <missions/>
    <outfits/>
   </services>
+  <commodities/>
   <description>People sometimes joke that Soromid will live anywhere, like vermin. This is not true. But a pilot looking at the colony on Thymo might well understand why people say such things. The planet is uninteresting by all means, having little in the way of natural resources and lacking an atmosphere entirely. But the Soromid still live here, mainly because they can. Thymo counts as a civilian world, albeit not a very rich one.</description>
   <bar>Like everything on Thymo, the spaceport bar is sober, utilitarian, efficient. Some pilots like it that way though, as the modest but content clientele testifies.</bar>
  </general>

--- a/dat/assets/topkapi_station.xml
+++ b/dat/assets/topkapi_station.xml
@@ -23,10 +23,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Topkapi is a trade hub and research post for the radiation-bombarded planet of Anker. The Za'lek use the data gleaned from this research to create more hostile-environment resistant habitats and shielding for vessels.</description>
  </general>
 </asset>

--- a/dat/assets/torg_crops.xml
+++ b/dat/assets/torg_crops.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Torg Crops is a crop-growing station constructed by the Dvaered to avert a famine that threatened to erupt in the Torg and Doranthex systems some cycles ago. It's currently running at about 80% of its potential output, but since population figures have remained relatively stable recently it seems that the station won't need to be expanded anytime soon.</description>
   <bar>The spacedock bar here exclusively serves drinks that have been produced from the plants that are grown on-station. This means that while the drinks have all kinds of exotic colors, they all basically taste like cabbage.</bar>
  </general>

--- a/dat/assets/tori.xml
+++ b/dat/assets/tori.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>When the thirteenth colony ship, Yamato Nadeshiko, arrived at Tori, it was sterile. Though it had both water and carbon in abundant supply, there was no life to be found. With the arrival of the mostly Asian human colonists, this changed. Human flora thrived on the planet, and within a century the planet had acquired a fully functional ecosystem. This marvel has inspired the inhabitants of Tori to leave much of the world's surface to nature. Though this means Tori's economic potential remains largely untapped, the thriving tourist industry largely compensates.</description>
   <bar>The spaceport bar is more than just functional. Since most new arrivals on the planet come here first, the authorities have taken pains to make the bar appealing and comfortable. Of course, the fact that Tori is a tourist attraction also means drinks are quite expensive in this bar...</bar>
  </general>

--- a/dat/assets/torloth.xml
+++ b/dat/assets/torloth.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Torloth is a heavy mining planet. It has rich ores and minerals in abundance with no local fauna to speak of. It's one of the strongholds of the Nexus corporation, housing some of their important ship factories, though the heavy gravity of the planet necessitates constructing larger ships off-world. Torloth produces ships exclusively for delivery to Nexus depots and endorsed shipyards.</description>
   <bar>The spaceport bar is carved from a rich mineral deposit lending the walls a glimmering, reflective quality. The local brews often include minerals in their production process, giving them a rich, somewhat saline taste.</bar>
  </general>

--- a/dat/assets/traal.xml
+++ b/dat/assets/traal.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Traal is a pleasant civilian world. With stable tectonics and a favorable climate on most of its land masses, the world makes for good living. It comes as no surprise that the Dvaered eye it greedily, so close to their borders, but so long as Inios Station guards Eye of Night, Dvaered High Command can't claim Traal.</description>
   <bar>Traal's spaceport bar is heavy on Sirian propaganda. With foreign territories just a jump away, the Sirii feel the need to spread their beliefs, even if only passively. Though House Sirius has stopped expanding in recent cycles, the Traalians believe that Sirichana is merely taking a pause to stabilize the existing Sirian worlds. Soon, they say, Fidelis will be Sirius space.</bar>
  </general>

--- a/dat/assets/trichu.xml
+++ b/dat/assets/trichu.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Trichu is both the base for a mining operation that extracts hydrogen from Adiadus IV and a manufacturing plant for low-level industrial goods. The goods are mostly consumed by other worlds in this system, but a small portion of it is exported abroad. Profit margins are minimal, but the facility at least manages to keep from going under.</description>
   <bar>By far, most patrons here are workers whose shifts have ended and whose transport home hasn't arrived yet. The rest are traders who are here to pick up goods.</bar>
  </general>

--- a/dat/assets/trincea.xml
+++ b/dat/assets/trincea.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Trincea is one of the most heavily populated worlds in Dvaered space. As such it is a rather attractive planet for Warlords to fight over, so the laws of the planet are prone to frequent change. The citizens have grown used to it, though, adapting to new legislation as a matter of course. By Dvaered standards, they're exceptionally flexible in their thinking.</description>
   <bar>The spaceport bar is subject to the whims of the Warlords just like anything else on the face of the planet, so it is best to check the local rules every time you set your ship down on Trincea. Fortunately, having drinks and checking the news have never been outlawed so far.</bar>
  </general>

--- a/dat/assets/trinel.xml
+++ b/dat/assets/trinel.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Trinel is a cold, empty mining world with a single colony upon it. Only the bare minimum of Za'lek forces are here to maintain order. Most of the people working the mines are criminals who are kept here for life. The main spaceport is separated from the prison complex.</description>
  </general>
 </asset>

--- a/dat/assets/triton_station.xml
+++ b/dat/assets/triton_station.xml
@@ -24,10 +24,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Triton Station is a shipyard station that's owned by the Empire, but most of its compartments have been leased by the Nexus corporation. The company produces combat-capable ships here, and given the stability of the neighboring systems, there certainly is a market for them.</description>
   <bar>The spaceport bar is a public facility onboard the station, and so the Empire runs it. As such, the bar complies with galactic standards, something that might not have been the case if Nexus had been in charge.</bar>
  </general>

--- a/dat/assets/tummalin.xml
+++ b/dat/assets/tummalin.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Tummalin is the base of operations of a small mining company. Its primary, Longbow III, is rich in various unusual substances. However, the planet itself is far too unstable to permit a permanent presence, so all mining operations are carried out with mobile harvester ships. It's dangerous work, but as long as there's a market there will always be someone willing to do it.</description>
   <bar>The bar has a window that looks out over the main docks for the harvester ships that the miners use to collect resources from the planet below. The ships are ugly and battered, but they are always kept in prime working condition. A malfunction on the surface of Longbow III can quickly lead to the deaths of all crew.</bar>
  </general>

--- a/dat/assets/turawee.xml
+++ b/dat/assets/turawee.xml
@@ -26,9 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>There is literally a world of difference between Thymo and Turawee. Unlike its barren cousin, Turawee is a lush, comfortable world that was never charted even during the Third Growth. The Soromid, having few natural M-class planets at their disposal, take good care of this world. While most other factions would struggle with the trade-off between prosperity and ecology, the Soromid have managed to strike a perfect balance. Turawee may be the only inhabited planet in the galaxy whose environment has not been significantly altered in any way by its occupants.</description>
   <bar>The Soromid are very protective of Turawee. Offworlders are allowed to land, but they have to abide by strict local rules. No smoking is allowed in this bar, nor can any unauthorized goods or substances be brought inside.</bar>
  </general>

--- a/dat/assets/ulios.xml
+++ b/dat/assets/ulios.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Ulios is a backwater independent world. Though a province of the Old Empire before the Incident, the planet has recently declared its independence and is now governed by a small political elite headed by Baron Dovai Sauterfeldt. As the Empire is all but impotent in this region of space and the world is too remote and isolated to be of much interest to the Dvaered, Ulios' independence stands.</description>
   <bar>Despite the relatively accommodating interior, Ulios' spaceport bar doesn't get too many customers. Traders do visit the world, but as there is little profit to be made the ships are few and far between. The captains often choose to conduct their business and move on rather than stay and kick back for a few periods.</bar>
  </general>

--- a/dat/assets/ullnorn.xml
+++ b/dat/assets/ullnorn.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Ullnorn isn't actually a habitable planet, and there is no good reason why humans should make their home here. The fact that they do can be traced back to a Dvaered in-house conflict between two minor Warlords, who each claimed dominion over Ginger and everything in it. With both sides unwilling to back down, it came down to whoever held a permanent presence in the system. Thus, the colony on Ullnorn was established. Today, it is populated by Dvaered citizens unwilling to live there, but too stubborn to leave, lest their rivals claim victory in the age-old dispute.</description>
   <bar>This is a bar. It has to be, because you usually don't have to pay for muddy rainwater. It doesn't seem this place is frequented by its patrons for the purpose of entertainment, because there are no recreational facilities, not even a jukebox. The few appointments are welded to the floor, and everything else is either made out of steel or has steel bars covering it. Clearly, this is a place where fists meet faces. Maybe you shouldn't stay here too long...</bar>
  </general>

--- a/dat/assets/umbrella_station.xml
+++ b/dat/assets/umbrella_station.xml
@@ -23,9 +23,7 @@
    <bar/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Umbrella Station is a space-based clinic. It's common for most worlds to take care of their own health facilities as it is cheaper and faster than lifting patients off-planet, but sometimes medical stations like Umbrella have their uses. Umbrella is primarily a research clinic where unknown ailments are studied in perfect quarantine, in order to develop a cure. Without places such as this, public health would be under constant threat across the galaxy.</description>
   <bar>Though Umbrella Station doesn't have a spacedock bar in the classical sense, it does have a large waiting area equipped with news and recreational facilities. The patrons here aren't patients though, as patients tend to be kept in quarantine. Rather, they are here to visit family or friends, or to do business with the station itself.</bar>
  </general>

--- a/dat/assets/urail.xml
+++ b/dat/assets/urail.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Urail is a halfway decently habitable planet. Its proximity to Mutris makes it a very popular place to live for Sirii, which has driven the price of real estate to almost ridiculous heights. Many Sirii believe that living on Urail gives them a better chance of meeting a Touched, or even being called to Crater City themselves. There is no indication that this is indeed the case, however.</description>
   <bar>Every spaceport needs a spaceport bar. That is probably the only reason why Urail has one, since the population would much prefer to use the space so build housing for upper echelon Sirii. Nevertheless, the bar is comfortable enough, despite the pricey drinks.</bar>
  </general>

--- a/dat/assets/urbanus_crops.xml
+++ b/dat/assets/urbanus_crops.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>Urbanus Crops is one of House Dvaered's crop growing complexes. Though the idea was largely 'borrowed' from the Empire's INSS series, the efficiency of the actual installation is somewhat lower, because of the Dvaered's inferior technological background. Urbanus Crops gets the job done, though, and in fact most of Trincea's food is grown here.</description>
   <bar>If you didn't know better, you'd think you were on a Dvaered military base, from the look of the bar. It's utterly utilitarian, though in the owner's defense an attempt has been made at fitting in with the station's purpose, testament the withered plant on the corner of the bar.</bar>
  </general>

--- a/dat/assets/ururis.xml
+++ b/dat/assets/ururis.xml
@@ -23,9 +23,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Ururis is a relatively wealthy Sirian world. It lies on several major trade routes, which brings in quite a bit of revenue. Cashing in on the amount of visitors it gets, the local government often stages entertainment events designed to make the maximum amount of profit possible.</description>
  </general>
  <tech>

--- a/dat/assets/utsuwa.xml
+++ b/dat/assets/utsuwa.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Many people who live in the Empire think of the Dvaered as unsophisticated, brawny louts who spend all day down in the mines and all night picking fights with each other. This is a stereotype, and it's hardly a fair description of Dvaered society as a whole, but it happens to be absolutely accurate when it comes to the Dvaereds on Utsuwa. The colony on this planet is a full-time mining operation, and all who live on Utsuwa work in the mining industry or its peripherals. Needless to say, House Dvaered gets a significant amount of its raw resources from here.</description>
   <bar>This bar is a miner's bar, alpha and omega. Virtually all its patrons are miners, and they do what miners do, which is drink, fight, and talk about miner things. Fortunately, the owner of the bar is considerate to outside visitors, so in addition to Miner's Ale, Miner's Vodka, Miner's Whiskey and Bloody Miners you can also order a light beer, which has a little wooden miner's pickaxe in it.</bar>
  </general>

--- a/dat/assets/valt.xml
+++ b/dat/assets/valt.xml
@@ -24,11 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Valt is recent home to a Dvaered mining colony. An utterly inhospitable world, the extremely thin atmosphere makes the surface highly dangerous due to its perpetual bombardment by asteroids and solar radiation. The colony is situated nearly a kilometre below the planet's surface, in an immense, resource-rich cavern.</description>
   <bar>The Valt spaceport bar is nothing special. It's rather clean for a Dvaered bar, though that may speak more about the small size of the settlement than the pride the proprietor takes in keeping his establishment clean.</bar>
  </general>

--- a/dat/assets/varaati.xml
+++ b/dat/assets/varaati.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>The sixteenth colony ship to be launched from Earth, Archimedes had many improvements over its predecessors. Though high-yield terraforming was still unknown in those days, the ship did have rather effective atmospheric equalizers and soil enhancers, which allowed it to transform Varaati from a primordial world into a stable class M. Despite this success, Varaati's economic development started relatively late in the game, placing it a good distance behind Dawn and Tori.</description>
   <bar>Varaati's spaceport bar is one of those places where everything is in a state of disrepair, where none of the safety regulations are met and where the air is thick with odors you don't want to guess the origin of. In short, it's a great place to hang out.</bar>
  </general>

--- a/dat/assets/varia.xml
+++ b/dat/assets/varia.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Varia is a Dvaered world, so it can't be called lush or relaxing. But it's the next best thing. The climate on Varia is as close to old Earth's as makes no difference, and the inhabitants of this world typically lead healthy, long lives. In fact, the planet is so nice that some feel it is wasted on the Dvaered, who misuse the bounty the planet offers for their crude, destructive forms of entertainment.</description>
   <bar>Varia's bar is more like a bar complex than a bar. With multiple rooms, each decorated in different styles and each serving different beverages, the discerning alcoholic with money to spare could spend all week here without ever getting bored. Most of the merchants and businesspeople prefer to stick to the main room, however.</bar>
  </general>

--- a/dat/assets/vennis.xml
+++ b/dat/assets/vennis.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Vennis is a planet with characteristics quite close to the Earth Standard. Its gravity, surface area, day-night cycle and annual cycle closely match that of old Earth. It would be a highly suitable planet to live on, were it not for the highly acidic atmosphere. House Sirius has settled a dome colony here, with the intent of eventually terraforming the planet to a high class residential world. It will be many cycles before this ideal will be realized, but the inhabitants of Vennis persevere.</description>
   <bar>Though the planet is many cycles away from being suitable for open-air human life, the spaceport authorities have put up various promotional holovids that showcase the terraforming effort and its predicted effects. It's a mandatory watch for any visitor to the spaceport bar who wishes to use the standard facilities.</bar>
  </general>

--- a/dat/assets/vertigo.xml
+++ b/dat/assets/vertigo.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Vertigo is the second moon orbiting Nartur IV. While the rock itself is utterly uninteresting, Nartur's first moon is anything but. It is a semi-fluid sphere of valuable mineral that often gets used in hyperdrives. Vertigo is the closest place where a harvesting base can be set up, short of building a whole new starbase.</description>
   <bar>Vertigo's spaceport bar has an excellent view of Nartur IV and IVa. Depending on the phase of the various orbital cycles, it can be quite a fetching sight. Of course, some of the time there's very little to see at all.</bar>
  </general>

--- a/dat/assets/vigilance_station.xml
+++ b/dat/assets/vigilance_station.xml
@@ -24,13 +24,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Vigilance Station is the defense center for Procyon. Unusually for a Za'lek military asset, it is well-supplied and cared for, with the staff being ready at a moment's notice to come to Procyon's aid.</description>
   <bar>This bar is simple and clean. Every inch a military establishment.</bar>
  </general>

--- a/dat/assets/vilati_vilata.xml
+++ b/dat/assets/vilati_vilata.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Frozen worlds are usually not colonized unless there is very good reason. Vilati Vilata is no exception. The world offers a wealth of valuable natural resources, as well as expansive subglacial cavern systems that lend themselves quite well to human habitation. The Dvaered have based what would become one of their most successful industrial franchises on this planet, so although nobody likes living here, the place is home to a sizeable amount of workers.</description>
   <bar>The bar is cold. It must be mentioned. Every effort has been made to minimize loss of heat from the building, but given the bar's close proximity to the spaceport, which is exposed to the elements, and the constant flow of customers, it has proven impossible to keep out the cold. This situation has given rise to a number of unkind jokes about the Vilati bar, which are told throughout the galaxy.</bar>
  </general>

--- a/dat/assets/vino.xml
+++ b/dat/assets/vino.xml
@@ -25,11 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Though Vino is a good world for civilian habitation by most standards, the local government is rather distrustful of offworlders. It has made immigration procedures so arduous that the vast majority of potential newcomers gives up when they see the requirements. On the flipside, Vinoan citizens are loath to leave their world, be it temporarily or permanently. This makes Vino an isolated enclave, although trade is still at a decent level despite everything.</description>
   <bar>Vino has a spaceport bar, but only because the government couldn't close it down without running into Empire-wide spaceport regulations. So although the place is open and functional, no effort has been spared to make the place as inhospitable and unpleasant as possible. Real seasoned traders have learned to ignore it, though.</bar>
  </general>

--- a/dat/assets/vlexair.xml
+++ b/dat/assets/vlexair.xml
@@ -24,12 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Vlexair is a harsh, frozen world. Formerly a lush paradise, an internal cataclysm caused its molten core to solidify, resulting in an ice age. Virtually no flora or fauna exist outside of the station. Due to its an extremely dangerous environment, it's proven suitable only to the Dvaered workers.</description>
   <bar>The Vlexair bar is small, as far as Dvaered bars go. There's not much variety of drink other than the standard Dvaered grogs.</bar>
  </general>

--- a/dat/assets/vorca.xml
+++ b/dat/assets/vorca.xml
@@ -27,11 +27,7 @@
    <shipyard/>
    <blackmarket/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Vorca has long been the main base of operations of small time gangsters and crooks, but it didn't grow into a serious Pirate clan until the Dvaered Revolts. In that time of tension and discord, many decided to turn their backs on the Empire entirely and eke out a new life and accrue wealth by taking it from others. Those who survived in that line of work flocked to Vorca and now the planet is host to an impressive fleet of private, more-or-less similarly aligned ships.</description>
   <bar>The average space pilot would, when walking into a Pirate bar, expect utter chaos, fraught with boozing, gambling, violence and narcotic substances. This is an expectation the bar on Vorca does not live up to. As a matter of fact the establishment is quite tightly policed by henchmen of the clan leaders and as such is one of the most orderly places within several jumps. The bar serves as neutral ground among the Pirates themselves and a meeting place for those who, for whatever reason, want to solicit their aid.</bar>
  </general>

--- a/dat/assets/vuere.xml
+++ b/dat/assets/vuere.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>The Emperor's Fist project needs labor. A lot of labor. And so long as the world itself remains unfit for habitation, the workforce needs someplace else to live. The inhabitants of Halir refused to provide them shelter, invoking various complicated rights and regulations, so rather than persuade the local government, the Imperial Council decided to deploy prefab survival units on Vuere. As such, Vuere should be considered a temporary camp rather than a colony. However, with a population this size and a projected duration of stay this long, it is doubtful if Vuere will ever truly be abandoned.</description>
   <bar>The bar is surprisingly hospitable for such a makeshift settlement. The inhabitants apparently feel the need to make up for the harsh environment of their C-class planet by making their indoor areas as comfortable and appealing as they can. The bar is a prime example of this.</bar>
  </general>

--- a/dat/assets/wahri.xml
+++ b/dat/assets/wahri.xml
@@ -26,10 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Industrial Goods</commodity>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>A simple lunar outpost built primarily to mine the local X-class world for its resources and ship them to other parts of Za'lek space. There are rumors of the world being used for weapons testing, but there is little evidence to support that.</description>
   <bar>A simple spacebort bar built entirely out of prefabricated parts. If you want watered-down beer and a filling meal, it will do the job.</bar>
  </general>

--- a/dat/assets/wakan.xml
+++ b/dat/assets/wakan.xml
@@ -22,11 +22,7 @@
    <refuel/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>Wa'kan is a mining world where the mines are solely worked by prisoners. There is a guard detail posted and a small degree of Za'lek researchers here working on criminal justice programs.</description>
  </general>
 </asset>

--- a/dat/assets/warei.xml
+++ b/dat/assets/warei.xml
@@ -25,10 +25,7 @@
    <commodity/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Part of the reason why Warei's surface is permanently frozen is because the planet's core is cold. This is a fascinating aberration from the standard planetary model, but more than that it offers great economical possibilities as there are vast amounts of raw minerals to be had under the crust. The Soromid have taken to set up a parts and ship manufacturing complex here.</description>
   <bar>Even the Soromid need protection from the cold climate, but they're certainly more resistant to it than normal humans. Most non-Soromid traders visiting Warei complain about the cold - the ambient temperature in the bar is far from comfortable.</bar>
  </general>

--- a/dat/assets/warnecke.xml
+++ b/dat/assets/warnecke.xml
@@ -25,10 +25,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>This gas giant is the epicenter of a gas mining operation for the Za'lek navy and merchant marine. The gasses here are refined into fuel for the Za'lek's new ring drives. Obviously, scientists here also work obsessively on building new and better forms of engines for the house's vessels.</description>
   <bar>This bar smells faintly of the refining going on throughout the orbital station skimming the upper atmosphere of the gas giant Warnecke. It does very little to impress, and the bartender apologizes for the poor air scrubbers labouring in the corners.</bar>
  </general>

--- a/dat/assets/waterholes_moon.xml
+++ b/dat/assets/waterholes_moon.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-  </commodities>
+  <commodities/>
   <description>In the days of the Old Empire, Waterhole was the farthest outpost of the Empire. To the Imperials, it was the last outpost of civilization, the last bastion of safety before venturing out into the systems beyond. It is because of this that Waterhole, the system and the planet, derive their names. Now, centuries later, Waterhole remains at the border of Empire space. It is still the last stop for traders venturing out, and the first of those coming in.</description>
   <bar>Waterhole's Moon wouldn't be Waterhole's Moon if its bar wasn't called The Waterhole. Though the place is open to visitors from all origins and walks of life, the majority of the clientele is Imperial in nature. It seems that nothing creates a longing for home like being away from it for prolonged periods of time.</bar>
  </general>

--- a/dat/assets/werlen.xml
+++ b/dat/assets/werlen.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Werlen is a world devoted to the cultivation of the raw materials the Soromid use to fabricate their ships. The world is off-limits to casual traffic, and only those trusted by the Soromid are permitted access.</description>
   <bar>Virtually spotless despite being situated on a mining colony, this bar is an anomaly. Its cleanliness appears to be thanks in large part to an automated cleaning apparatus, the sides of which are covered in dire warning labels. The other patrons appear to be giving the machine a wide berth.</bar>
  </general>

--- a/dat/assets/wigheta.xml
+++ b/dat/assets/wigheta.xml
@@ -23,6 +23,7 @@
    <bar/>
    <missions/>
   </services>
+  <commodities/>
   <description>While the main line of Soromid military ship production is located on Heronus in Uridhrion, there is a secondary ship plant here on Wigheta. Wigheta does not grow the regular models, however. Instead, the world acts as a research facility for bioships, where new designs and growth methods are invented and tested. It's a slow and expensive process, and Wigheta only produces a useful result once every few cycles, but without the work done here the Soromid bioship technology will never evolve.</description>
   <bar>Wigheta's spaceport bar is located close to the actual landing docks of the spaceport. The research done on Wigheta is top-secret, so every precaution is being taken to prevent visitors from wandering into places they shouldn't.</bar>
  </general>

--- a/dat/assets/wikon.xml
+++ b/dat/assets/wikon.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Wikon is a high-profile Sirian world, one of the driving economical forces in the core of Sirius space. With planetary characteristics fairly close to ideal class M, it is both attractive for habitation and industry. Land values are rather high, and the population tends toward the Serra class.</description>
   <bar>A better name for the spaceport bar would be "spaceport lounge". The establishment is luxurious even by non-spaceport standards, offering various recreational facilities in addition to the standard ones. It is possible to dine here too, and the menu is far from modest. Of course all this comes with a considerable price tag, but the economic climate allows for that.</bar>
  </general>

--- a/dat/assets/wonclock.xml
+++ b/dat/assets/wonclock.xml
@@ -22,12 +22,10 @@
    <refuel/>
    <bar/>
    <missions/>
-   <outfits/>
    <commodity/>
+   <outfits/>
   </services>
-  <commodities>
-   <commodity>Medicine</commodity>
-  </commodities>
+  <commodities/>
   <description>The Soromid have more or less stabilized as a genetically modified offshoot from humanity, but that doesn't mean research into genetic alteration isn't still ongoing. Woncloak hosts one of the largest bioresearch centers in Soromid space. Many of the commercially sold gene treatments were developed here, and being a researcher on Woncloak carries a lot of prestige with the Soromid.</description>
   <bar>Being such an important location for Soromid society, security on Woncloak is pretty tight. In particular, visitors have their background checked, to make sure they're not here with a Za'lek agenda. The spaceport bar can only be accessed after pilots have passed all the security protocols.</bar>
  </general>

--- a/dat/assets/worscha.xml
+++ b/dat/assets/worscha.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Worscha is a relatively wealthy Sirian world with a mild climate and pleasant planetary conditions. Its rotation is a bit on the long side, about 25% longer than that of old Earth, which has led to the daily rhythm being a little slower than elsewhere.</description>
   <bar>Many Sirian bars have some sort of layout separation for the various echelons, but Worscha's bar doesn't have anything of the sort. This sometimes leads to Sirian traders getting confused, as they are used to placing themselves in the correct section of the bar.</bar>
  </general>

--- a/dat/assets/yrina.xml
+++ b/dat/assets/yrina.xml
@@ -24,9 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Ore</commodity>
-  </commodities>
+  <commodities/>
   <description>Yrina is a resource world that's being strip-mined by the Sirii. The climate is harsh and almost all of the planet's surface is frozen, but in some cases that is actually desirable, as substances that would normally be fluid are now solid, and therefore mined more easily. Yrina supplies mostly Aesir, but some of the more exotic elements are exported to other parts of Sirius space, and beyond.</description>
   <bar>The bar has various displays that provide the patrons with details about the mining process, and the current state of the operation in various areas. Though to most visitors it is of passing interest at best, you've got to at least hand it to the Sirius that they take an informative approach to their operation here.</bar>
  </general>

--- a/dat/assets/zabween.xml
+++ b/dat/assets/zabween.xml
@@ -26,12 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zabween is an old station. It was first created as an outpost to fight piracy, but with the destruction of the Haven it has settled into a more traditional role. It presently functions as a largely commercial station, trading in many commodities. It keeps a museum with all sorts of ships and weapons that were used in the final fight against Haven.</description>
   <bar>The bar walls are decorated with pictures of Empire soldiers who have fallen in the fight against Haven and piracy in general. It has become customary for the Empire to post pictures of the fallen, honouring those who gave their lives protecting the Empire's ideals. They are working on another addition to be able to fit more pictures.</bar>
  </general>

--- a/dat/assets/zalebus.xml
+++ b/dat/assets/zalebus.xml
@@ -22,14 +22,11 @@
    <refuel/>
    <bar/>
    <missions/>
+   <commodity/>
    <outfits/>
    <shipyard/>
-   <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zalebus is a nice planet that was terraformed by the Soromid shortly before the Incident. It was a borderline class M to begin with, so the process was one of the fastest in human history. Now, there are billions of people living here.</description>
   <bar>The age demographic of Zalebus tends toward younger citizens. As a result, the spaceport bar is often full of youngsters preparing for a trip into space, or just returning from one.</bar>
  </general>

--- a/dat/assets/zembla_shakar.xml
+++ b/dat/assets/zembla_shakar.xml
@@ -25,11 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Medicine</commodity>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zembla Shakar is like a resort for the elite within the Shakar system. The people who live here live on gigantic estates that they usually haven't seen all of. Most of the planet is off-limits to offworlders, and most traffic to the planet consists of import luxury goods and export waste products.</description>
   <bar>The bar is where traders wait until their cargo is loaded and unloaded. Pilots who come here expecting a glimpse of the rich lands that cover the surface of the planet will be disappointed, as there is very little to see here.</bar>
  </general>

--- a/dat/assets/zeo.xml
+++ b/dat/assets/zeo.xml
@@ -24,10 +24,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Most of Zeo's inhabitation is recently new. After the Incident, real estate prices had a major overhaul all across the galaxy, and the once neglected backwater world of Zeo quickly became prime land to settle for Imperial citizens. Though the population is still on the low side compared to older civilian worlds, the number of people living here rises by the day.</description>
   <bar>Because of Zeo's abrupt rise in value after the Incident, the antiquated facilities at the time had to be replaced to handle the influx of Imperial colonists. As a result, most of the infrastructure here is relatively modern. You won't find anything out of order or slow to respond in this bar.</bar>
  </general>

--- a/dat/assets/zepei.xml
+++ b/dat/assets/zepei.xml
@@ -25,9 +25,7 @@
    <commodity/>
    <outfits/>
   </services>
-  <commodities>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zepei has a modest native population, and a sizeable non-permanent population. The surface of the planet is covered with holiday resorts, nature parks and outdoor sports areas. Most of the vacation goers are Soromid. Non-modified humans would find the recreational activities too rough for comfort.</description>
   <bar>The spaceport bar is not frequented much. The Soromid who come here on vacation typically go straight to the terminals, and they constitute most of the spaceport's traffic. The bar is used only by the captains of the supply and trade ships that land on Zeppei.</bar>
  </general>

--- a/dat/assets/zhang_lu.xml
+++ b/dat/assets/zhang_lu.xml
@@ -22,12 +22,10 @@
    <refuel/>
    <bar/>
    <missions/>
-   <outfits/>
    <commodity/>
+   <outfits/>
   </services>
-  <commodities>
-   <commodity>Luxury Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zhang Lu is a world with vast mountain ranges, the biggest of which reaches almost a third of the way around the planet. The world is utterly uninteresting for habitation even by Soromid standards, but the rugged terrain is irresistible for people who like mountaineering. There are countless peaks that have never been conquered, so tourists like to try and be the first to climb one.</description>
   <bar>The spaceport is build in a valley. The reason for this is that tourists arriving will immediately be presented with mountains towering over them on all sides, which really gets them in the mood. Unfortunately this location is less than practical from a pilot's point of view, as having mountains all around the spaceport severely limits the choice in approach vectors.</bar>
  </general>

--- a/dat/assets/zhiru.xml
+++ b/dat/assets/zhiru.xml
@@ -26,11 +26,7 @@
    <outfits/>
    <shipyard/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Ore</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zhiru was once home to Eduard Manuel Goddard, the man who single-handedly designed the then-revolutionary Goddard battlecruiser, and who would establish the minor House Goddard. Now Zhiru has a booming spacecraft industry, specialized in the creation and maintenance of the Goddard ships. This is all possible due to the weak gravity and atmosphere that envelops Zhiru, which allows the massive spacecraft to land and take off with little difficulty.</description>
   <bar>The Goddard Bar is, unsurprisingly, an obsolete model of their eponymous ship, stripped and refitted in the form of a bar. It's surprisingly comfortable and cozy as a bar, although every so often you can hear creaking in the ancient metal frame.</bar>
  </general>

--- a/dat/assets/zuner.xml
+++ b/dat/assets/zuner.xml
@@ -24,10 +24,7 @@
    <missions/>
    <commodity/>
   </services>
-  <commodities>
-   <commodity>Food</commodity>
-   <commodity>Industrial Goods</commodity>
-  </commodities>
+  <commodities/>
   <description>Zuner's surface has been dedicated almost entirely to crop growing. While there are some urban centers scattered around the world, their population is low compared to the residential megaplexes of more densely populated worlds. Though the community is to a large extent agricultural, the inhabitants are in no way out of touch with the rest of the galaxy. In fact, Zuner is quite wealthy, given how lucrative food production can be.</description>
   <bar>Many spacers think of agricultural worlds as backwater places that lag some 30 cycles behind the rest of the galaxy. Sometimes, they are right. But not in the case of Zuner. The spaceport is as modern as can be, and the spaceport bar wouldn't be out of place even in the Sirius core.</bar>
  </general>

--- a/dat/commodity.xml
+++ b/dat/commodity.xml
@@ -5,6 +5,7 @@
   <description>Evolving from the military rations of centuries past, modern packaged meals are rich in nutrients and able to last decades in their vacuum-sealed packaging.</description>
   <price>140</price>
   <gfx_store>standard_mealpacks</gfx_store>
+  <standard/>
   <planet_modifier type="0">1.1</planet_modifier>
   <planet_modifier type="1">1.05</planet_modifier>
   <planet_modifier type="2">1.2</planet_modifier>
@@ -51,7 +52,6 @@
   <price>450</price>
   <gfx_store>gold</gfx_store>
   <gfx_space>gold</gfx_space>
-  <standard/>
   <planet_modifier type="0">1.2</planet_modifier>
   <planet_modifier type="1">1.3</planet_modifier>
   <planet_modifier type="2">1.4</planet_modifier>
@@ -72,6 +72,7 @@
   <description>An assortment of industrial goods, ranging from cutting lasers to processed metals.</description>
   <price>340</price>
   <gfx_store>recycled_electronics</gfx_store>
+  <standard/>
   <planet_modifier type="1">1.1</planet_modifier>
   <planet_modifier type="2">1.1</planet_modifier>
   <planet_modifier type="3">1.1</planet_modifier>
@@ -95,6 +96,7 @@
   <description>An assortment of medicines suitable for curing all sorts of ailments.</description>
   <price>750</price>
   <gfx_store>vaccines</gfx_store>
+  <standard/>
   <planet_modifier type="1">1.1</planet_modifier>
   <planet_modifier type="2">1.2</planet_modifier>
   <planet_modifier type="H">1.2</planet_modifier>
@@ -116,6 +118,7 @@
   <description>All sorts of high quality luxury goods.</description>
   <price>630</price>
   <gfx_store>first_class_passenger</gfx_store>
+  <standard/>
   <planet_modifier type="0">1.05</planet_modifier>
   <planet_modifier type="1">1.2</planet_modifier>
   <planet_modifier type="2">0.8</planet_modifier>

--- a/dat/ssys/alteris.xml
+++ b/dat/ssys/alteris.xml
@@ -19,8 +19,8 @@
   <asset>Takeru</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Empire Small</asset>
-  <asset>Virtual Trader Local</asset>
   <asset>Virtual Miner Small</asset>
+  <asset>Virtual Trader Local</asset>
  </assets>
  <jumps>
   <jump target="Coriolis">
@@ -42,9 +42,8 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <type>default</type>
-   <pos x="0" y="0"/>
-   <radius>5000</radius>
+   <radius>5000.000000</radius>
+   <pos x="0.000000" y="0.000000"/>
    <density>0.250000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/amatiri.xml
+++ b/dat/ssys/amatiri.xml
@@ -14,8 +14,8 @@
   <asset>Amatiri I</asset>
   <asset>Amatiri II</asset>
   <asset>Amatiri Ia</asset>
-  <asset>Virtual Pirate Small</asset>
   <asset>Virtual Miner Small</asset>
+  <asset>Virtual Pirate Small</asset>
  </assets>
  <jumps>
   <jump target="Ariadus">
@@ -32,9 +32,9 @@
    <type>default</type>
    <type>default</type>
    <type>golden</type>
-   <pos x="4000" y="-1000"/>
-   <radius>3000</radius>
-   <density>1.0</density>
+   <radius>3000.000000</radius>
+   <pos x="4000.000000" y="-1000.000000"/>
+   <density>1.000000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/arcanis.xml
+++ b/dat/ssys/arcanis.xml
@@ -34,9 +34,9 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="4000" y="6000"/>
-   <radius>4000</radius>
-   <density>1.0</density>
+   <radius>4000.000000</radius>
+   <pos x="4000.000000" y="6000.000000"/>
+   <density>1.000000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/diadem.xml
+++ b/dat/ssys/diadem.xml
@@ -32,33 +32,28 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <type>default</type>
-   <pos x="-2000" y="-3000"/>
-   <radius>1000</radius>
+   <radius>1000.000000</radius>
+   <pos x="-2000.000000" y="-3000.000000"/>
    <density>0.500000</density>
   </asteroid>
   <asteroid>
-   <type>default</type>
-   <pos x="-1000" y="-2500"/>
-   <radius>1000</radius>
+   <radius>1000.000000</radius>
+   <pos x="-1000.000000" y="-2500.000000"/>
    <density>0.500000</density>
   </asteroid>
   <asteroid>
-   <type>default</type>
-   <pos x="0" y="-1000"/>
-   <radius>1500</radius>
+   <radius>1500.000000</radius>
+   <pos x="0.000000" y="-1000.000000"/>
    <density>0.500000</density>
   </asteroid>
   <asteroid>
-   <type>default</type>
-   <pos x="500" y="500"/>
-   <radius>1000</radius>
+   <radius>1000.000000</radius>
+   <pos x="500.000000" y="500.000000"/>
    <density>0.500000</density>
   </asteroid>
   <asteroid>
-   <type>default</type>
-   <pos x="1400" y="-2000"/>
-   <radius>500</radius>
+   <radius>500.000000</radius>
+   <pos x="1400.000000" y="-2000.000000"/>
    <density>0.750000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/euler.xml
+++ b/dat/ssys/euler.xml
@@ -27,8 +27,8 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="2000" y="2000"/>
-   <radius>5000</radius>
+   <radius>5000.000000</radius>
+   <pos x="2000.000000" y="2000.000000"/>
    <density>0.333333</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/felzen.xml
+++ b/dat/ssys/felzen.xml
@@ -11,8 +11,8 @@
   <y>-954.416665</y>
  </pos>
  <assets>
-  <asset>Virtual Pirate Small</asset>
   <asset>Virtual Miner Small</asset>
+  <asset>Virtual Pirate Small</asset>
  </assets>
  <jumps>
   <jump target="Peter">
@@ -32,9 +32,9 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="0" y="0"/>
-   <radius>4000</radius>
-   <density>0.5</density>
+   <radius>4000.000000</radius>
+   <pos x="0.000000" y="0.000000"/>
+   <density>0.500000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/fern.xml
+++ b/dat/ssys/fern.xml
@@ -19,9 +19,9 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="0" y="0"/>
-   <radius>3000</radius>
-   <density>1.0</density>
+   <radius>3000.000000</radius>
+   <pos x="0.000000" y="0.000000"/>
+   <density>1.000000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/flow.xml
+++ b/dat/ssys/flow.xml
@@ -11,11 +11,11 @@
   <y>545.000000</y>
  </pos>
  <assets>
+  <asset>HS-54</asset>
   <asset>Kaira</asset>
+  <asset>NS-27</asset>
   <asset>Nasano</asset>
   <asset>Sevlow</asset>
-  <asset>HS-54</asset>
-  <asset>NS-27</asset>
  </assets>
  <jumps>
   <jump target="Aesria">

--- a/dat/ssys/gammacron.xml
+++ b/dat/ssys/gammacron.xml
@@ -30,13 +30,13 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="1200" y="4032"/>
-   <radius>1400</radius>
-   <density>10.0</density>
+   <radius>1400.000000</radius>
+   <pos x="1200.000000" y="4032.000000"/>
+   <density>10.000000</density>
   </asteroid>
   <exclusion>
-   <pos x="1200" y="4032"/>
-   <radius>1000</radius>
+   <radius>1000.000000</radius>
+   <pos x="1200.000000" y="4032.000000"/>
   </exclusion>
  </asteroids>
 </ssys>

--- a/dat/ssys/haven.xml
+++ b/dat/ssys/haven.xml
@@ -42,8 +42,8 @@
    <type>default</type>
    <type>default</type>
    <type>golden</type>
-   <pos x="6000" y="6000"/>
-   <radius>4000</radius>
+   <radius>4000.000000</radius>
+   <pos x="6000.000000" y="6000.000000"/>
    <density>0.500000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/hephaestus.xml
+++ b/dat/ssys/hephaestus.xml
@@ -23,24 +23,8 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <corner>
-    <x>-4000.000000</x>
-    <y>-3000.000000</y>
-   </corner>
-   <corner>
-    <x>-1000.000000</x>
-    <y>-4000.000000</y>
-   </corner>
-   <corner>
-    <x>0.000000</x>
-    <y>0.000000</y>
-   </corner>
-   <corner>
-    <x>-3000.000000</x>
-    <y>-500.000000</y>
-   </corner>
-   <pos x="-2000" y="-2000"/>
-   <radius>2000</radius>
+   <radius>2000.000000</radius>
+   <pos x="-2000.000000" y="-2000.000000"/>
    <density>1.000000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/jommel.xml
+++ b/dat/ssys/jommel.xml
@@ -11,8 +11,8 @@
   <y>604.486667</y>
  </pos>
  <assets>
-  <asset>Virtual Pirate Small</asset>
   <asset>Virtual Miner Small</asset>
+  <asset>Virtual Pirate Small</asset>
  </assets>
  <jumps>
   <jump target="Point Zero">
@@ -26,9 +26,9 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="3000" y="-1000"/>
-   <radius>5000</radius>
-   <density>0.5</density>
+   <radius>5000.000000</radius>
+   <pos x="3000.000000" y="-1000.000000"/>
+   <density>0.500000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/knave.xml
+++ b/dat/ssys/knave.xml
@@ -11,8 +11,8 @@
   <y>-52.237037</y>
  </pos>
  <assets>
-  <asset>Virtual Pirate Small</asset>
   <asset>Virtual Miner Small</asset>
+  <asset>Virtual Pirate Small</asset>
  </assets>
  <jumps>
   <jump target="Delta Polaris">
@@ -26,9 +26,8 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <type>default</type>
-   <pos x="-4500" y="4000"/>
-   <radius>2000</radius>
+   <radius>2000.000000</radius>
+   <pos x="-4500.000000" y="4000.000000"/>
    <density>0.500000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/lapis.xml
+++ b/dat/ssys/lapis.xml
@@ -36,23 +36,23 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="6000" y="-5000"/>
-   <radius>1000</radius>
+   <radius>1000.000000</radius>
+   <pos x="6000.000000" y="-5000.000000"/>
    <density>1.500000</density>
   </asteroid>
   <asteroid>
-   <pos x="6500" y="-2000"/>
-   <radius>2500</radius>
+   <radius>2500.000000</radius>
+   <pos x="6500.000000" y="-2000.000000"/>
    <density>0.500000</density>
   </asteroid>
   <asteroid>
-   <pos x="7000" y="500"/>
-   <radius>500</radius>
+   <radius>500.000000</radius>
+   <pos x="7000.000000" y="500.000000"/>
    <density>1.500000</density>
   </asteroid>
   <exclusion>
-   <pos x="2000" y="-700"/>
-   <radius>4700</radius>
+   <radius>4700.000000</radius>
+   <pos x="2000.000000" y="-700.000000"/>
   </exclusion>
  </asteroids>
 </ssys>

--- a/dat/ssys/metsys.xml
+++ b/dat/ssys/metsys.xml
@@ -10,6 +10,7 @@
   <x>605.000000</x>
   <y>352.000000</y>
  </pos>
+ <assets/>
  <jumps>
   <jump target="Adran">
    <autopos/>

--- a/dat/ssys/nougat.xml
+++ b/dat/ssys/nougat.xml
@@ -31,13 +31,13 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="-480" y="10020"/>
-   <radius>800</radius>
-   <density>10.0</density>
+   <radius>800.000000</radius>
+   <pos x="-480.000000" y="10020.000000"/>
+   <density>10.000000</density>
   </asteroid>
   <exclusion>
-   <pos x="-480" y="10020"/>
-   <radius>500</radius>
+   <radius>500.000000</radius>
+   <pos x="-480.000000" y="10020.000000"/>
   </exclusion>
  </asteroids>
 </ssys>

--- a/dat/ssys/nunavut.xml
+++ b/dat/ssys/nunavut.xml
@@ -11,8 +11,8 @@
   <y>-1012.833806</y>
  </pos>
  <assets>
-  <asset>Virtual Pirate Small</asset>
   <asset>Virtual Miner Small</asset>
+  <asset>Virtual Pirate Small</asset>
  </assets>
  <jumps>
   <jump target="Straight Row">
@@ -27,9 +27,9 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="1000" y="3000"/>
-   <radius>2000</radius>
-   <density>1.0</density>
+   <radius>2000.000000</radius>
+   <pos x="1000.000000" y="3000.000000"/>
+   <density>1.000000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/pso.xml
+++ b/dat/ssys/pso.xml
@@ -32,8 +32,8 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <pos x="7500" y="1000"/>
-   <radius>3000</radius>
+   <radius>3000.000000</radius>
+   <pos x="7500.000000" y="1000.000000"/>
    <density>1.000000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/rotide.xml
+++ b/dat/ssys/rotide.xml
@@ -30,9 +30,8 @@
  </jumps>
  <asteroids>
   <asteroid>
-   <type>default</type>
-   <pos x="-6000" y="3000"/>
-   <radius>4000</radius>
+   <radius>4000.000000</radius>
+   <pos x="-6000.000000" y="3000.000000"/>
    <density>0.250000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/sigur.xml
+++ b/dat/ssys/sigur.xml
@@ -11,8 +11,8 @@
   <y>90.000000</y>
  </pos>
  <assets>
-  <asset>Virtual Sindbad</asset>
   <asset>Virtual Empire Unpresence</asset>
+  <asset>Virtual Sindbad</asset>
   <asset>Virtual Soromid Unpresence</asset>
  </assets>
  <jumps>

--- a/dat/ssys/sol.xml
+++ b/dat/ssys/sol.xml
@@ -29,9 +29,9 @@
   <asteroid>
    <type>default</type>
    <type>golden</type>
-   <pos x="0" y="0"/>
-   <radius>20000</radius>
-   <density>0.05</density>
+   <radius>20000.000000</radius>
+   <pos x="0.000000" y="0.000000"/>
+   <density>0.050000</density>
   </asteroid>
  </asteroids>
 </ssys>

--- a/dat/ssys/tobanna.xml
+++ b/dat/ssys/tobanna.xml
@@ -27,8 +27,8 @@
    <type>default</type>
    <type>default</type>
    <type>golden</type>
-   <pos x="1000" y="-3000"/>
-   <radius>2000</radius>
+   <radius>2000.000000</radius>
+   <pos x="1000.000000" y="-3000.000000"/>
    <density>0.500000</density>
   </asteroid>
  </asteroids>

--- a/dat/ssys/toros.xml
+++ b/dat/ssys/toros.xml
@@ -10,8 +10,7 @@
   <x>540.000000</x>
   <y>-45.000000</y>
  </pos>
- <assets>
- </assets>
+ <assets/>
  <jumps>
   <jump target="Doeston">
    <autopos/>

--- a/dat/ssys/vean.xml
+++ b/dat/ssys/vean.xml
@@ -11,11 +11,11 @@
   <y>473.000000</y>
  </pos>
  <assets>
-  <asset>Vean I</asset>
-  <asset>Vean II</asset>
   <asset>HS-24</asset>
   <asset>NS-63</asset>
   <asset>SY-19</asset>
+  <asset>Vean I</asset>
+  <asset>Vean II</asset>
  </assets>
  <jumps>
   <jump target="Aesria">

--- a/dat/ssys/zied.xml
+++ b/dat/ssys/zied.xml
@@ -34,8 +34,8 @@
   <asteroid>
    <type>default</type>
    <type>golden</type>
-   <pos x="3000" y="1500"/>
-   <radius>2000</radius>
+   <radius>2000.000000</radius>
+   <pos x="3000.000000" y="1500.000000"/>
    <density>1.000000</density>
   </asteroid>
  </asteroids>

--- a/src/dev_planet.c
+++ b/src/dev_planet.c
@@ -111,10 +111,14 @@ int dpl_savePlanet( const Planet *p )
          xmlw_elemEmpty( writer, "blackmarket" );
       xmlw_endElem( writer ); /* "services" */
       if (planet_hasService( p, PLANET_SERVICE_LAND )) {
-         xmlw_startElem( writer, "commodities" );
-         for (i=0; i<p->ncommodities; i++)
-            xmlw_elem( writer, "commodity", "%s", p->commodities[i]->name );
-         xmlw_endElem( writer ); /* "commodities" */
+         if (p->faction > 0) {
+            xmlw_startElem( writer, "commodities" );
+            for (i=0; i<p->ncommodities; i++){
+               if (p->commodities[i]->standard == 0)
+                  xmlw_elem( writer, "commodity", "%s", p->commodities[i]->name );
+            }
+            xmlw_endElem( writer ); /* "commodities" */
+         }
 
          xmlw_elem( writer, "description", "%s", p->description );
          if (planet_hasService( p, PLANET_SERVICE_BAR ))


### PR DESCRIPTION
With this PR, the main commodities are standard. Only gold is non-standard and only sellable on Bon Sebb. I did this mainly in order to have a remaining occurence of the commodity tag somewhere.

I used the map editor to change the files, and some systems files have been modified as well (it's just a question of format apparently). By the way, the system editor created a `virtual_simbad.xml`. I did not keep it because I remembered there was mess around this one.