### PR TITLE
re-compute economy after each unidiff

### DIFF
--- a/src/unidiff.c
+++ b/src/unidiff.c
@@ -230,7 +230,9 @@ int diff_apply( const char *name )
             xmlFreeDoc(doc);
             free(buf);
 
+            /* Re-compute the economy. */
             economy_execQueued();
+            economy_initialiseCommodityPrices();
 
             return 0;
          }


### PR DESCRIPTION
I could not reproduce the -\infinity problem. The only issue I had was that the commoditie's prices at Sindbad was 0 (and when selling I gained 0 as well). Now, Sindbad's prices are computes the same way as the other ones.