### PR TITLE
made kidnapped mission avaliable later

### DIFF
--- a/dat/event.xml
+++ b/dat/event.xml
@@ -161,6 +161,6 @@
   <lua>neutral/kidnapped</lua>
   <trigger>enter</trigger>
   <chance>15</chance>
-  <cond>player.misnDone("Kidnapped") == false and var.peek("traffic_00_active") == nil and system.cur():name() == "Arcturus"</cond>
+  <cond>player.misnDone("Kidnapped") == false and var.peek("traffic_00_active") == nil and system.cur():name() == "Arcturus" and player.numOutfit("Light Combat Vessel License") &gt; 0</cond>
  </event>
 </Events>


### PR DESCRIPTION
Now that the medusa launchers are medium size, this mission is really hard on a Llama. Maybe it should be proposed to the players only once they have started to get interested enough in the weaponry to buy a combat vessel license ?