### PR TITLE
Added some colonies for the Proteron

### DIFF
--- a/dat/assets/aera.xml
+++ b/dat/assets/aera.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Aera">
+ <pos>
+  <x>6751.366090</x>
+  <y>-12894.396502</y>
+ </pos>
+ <GFX>
+  <space>I07.png</space>
+  <exterior>methane.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>I</class>
+  <population>100000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>This gas giant is rich enough in valuable minerals that the Proteron decided to establish a mining colony. The minerals are extracted with OOA heat subduction, which coaxes them out of the planet's dangerous core and into the upper atmosphere where they can be safely collected.</description>
+ </general>
+</asset>

--- a/dat/assets/akra_iii.xml
+++ b/dat/assets/akra_iii.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Akra III">
+ <pos>
+  <x>-1987.421180</x>
+  <y>-2782.389652</y>
+ </pos>
+ <GFX>
+  <space>H01.png</space>
+  <exterior>desertic.png</exterior>
+ </GFX>
+ <general>
+  <class>H</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/akra_station.xml
+++ b/dat/assets/akra_station.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Akra Station">
+ <pos>
+  <x>-2449.716430</x>
+  <y>-2403.495366</y>
+ </pos>
+ <GFX>
+  <space>station-commerce2.png</space>
+  <exterior>traderoom.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>0</range>
+ </presence>
+ <general>
+  <class>0</class>
+  <population>200000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <missions/>
+   <outfits/>
+  </services>
+  <commodities/>
+  <description>Built to service ships in the area, Akra Station also serves as an essential communication and trade hub for residents of Akra. People from all over the system congregate here, leading to more inter-planetary personal relationships than normal.</description>
+  <bar>The bar is bustling and seemingly constantly packed, yet never seems to cause anyone any problem due to how efficient everything is.</bar>
+ </general>
+ <tech>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>Star Maps</item>
+  <item>Systems Low</item>
+  <item>Systems High</item>
+  <item>Engines Low</item>
+  <item>Hulls Low</item>
+  <item>Low Tech Upgrades</item>
+  <item>High Tech Upgrades 1</item>
+  <item>Ion 1</item>
+  <item>Kinetic 1</item>
+  <item>Laser 1</item>
+ </tech>
+</asset>

--- a/dat/assets/akra_v.xml
+++ b/dat/assets/akra_v.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Akra V">
+ <pos>
+  <x>-22362.490650</x>
+  <y>652.148409</y>
+ </pos>
+ <GFX>
+  <space>S00.png</space>
+  <exterior>forest.png</exterior>
+ </GFX>
+ <general>
+  <class>S</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/amianta.xml
+++ b/dat/assets/amianta.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Amianta">
+ <pos>
+  <x>14165.896522</x>
+  <y>10080.641875</y>
+ </pos>
+ <GFX>
+  <space>P02.png</space>
+  <exterior>snow.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>700.000000</value>
+  <range>3</range>
+ </presence>
+ <general>
+  <class>C</class>
+  <population>600000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <missions/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>The frigid temperatures of Amianta would drive some people away, but the Proteron colonized it anyway due to the rich source of both food and water found underneath the ice.</description>
+ </general>
+</asset>

--- a/dat/assets/apik_i.xml
+++ b/dat/assets/apik_i.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Apik I">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>10069.600646</x>
+  <y>9605.869037</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>G01.png</space>
+  <exterior>forest2.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>G</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/apik_ii.xml
+++ b/dat/assets/apik_ii.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Apik II">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>-5706.526190</x>
+  <y>7721.039274</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>C00.png</space>
+  <exterior>snow.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>C</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/apik_shipyard.xml
+++ b/dat/assets/apik_shipyard.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Apik Shipyard">
+ <pos>
+  <x>-4955.450149</x>
+  <y>7007.406875</y>
+ </pos>
+ <GFX>
+  <space>station-shipyard.png</space>
+  <exterior>aquatic.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>0</class>
+  <population>3000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <outfits/>
+   <shipyard/>
+  </services>
+  <commodities/>
+  <description>Unlike Sigma Station on Protera, Apik Shipyard is designed to cater to the needs of the general population. It efficiently churns out and services civilian vessels on an as-needed basis.</description>
+ </general>
+ <tech>
+  <item>Basic Civilian Ships</item>
+  <item>Basic Trade Ships</item>
+  <item>Bulk Trade Ships</item>
+  <item>Light Civilian Combat Ships</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>Low Tech Upgrades</item>
+  <item>Star Maps</item>
+  <item>Engines Cargo</item>
+  <item>Hulls High</item>
+  <item>Engines Medium</item>
+  <item>Engines Low</item>
+  <item>Systems Low</item>
+  <item>Hulls Low</item>
+  <item>Laser 1</item>
+  <item>Ion 1</item>
+  <item>Kinetic 1</item>
+  <item>Laser 2</item>
+  <item>Plasma 1</item>
+  <item>Beam 1</item>
+ </tech>
+</asset>

--- a/dat/assets/apik_shipyard.xml
+++ b/dat/assets/apik_shipyard.xml
@@ -30,7 +30,6 @@
   <item>Basic Civilian Ships</item>
   <item>Basic Trade Ships</item>
   <item>Bulk Trade Ships</item>
-  <item>Light Civilian Combat Ships</item>
   <item>Basic Outfits 1</item>
   <item>Basic Outfits 2</item>
   <item>Low Tech Upgrades</item>
@@ -44,7 +43,6 @@
   <item>Laser 1</item>
   <item>Ion 1</item>
   <item>Kinetic 1</item>
-  <item>Laser 2</item>
   <item>Plasma 1</item>
   <item>Beam 1</item>
  </tech>

--- a/dat/assets/ekta_i.xml
+++ b/dat/assets/ekta_i.xml
@@ -5,7 +5,7 @@
   <y>-1905.957803</y>
  </pos>
  <GFX>
-  <space>000.png</space>
+  <space>C01.png</space>
   <exterior>station01.png</exterior>
  </GFX>
  <general>

--- a/dat/assets/ekta_i.xml
+++ b/dat/assets/ekta_i.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Ekta I">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>10276.833832</x>
+  <y>-1905.957803</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>000.png</space>
+  <exterior>station01.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>D</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/ekta_ii.xml
+++ b/dat/assets/ekta_ii.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Ekta II">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>-4443.719337</x>
+  <y>-7948.916924</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>I03.png</space>
+  <exterior>methane.png</exterior>
  </GFX>
  <general>
   <class>I</class>

--- a/dat/assets/ekta_iia.xml
+++ b/dat/assets/ekta_iia.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Ekta IIa">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>-3658.985231</x>
+  <y>-8016.971854</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>moon-D00.png</space>
+  <exterior>asteroid.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>D</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/ekta_iib.xml
+++ b/dat/assets/ekta_iib.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Ekta IIb">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>-3109.066511</x>
+  <y>-8609.192014</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>moon-A00.png</space>
+  <exterior>station01.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>A</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/ekta_station.xml
+++ b/dat/assets/ekta_station.xml
@@ -43,5 +43,6 @@
   <item>Ion 1</item>
   <item>Missiles 1</item>
   <item>High Tech Upgrades 2</item>
+  <item>Engines High</item>
  </tech>
 </asset>

--- a/dat/assets/ekta_station.xml
+++ b/dat/assets/ekta_station.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Ekta Station">
+ <pos>
+  <x>9509.385492</x>
+  <y>-2399.956164</y>
+ </pos>
+ <GFX>
+  <space>station-shipyard2.png</space>
+  <exterior>station05.png</exterior>
+ </GFX>
+ <general>
+  <class>0</class>
+  <population>5000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <outfits/>
+   <shipyard/>
+  </services>
+  <description>With the influx of Proteron civilians into the planet Thavma, it soon became clear that a local shipyard would be useful. For that purpose, Ekta Station was built. While not as extensive as Apik Shipyard in terms of offerings, Ekta Station nonetheless manages to be a good source of ships and ship maintenance for locals.</description>
+  <bar>Civilians, traders, and military personnel alike meet at this bar as they wait for the repairs and modifications of their ships to be finished. It's a small but cozy bar, with people constantly coming and going.</bar>
+ </general>
+ <tech>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>Light Civilian Combat Ships</item>
+  <item>Low Tech Upgrades</item>
+  <item>Beam 1</item>
+  <item>Laser 1</item>
+  <item>Laser 2</item>
+  <item>Systems Low</item>
+  <item>Engines Low</item>
+  <item>Hulls Low</item>
+  <item>Star Maps</item>
+  <item>Ion 1</item>
+  <item>Missiles 1</item>
+  <item>High Tech Upgrades 2</item>
+ </tech>
+</asset>

--- a/dat/assets/ekta_station.xml
+++ b/dat/assets/ekta_station.xml
@@ -8,6 +8,11 @@
   <space>station-shipyard2.png</space>
   <exterior>station05.png</exterior>
  </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>1</range>
+ </presence>
  <general>
   <class>0</class>
   <population>5000</population>
@@ -19,6 +24,7 @@
    <outfits/>
    <shipyard/>
   </services>
+  <commodities/>
   <description>With the influx of Proteron civilians into the planet Thavma, it soon became clear that a local shipyard would be useful. For that purpose, Ekta Station was built. While not as extensive as Apik Shipyard in terms of offerings, Ekta Station nonetheless manages to be a good source of ships and ship maintenance for locals.</description>
   <bar>Civilians, traders, and military personnel alike meet at this bar as they wait for the repairs and modifications of their ships to be finished. It's a small but cozy bar, with people constantly coming and going.</bar>
  </general>

--- a/dat/assets/elpa.xml
+++ b/dat/assets/elpa.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Elpa">
+ <pos>
+  <x>2923.241994</x>
+  <y>-9792.061981</y>
+ </pos>
+ <GFX>
+  <space>H00.png</space>
+  <exterior>aquatic.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>500.000000</value>
+  <range>3</range>
+ </presence>
+ <general>
+  <class>H</class>
+  <population>600000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <missions/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>Elpa was the first post-Incident Proteron colony which was able to sustain human life without significant terraforming, designated for the production of Proteron goods.</description>
+  <bar>The bar hums with activity from traders and workers alike despite the lack of seating arrangements.</bar>
+ </general>
+</asset>

--- a/dat/assets/elpa.xml
+++ b/dat/assets/elpa.xml
@@ -10,7 +10,7 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>500.000000</value>
+  <value>700.000000</value>
   <range>3</range>
  </presence>
  <general>

--- a/dat/assets/hystera_i.xml
+++ b/dat/assets/hystera_i.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Hystera I">
+ <pos>
+  <x>-4845.639732</x>
+  <y>3799.910416</y>
+ </pos>
+ <GFX>
+  <space>I00.png</space>
+  <exterior>forest.png</exterior>
+ </GFX>
+ <general>
+  <class>I</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/hystera_ia.xml
+++ b/dat/assets/hystera_ia.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Hystera Ia">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>-4850.358644</x>
+  <y>3584.272380</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>D05.png</space>
+  <exterior>desertic2.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>D</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/hystera_ii.xml
+++ b/dat/assets/hystera_ii.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Hystera II">
+ <pos>
+  <x>4975.815716</x>
+  <y>6650.709137</y>
+ </pos>
+ <GFX>
+  <space>X00.png</space>
+  <exterior>oceanic2.png</exterior>
+ </GFX>
+ <general>
+  <class>X</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/hystera_outpost.xml
+++ b/dat/assets/hystera_outpost.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <asset name="Hystera Outpost">
  <pos>
-  <x>5530.207822</x>
-  <y>6429.312839</y>
+  <x>5647.850814</x>
+  <y>6361.203738</y>
  </pos>
  <GFX>
-  <space>001.png</space>
+  <space>station-commerce3.png</space>
   <exterior>traderoom.png</exterior>
  </GFX>
  <presence>

--- a/dat/assets/hystera_outpost.xml
+++ b/dat/assets/hystera_outpost.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Hystera Outpost">
+ <pos>
+  <x>5530.207822</x>
+  <y>6429.312839</y>
+ </pos>
+ <GFX>
+  <space>001.png</space>
+  <exterior>traderoom.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>0</class>
+  <population>2000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <missions/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>After the Incident, the surviving Proteron on Protera Sigma sought to establish new colonies to replace the ones they had lost. Hystera was the first nearby system to be discovered, but it was found to contain a gas giant and a hostile planet with nothing of interest. The Proteron therefore instead decided to establish an outpost, this one, orbiting Hystera II, with the goal of finding additional systems in the vicinity. With the discovery of Korifa, the station had fulfilled its purpose and was converted for use as a trade hub.</description>
+  <bar>Proteron civilians enter and exit the bar with incredible efficiency, not wasting a moment of their time.</bar>
+ </general>
+</asset>

--- a/dat/assets/karvua.xml
+++ b/dat/assets/karvua.xml
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>600.000000</value>
-  <range>3</range>
+  <value>200.000000</value>
+  <range>2</range>
  </presence>
  <general>
   <class>Y</class>

--- a/dat/assets/karvua.xml
+++ b/dat/assets/karvua.xml
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>300.000000</value>
-  <range>1</range>
+  <value>600.000000</value>
+  <range>3</range>
  </presence>
  <general>
   <class>Y</class>
@@ -20,6 +20,7 @@
   <services>
    <land/>
    <refuel/>
+   <missions/>
    <commodity/>
   </services>
   <commodities/>

--- a/dat/assets/karvua.xml
+++ b/dat/assets/karvua.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Karvua">
+ <pos>
+  <x>-9433.020360</x>
+  <y>1832.393286</y>
+ </pos>
+ <GFX>
+  <space>moon-Y00.png</space>
+  <exterior>mining4.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>Y</class>
+  <population>60000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>While not exactly hospitable, Karvua is a rich source of minerals that the Proteron were all too happy to exploit, leading them to turn the planet into a big mining colony.</description>
+ </general>
+</asset>

--- a/dat/assets/karvua.xml
+++ b/dat/assets/karvua.xml
@@ -10,7 +10,7 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>200.000000</value>
+  <value>300.000000</value>
   <range>1</range>
  </presence>
  <general>

--- a/dat/assets/korifa_i.xml
+++ b/dat/assets/korifa_i.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Korifa I">
+ <pos>
+  <x>9393.556393</x>
+  <y>-3499.398679</y>
+ </pos>
+ <GFX>
+  <space>A02.png</space>
+  <exterior>desertic2.png</exterior>
+ </GFX>
+ <general>
+  <class>X</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/korifa_ia.xml
+++ b/dat/assets/korifa_ia.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Korifa Ia">
+ <pos>
+  <x>9686.394456</x>
+  <y>-2877.319390</y>
+ </pos>
+ <GFX>
+  <space>moon-J00.png</space>
+  <exterior>lava.png</exterior>
+ </GFX>
+ <general>
+  <class>J</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/korifa_ii.xml
+++ b/dat/assets/korifa_ii.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Korifa II">
+ <pos>
+  <x>-15916.313676</x>
+  <y>-6371.651665</y>
+ </pos>
+ <GFX>
+  <space>K00.png</space>
+  <exterior>methane.png</exterior>
+ </GFX>
+ <general>
+  <class>K</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/korifa_iii.xml
+++ b/dat/assets/korifa_iii.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Korifa III">
+ <pos>
+  <x>6460.346450</x>
+  <y>15786.755639</y>
+ </pos>
+ <GFX>
+  <space>I06.png</space>
+  <exterior>methane.png</exterior>
+ </GFX>
+ <general>
+  <class>I</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/luna_skona.xml
+++ b/dat/assets/luna_skona.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Luna Skona">
+ <pos>
+  <x>-11744.645642</x>
+  <y>9301.199184</y>
+ </pos>
+ <GFX>
+  <space>moon-P03.png</space>
+  <exterior>station00.png</exterior>
+ </GFX>
+ <general>
+  <class>P</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/megala.xml
+++ b/dat/assets/megala.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Megala">
+ <pos>
+  <x>-10147.718927</x>
+  <y>1575.074787</y>
+ </pos>
+ <GFX>
+  <space>S01.png</space>
+  <exterior>methane.png</exterior>
+ </GFX>
+ <general>
+  <class>S</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/mida_proxima.xml
+++ b/dat/assets/mida_proxima.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<asset name="Hystera I">
+<asset name="Mida Proxima">
  <pos>
-  <x>-5799.662480</x>
-  <y>4379.456945</y>
+  <x>3088.306661</x>
+  <y>-6629.209987</y>
  </pos>
  <GFX>
-  <space>I00.png</space>
-  <exterior>forest.png</exterior>
+  <space>J08.png</space>
+  <exterior>lava.png</exterior>
  </GFX>
  <general>
-  <class>I</class>
+  <class>J</class>
   <population>0</population>
   <hide>0.250000</hide>
   <services/>

--- a/dat/assets/nera.xml
+++ b/dat/assets/nera.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Nera">
+ <pos>
+  <x>5670.230758</x>
+  <y>14988.019003</y>
+ </pos>
+ <GFX>
+  <space>moon-O01.png</space>
+  <exterior>aquatic3.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>500.000000</value>
+  <range>3</range>
+ </presence>
+ <general>
+  <class>O</class>
+  <population>600000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <missions/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>Nera was found by the Proteron not long after Elpa, and it turned out to be a perfect complement. Where Elpa is dry and arid, Nera's surface is almost entirely made up of water, to the point where those who live here have to make do with underwater habitations.</description>
+ </general>
+</asset>

--- a/dat/assets/nera.xml
+++ b/dat/assets/nera.xml
@@ -10,7 +10,7 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>500.000000</value>
+  <value>750.000000</value>
   <range>3</range>
  </presence>
  <general>

--- a/dat/assets/petra.xml
+++ b/dat/assets/petra.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Petra">
+ <pos>
+  <x>-1490.060305</x>
+  <y>11785.627859</y>
+ </pos>
+ <GFX>
+  <space>G03.png</space>
+  <exterior>mining.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>600.000000</value>
+  <range>3</range>
+ </presence>
+ <general>
+  <class>G</class>
+  <population>400000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <missions/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>While not the most comfortable planet in Proteron space, Petra is filled with valuable minerals and much easier to mine than the nearby planet Karvua.</description>
+ </general>
+</asset>

--- a/dat/assets/protera_sigma.xml
+++ b/dat/assets/protera_sigma.xml
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>800.000000</value>
-  <range>3</range>
+  <value>1200.000000</value>
+  <range>4</range>
  </presence>
  <general>
   <class>M</class>

--- a/dat/assets/protera_sigma.xml
+++ b/dat/assets/protera_sigma.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <asset name="Protera Sigma">
  <pos>
-  <x>0.000000</x>
-  <y>0.000000</y>
+  <x>1881.178787</x>
+  <y>-2335.239458</y>
  </pos>
  <GFX>
   <space>M05.png</space>
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>300.000000</value>
-  <range>0</range>
+  <value>600.000000</value>
+  <range>2</range>
  </presence>
  <general>
   <class>M</class>
@@ -27,7 +27,7 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>Protera Sigma is the only Proteron colony known to have survived the Incident. One of the earlier Proteron settlements, it has an established shipyard and access to the original blueprints, so Proteron shipbuilding traditions live on.</description>
+  <description>Protera Sigma is the only original Proteron colony known to have survived the Incident. One of the earlier Proteron settlements, it has an established shipyard and access to the original blueprints, so Proteron shipbuilding traditions live on.</description>
   <bar>Rather distinct from traditional Empire bars, the Protera Sigma bar is entirely open and without seats, as the Proteron believe one should stand while eating and drinking. Despite this curiosity, their brews don't stray far from typical Empire faire.</bar>
  </general>
  <tech>
@@ -35,6 +35,14 @@
   <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>Missiles 2</item>
-  <item>Proteron Military Ships</item>
+  <item>Basic Civilian Ships</item>
+  <item>Basic Trade Ships</item>
+  <item>Star Maps</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Engines Low</item>
+  <item>Engines Cargo</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
  </tech>
 </asset>

--- a/dat/assets/protera_sigma.xml
+++ b/dat/assets/protera_sigma.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <asset name="Protera Sigma">
  <pos>
-  <x>1881.178787</x>
-  <y>-2335.239458</y>
+  <x>5541.887113</x>
+  <y>5474.271638</y>
  </pos>
  <GFX>
   <space>M05.png</space>
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>600.000000</value>
-  <range>2</range>
+  <value>800.000000</value>
+  <range>3</range>
  </presence>
  <general>
   <class>M</class>
@@ -24,7 +24,6 @@
    <missions/>
    <commodity/>
    <outfits/>
-   <shipyard/>
   </services>
   <commodities/>
   <description>Protera Sigma is the only original Proteron colony known to have survived the Incident. One of the earlier Proteron settlements, it has an established shipyard and access to the original blueprints, so Proteron shipbuilding traditions live on.</description>
@@ -35,8 +34,6 @@
   <item>Low Tech Upgrades</item>
   <item>High Tech Upgrades 1</item>
   <item>Missiles 2</item>
-  <item>Basic Civilian Ships</item>
-  <item>Basic Trade Ships</item>
   <item>Star Maps</item>
   <item>Systems Low</item>
   <item>Systems Medium</item>

--- a/dat/assets/sigma_station.xml
+++ b/dat/assets/sigma_station.xml
@@ -10,7 +10,7 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>200.000000</value>
+  <value>600.000000</value>
   <range>2</range>
  </presence>
  <general>

--- a/dat/assets/sigma_station.xml
+++ b/dat/assets/sigma_station.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Sigma Station">
+ <pos>
+  <x>2358.040483</x>
+  <y>-2770.284319</y>
+ </pos>
+ <GFX>
+  <space>station-fleetbase.png</space>
+  <exterior>station03.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>2</range>
+ </presence>
+ <general>
+  <class>1</class>
+  <population>10000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land>ptn_mil_restricted</land>
+   <refuel/>
+   <bar/>
+   <missions/>
+   <outfits/>
+   <shipyard/>
+  </services>
+  <commodities/>
+  <description>This station's sole job is to crank out the powerful Proteron military ships. Regular Proteron civilians typically aren't allowed access to this facility.</description>
+  <bar>Even for a Proteron bar, this one is heavily business-oriented. Most patrons seem to be here for a specific purpose.</bar>
+ </general>
+ <tech>
+  <item>Proteron Military Ships</item>
+  <item>Basic Outfits 1</item>
+  <item>Basic Outfits 2</item>
+  <item>Star Maps</item>
+  <item>High Tech Upgrades 1</item>
+  <item>High Tech Upgrades 2</item>
+  <item>Laser 1</item>
+  <item>Laser 2</item>
+  <item>Laser 3</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Systems High</item>
+  <item>Systems Elite</item>
+  <item>Engines Low</item>
+  <item>Engines Medium</item>
+  <item>Engines High</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Hulls High</item>
+  <item>Hulls Elite</item>
+  <item>Low Tech Upgrades</item>
+  <item>Heavy Weapons 1</item>
+  <item>Heavy Weapons 2</item>
+  <item>Missiles 1</item>
+  <item>Missiles 2</item>
+ </tech>
+</asset>

--- a/dat/assets/sigma_station.xml
+++ b/dat/assets/sigma_station.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <asset name="Sigma Station">
  <pos>
-  <x>2358.040483</x>
-  <y>-2770.284319</y>
+  <x>3150.528370</x>
+  <y>-2234.267876</y>
  </pos>
  <GFX>
   <space>station-fleetbase.png</space>
@@ -55,5 +55,11 @@
   <item>Heavy Weapons 2</item>
   <item>Missiles 1</item>
   <item>Missiles 2</item>
+  <item>Ion 1</item>
+  <item>Kinetic 1</item>
+  <item>Plasma 1</item>
+  <item>Beam 1</item>
+  <item>Beam 2</item>
+  <item>Ion 2</item>
  </tech>
 </asset>

--- a/dat/assets/skona.xml
+++ b/dat/assets/skona.xml
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>300.000000</value>
-  <range>1</range>
+  <value>450.000000</value>
+  <range>2</range>
  </presence>
  <general>
   <class>K</class>

--- a/dat/assets/skona.xml
+++ b/dat/assets/skona.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Skona">
+ <pos>
+  <x>-10623.852497</x>
+  <y>8565.472416</y>
+ </pos>
+ <GFX>
+  <space>K05.png</space>
+  <exterior>forest.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>300.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>K</class>
+  <population>400000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <missions/>
+   <commodity/>
+   <outfits/>
+   <shipyard/>
+  </services>
+  <commodities/>
+  <description>Originally possessing very little atmosphere to speak of, the Proteron terraformmed this planet into a respectable, though not altogether that impressive planet. It is mainly engaged in the production of goods.</description>
+  <bar>The bar is decorated with various trinkets and artwork dedicated to Proteron nationalism, with some of its drinks named after famous Proteron leaders.</bar>
+ </general>
+ <tech>
+  <item>Basic Outfits 1</item>
+  <item>High Tech Upgrades 1</item>
+  <item>Heavy Civilian Combat Ships</item>
+  <item>Basic Outfits 2</item>
+  <item>Hulls Low</item>
+  <item>Hulls Medium</item>
+  <item>Engines Low</item>
+  <item>Engines Medium</item>
+  <item>Systems Low</item>
+  <item>Systems Medium</item>
+  <item>Star Maps</item>
+  <item>Plasma 1</item>
+  <item>Plasma 2</item>
+ </tech>
+</asset>

--- a/dat/assets/telika_ii.xml
+++ b/dat/assets/telika_ii.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Telika II">
+ <pos>
+  <x>5886.385030</x>
+  <y>-4991.607216</y>
+ </pos>
+ <GFX>
+  <space>J09.png</space>
+  <exterior>lava.png</exterior>
+ </GFX>
+ <general>
+  <class>J</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/telika_iii.xml
+++ b/dat/assets/telika_iii.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Telika III">
+ <pos>
+  <x>10028.372174</x>
+  <y>8612.168880</y>
+ </pos>
+ <GFX>
+  <space>C01.png</space>
+  <exterior>station01.png</exterior>
+ </GFX>
+ <general>
+  <class>C</class>
+  <population>0</population>
+  <hide>0.250000</hide>
+  <services/>
+ </general>
+</asset>

--- a/dat/assets/telika_station.xml
+++ b/dat/assets/telika_station.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Telika Station">
+ <pos>
+  <x>-6628.943924</x>
+  <y>-5140.913146</y>
+ </pos>
+ <GFX>
+  <space>station-sphere.png</space>
+  <exterior>desertic.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>200.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>0</class>
+  <population>10000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <missions/>
+  </services>
+  <commodities/>
+  <description>The Proteron decided that they should have a center for scientific progress, so they built this station. The greatest Proteron scientific minds come together here to further the technological prowess of the Proteron.</description>
+  <bar>The bar is mostly empty, probably due to the busy schedules of the station's scientists. Other than that, it's essentially the same as other Proteron bars.</bar>
+ </general>
+</asset>

--- a/dat/assets/thavma.xml
+++ b/dat/assets/thavma.xml
@@ -10,12 +10,12 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>500.000000</value>
+  <value>700.000000</value>
   <range>3</range>
  </presence>
  <general>
   <class>M</class>
-  <population>13000000</population>
+  <population>1000000</population>
   <hide>0.250000</hide>
   <services>
    <land/>

--- a/dat/assets/thavma.xml
+++ b/dat/assets/thavma.xml
@@ -10,8 +10,8 @@
  </GFX>
  <presence>
   <faction>Proteron</faction>
-  <value>700.000000</value>
-  <range>3</range>
+  <value>1000.000000</value>
+  <range>4</range>
  </presence>
  <general>
   <class>M</class>
@@ -21,6 +21,7 @@
    <land/>
    <refuel/>
    <bar/>
+   <missions/>
    <commodity/>
   </services>
   <commodities/>

--- a/dat/assets/thavma.xml
+++ b/dat/assets/thavma.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Thavma">
+ <pos>
+  <x>6558.489894</x>
+  <y>9804.611155</y>
+ </pos>
+ <GFX>
+  <space>M10.png</space>
+  <exterior>forest.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>500.000000</value>
+  <range>3</range>
+ </presence>
+ <general>
+  <class>M</class>
+  <population>13000000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>Thavma was an unexpected and welcome discovery for the Proteron, an undiscovered lush planet perfect for agriculture. Not being ones to miss an opportunity, the Proteron immediately set to work turning the planet into a supplier of food and water.</description>
+  <bar>A radio permanently installed in this bar constantly delivers important news interspersed with Proteron propaganda. The locals seem used to it.</bar>
+ </general>
+</asset>

--- a/dat/assets/virtual_sindbad.xml
+++ b/dat/assets/virtual_sindbad.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Virtual Sindbad">
+ <virtual/>
+ <presence>
+  <faction>FLF</faction>
+  <value>100.000000</value>
+  <range>2</range>
+ </presence>
+</asset>

--- a/dat/assets/vracha.xml
+++ b/dat/assets/vracha.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Vracha">
+ <pos>
+  <x>5096.652507</x>
+  <y>-4150.810917</y>
+ </pos>
+ <GFX>
+  <space>moon-D02.png</space>
+  <exterior>rocky_small.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>100.000000</value>
+  <range>1</range>
+ </presence>
+ <general>
+  <class>D</class>
+  <population>5000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <bar/>
+  </services>
+  <commodities/>
+  <description>Vracha was colonized by the Proteron for use as a testing ground for potentially dangerous terraforming techniques and other things that require a planetary surface, but may cause serious harm to said planetary surface.</description>
+  <bar>Every once in a while you hear an explosion, see strange colors, or notice the lights flickering on and off. The bar staff and patrons pay no mind to this phenomenon, suggesting that they experience it on a regular basis.</bar>
+ </general>
+</asset>

--- a/dat/assets/zesta.xml
+++ b/dat/assets/zesta.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asset name="Zesta">
+ <pos>
+  <x>-5564.779304</x>
+  <y>11195.805981</y>
+ </pos>
+ <GFX>
+  <space>A03.png</space>
+  <exterior>station00.png</exterior>
+ </GFX>
+ <presence>
+  <faction>Proteron</faction>
+  <value>500.000000</value>
+  <range>3</range>
+ </presence>
+ <general>
+  <class>A</class>
+  <population>400000</population>
+  <hide>0.250000</hide>
+  <services>
+   <land/>
+   <refuel/>
+   <commodity/>
+  </services>
+  <commodities/>
+  <description>Mineral-rich, but unbearably hot, Zesta has been established as a high-intensity mining colony by the Proteron. Water and ice taken from Amianta is routinely used as part of the extraction process, and to prevent severe burns to the miners.</description>
+ </general>
+</asset>

--- a/dat/landing.lua
+++ b/dat/landing.lua
@@ -132,7 +132,6 @@ function srm_mil_kataka( pnt )
          _("\"We don't need your money, outsider.\""))
 end
 
-
 -- Za'lek's military assets.
 function zlk_mil_restricted( pnt )
    return land_military(pnt, 30,
@@ -142,10 +141,18 @@ function zlk_mil_restricted( pnt )
          _("Money is irrelevant."))
 end
 
-
 -- Za'lek's military center.
 function zlk_ruadan( pnt )
    return false, "Permission denied. Ruadan space is off-limits to you."
+end
+
+-- Proteron military assets.
+function ptn_mil_restricted( pnt )
+   return land_military(pnt, 50,
+         _("Permission to land granted."),
+         _("You are not authorized to land here."),
+         _("Landing request denied."),
+         _("We Proteron don't take kindly to bribery."))
 end
 
 -- Pirate clanworld.

--- a/dat/ships/proteron_kahan.xml
+++ b/dat/ships/proteron_kahan.xml
@@ -22,10 +22,10 @@
   <cargo>40</cargo>
  </characteristics>
  <slots>
-  <weapon size="medium" x="28" y="0" h="5"/>
-  <weapon size="medium" x="18" y="0" h="5"/>
-  <weapon size="medium" x="-30" y="-8" h="3"/>
-  <weapon size="medium" x="-30" y="8" h="3"/>
+  <weapon size="large" x="28" y="0" h="5"/>
+  <weapon size="large" x="18" y="0" h="5"/>
+  <weapon size="large" x="-30" y="-8" h="3"/>
+  <weapon size="large" x="-30" y="8" h="3"/>
   <utility size="medium" prop="systems" exclusive="1" required="1">Unicorp PT-600 Core System</utility>
   <utility size="large"/>
   <utility size="large"/>

--- a/dat/ssys/akra.xml
+++ b/dat/ssys/akra.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1346.571520</x>
-  <y>429.581760</y>
+  <x>1336.571520</x>
+  <y>426.581760</y>
  </pos>
  <assets>
   <asset>Virtual Civilian Standard</asset>

--- a/dat/ssys/akra.xml
+++ b/dat/ssys/akra.xml
@@ -11,6 +11,7 @@
   <y>426.581760</y>
  </pos>
  <assets>
+  <asset>Amianta</asset>
   <asset>Virtual Civilian Standard</asset>
  </assets>
  <jumps>

--- a/dat/ssys/akra.xml
+++ b/dat/ssys/akra.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1434.371520</x>
-  <y>362.581760</y>
+  <x>1357.571520</x>
+  <y>422.581760</y>
  </pos>
  <assets>
   <asset>Virtual Civilian Standard</asset>

--- a/dat/ssys/akra.xml
+++ b/dat/ssys/akra.xml
@@ -11,8 +11,16 @@
   <y>426.581760</y>
  </pos>
  <assets>
+  <asset>Aera</asset>
+  <asset>Akra III</asset>
+  <asset>Akra Station</asset>
+  <asset>Akra V</asset>
   <asset>Amianta</asset>
   <asset>Virtual Civilian Standard</asset>
+  <asset>Virtual Civilian Standard</asset>
+  <asset>Virtual Trader Area</asset>
+  <asset>Virtual Trader Local</asset>
+  <asset>Zesta</asset>
  </assets>
  <jumps>
   <jump target="Mida">

--- a/dat/ssys/akra.xml
+++ b/dat/ssys/akra.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssys name="Akra">
+ <general>
+  <radius>25000.000000</radius>
+  <stars>300</stars>
+  <interference>0.000000</interference>
+  <nebula volatility="0.000000">0.000000</nebula>
+ </general>
+ <pos>
+  <x>1434.371520</x>
+  <y>362.581760</y>
+ </pos>
+ <assets>
+  <asset>Virtual Civilian Standard</asset>
+ </assets>
+ <jumps>
+  <jump target="Mida">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+ </jumps>
+</ssys>

--- a/dat/ssys/akra.xml
+++ b/dat/ssys/akra.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1357.571520</x>
-  <y>422.581760</y>
+  <x>1346.571520</x>
+  <y>429.581760</y>
  </pos>
  <assets>
   <asset>Virtual Civilian Standard</asset>

--- a/dat/ssys/apik.xml
+++ b/dat/ssys/apik.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssys name="Apik">
+ <general>
+  <radius>22000.000000</radius>
+  <stars>400</stars>
+  <interference>0.000000</interference>
+  <nebula volatility="0.000000">0.000000</nebula>
+ </general>
+ <pos>
+  <x>1208.000000</x>
+  <y>516.000000</y>
+ </pos>
+ <assets>
+  <asset>Virtual Civilian Standard</asset>
+  <asset>Virtual Civilian Standard</asset>
+  <asset>Virtual Trader Area</asset>
+  <asset>Virtual Trader Area</asset>
+ </assets>
+ <jumps>
+  <jump target="Mida">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+  <jump target="Protera">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+ </jumps>
+</ssys>

--- a/dat/ssys/apik.xml
+++ b/dat/ssys/apik.xml
@@ -7,10 +7,14 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1208.000000</x>
-  <y>516.000000</y>
+  <x>1196.000000</x>
+  <y>510.000000</y>
  </pos>
  <assets>
+  <asset>Apik I</asset>
+  <asset>Apik II</asset>
+  <asset>Apik Shipyard</asset>
+  <asset>Elpa</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Trader Area</asset>

--- a/dat/ssys/cleai.xml
+++ b/dat/ssys/cleai.xml
@@ -10,7 +10,9 @@
   <x>944.000000</x>
   <y>424.000000</y>
  </pos>
- <assets/>
+ <assets>
+  <asset>Virtual Proteron Unpresence</asset>
+ </assets>
  <jumps>
   <jump target="Haered">
    <autopos/>

--- a/dat/ssys/cleai.xml
+++ b/dat/ssys/cleai.xml
@@ -12,6 +12,7 @@
  </pos>
  <assets>
   <asset>Virtual Proteron Unpresence</asset>
+  <asset>Virtual Proteron Unpresence</asset>
  </assets>
  <jumps>
   <jump target="Haered">

--- a/dat/ssys/ekta.xml
+++ b/dat/ssys/ekta.xml
@@ -1,35 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ssys name="Protera">
+<ssys name="Ekta">
  <general>
-  <radius>17500.000000</radius>
-  <stars>500</stars>
+  <radius>21000.000000</radius>
+  <stars>400</stars>
   <interference>0.000000</interference>
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1103.000000</x>
-  <y>484.000000</y>
+  <x>1264.000000</x>
+  <y>336.000000</y>
  </pos>
  <assets>
-  <asset>Protera Sigma</asset>
-  <asset>Sigma Station</asset>
+  <asset>Karvua</asset>
+  <asset>Megala</asset>
+  <asset>Thavma</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Civilian Standard</asset>
-  <asset>Virtual Trader Local</asset>
-  <asset>Virtual Trader Local</asset>
-  <asset>Virtual Trader Local</asset>
+  <asset>Virtual Trader Area</asset>
+  <asset>Virtual Trader Area</asset>
+  <asset>Virtual Trader Area</asset>
  </assets>
  <jumps>
-  <jump target="Apik">
+  <jump target="Mida">
    <autopos/>
    <hide>1.250000</hide>
   </jump>
-  <jump target="Haered">
-   <autopos/>
-   <hide>1.250000</hide>
-  </jump>
-  <jump target="Hystera">
+  <jump target="Telika">
    <autopos/>
    <hide>1.250000</hide>
   </jump>

--- a/dat/ssys/ekta.xml
+++ b/dat/ssys/ekta.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1268.800000</x>
-  <y>369.600000</y>
+  <x>1249.800000</x>
+  <y>402.600000</y>
  </pos>
  <assets>
   <asset>Ekta I</asset>

--- a/dat/ssys/ekta.xml
+++ b/dat/ssys/ekta.xml
@@ -7,10 +7,14 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1264.000000</x>
-  <y>336.000000</y>
+  <x>1268.800000</x>
+  <y>369.600000</y>
  </pos>
  <assets>
+  <asset>Ekta I</asset>
+  <asset>Ekta II</asset>
+  <asset>Ekta IIa</asset>
+  <asset>Ekta IIb</asset>
   <asset>Karvua</asset>
   <asset>Megala</asset>
   <asset>Thavma</asset>

--- a/dat/ssys/ekta.xml
+++ b/dat/ssys/ekta.xml
@@ -15,6 +15,7 @@
   <asset>Ekta II</asset>
   <asset>Ekta IIa</asset>
   <asset>Ekta IIb</asset>
+  <asset>Ekta Station</asset>
   <asset>Karvua</asset>
   <asset>Megala</asset>
   <asset>Thavma</asset>

--- a/dat/ssys/haered.xml
+++ b/dat/ssys/haered.xml
@@ -12,6 +12,8 @@
  </pos>
  <assets>
   <asset>Virtual Proteron Unpresence</asset>
+  <asset>Virtual Proteron Unpresence</asset>
+  <asset>Virtual Proteron Unpresence</asset>
  </assets>
  <jumps>
   <jump target="Cleai">
@@ -20,7 +22,7 @@
   </jump>
   <jump target="Protera">
    <autopos/>
-   <hide>2.500000</hide>
+   <hide>5.000000</hide>
   </jump>
  </jumps>
 </ssys>

--- a/dat/ssys/haered.xml
+++ b/dat/ssys/haered.xml
@@ -10,7 +10,9 @@
   <x>1018.261333</x>
   <y>466.832000</y>
  </pos>
- <assets/>
+ <assets>
+  <asset>Virtual Proteron Unpresence</asset>
+ </assets>
  <jumps>
   <jump target="Cleai">
    <autopos/>
@@ -18,7 +20,7 @@
   </jump>
   <jump target="Protera">
    <autopos/>
-   <hide>1.250000</hide>
+   <hide>2.500000</hide>
   </jump>
  </jumps>
 </ssys>

--- a/dat/ssys/haered.xml
+++ b/dat/ssys/haered.xml
@@ -22,7 +22,7 @@
   </jump>
   <jump target="Protera">
    <autopos/>
-   <hide>5.000000</hide>
+   <hide>1.250000</hide>
   </jump>
  </jumps>
 </ssys>

--- a/dat/ssys/hystera.xml
+++ b/dat/ssys/hystera.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssys name="Hystera">
+ <general>
+  <radius>20000.000000</radius>
+  <stars>400</stars>
+  <interference>0.000000</interference>
+  <nebula volatility="0.000000">0.000000</nebula>
+ </general>
+ <pos>
+  <x>1047.000000</x>
+  <y>568.000000</y>
+ </pos>
+ <assets>
+  <asset>Hystera I</asset>
+  <asset>Hystera II</asset>
+  <asset>Hystera Outpost</asset>
+  <asset>Virtual Civilian Standard</asset>
+  <asset>Virtual Trader Area</asset>
+  <asset>Virtual Trader Area</asset>
+ </assets>
+ <jumps>
+  <jump target="Korifa">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+  <jump target="Protera">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+ </jumps>
+</ssys>

--- a/dat/ssys/hystera.xml
+++ b/dat/ssys/hystera.xml
@@ -7,12 +7,13 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1047.000000</x>
-  <y>568.000000</y>
+  <x>1067.400000</x>
+  <y>562.000000</y>
  </pos>
  <assets>
   <asset>Hystera I</asset>
   <asset>Hystera II</asset>
+  <asset>Hystera Ia</asset>
   <asset>Hystera Outpost</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Trader Area</asset>

--- a/dat/ssys/korifa.xml
+++ b/dat/ssys/korifa.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1132.000000</x>
-  <y>675.000000</y>
+  <x>1104.400000</x>
+  <y>643.800000</y>
  </pos>
  <assets>
   <asset>Virtual Civilian Standard</asset>

--- a/dat/ssys/korifa.xml
+++ b/dat/ssys/korifa.xml
@@ -11,6 +11,13 @@
   <y>643.800000</y>
  </pos>
  <assets>
+  <asset>Korifa I</asset>
+  <asset>Korifa II</asset>
+  <asset>Korifa III</asset>
+  <asset>Korifa Ia</asset>
+  <asset>Luna Skona</asset>
+  <asset>Nera</asset>
+  <asset>Skona</asset>
   <asset>Virtual Civilian Standard</asset>
  </assets>
  <jumps>

--- a/dat/ssys/korifa.xml
+++ b/dat/ssys/korifa.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssys name="Korifa">
+ <general>
+  <radius>23000.000000</radius>
+  <stars>300</stars>
+  <interference>0.000000</interference>
+  <nebula volatility="0.000000">0.000000</nebula>
+ </general>
+ <pos>
+  <x>1132.000000</x>
+  <y>675.000000</y>
+ </pos>
+ <assets>
+  <asset>Virtual Civilian Standard</asset>
+ </assets>
+ <jumps>
+  <jump target="Hystera">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+ </jumps>
+</ssys>

--- a/dat/ssys/machea.xml
+++ b/dat/ssys/machea.xml
@@ -10,7 +10,9 @@
   <x>935.000000</x>
   <y>368.000000</y>
  </pos>
- <assets/>
+ <assets>
+  <asset>Virtual Proteron Unpresence</asset>
+ </assets>
  <jumps>
   <jump target="Maron">
    <autopos/>

--- a/dat/ssys/maron.xml
+++ b/dat/ssys/maron.xml
@@ -10,7 +10,9 @@
   <x>865.000000</x>
   <y>406.000000</y>
  </pos>
- <assets/>
+ <assets>
+  <asset>Virtual Proteron Unpresence</asset>
+ </assets>
  <jumps>
   <jump target="Cleai">
    <autopos/>

--- a/dat/ssys/mida.xml
+++ b/dat/ssys/mida.xml
@@ -1,35 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ssys name="Protera">
+<ssys name="Mida">
  <general>
-  <radius>17500.000000</radius>
-  <stars>500</stars>
+  <radius>12000.000000</radius>
+  <stars>400</stars>
   <interference>0.000000</interference>
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1103.000000</x>
-  <y>484.000000</y>
+  <x>1272.000000</x>
+  <y>439.000000</y>
  </pos>
  <assets>
-  <asset>Protera Sigma</asset>
-  <asset>Sigma Station</asset>
   <asset>Virtual Civilian Standard</asset>
   <asset>Virtual Civilian Standard</asset>
-  <asset>Virtual Civilian Standard</asset>
-  <asset>Virtual Trader Local</asset>
-  <asset>Virtual Trader Local</asset>
-  <asset>Virtual Trader Local</asset>
  </assets>
  <jumps>
+  <jump target="Akra">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
   <jump target="Apik">
    <autopos/>
    <hide>1.250000</hide>
   </jump>
-  <jump target="Haered">
-   <autopos/>
-   <hide>1.250000</hide>
-  </jump>
-  <jump target="Hystera">
+  <jump target="Ekta">
    <autopos/>
    <hide>1.250000</hide>
   </jump>

--- a/dat/ssys/mida.xml
+++ b/dat/ssys/mida.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1281.600000</x>
-  <y>454.600000</y>
+  <x>1268.600000</x>
+  <y>467.600000</y>
  </pos>
  <assets>
   <asset>Virtual Civilian Standard</asset>

--- a/dat/ssys/mida.xml
+++ b/dat/ssys/mida.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ssys name="Mida">
  <general>
-  <radius>12000.000000</radius>
+  <radius>8000.000000</radius>
   <stars>400</stars>
   <interference>0.000000</interference>
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1272.000000</x>
-  <y>439.000000</y>
+  <x>1281.600000</x>
+  <y>454.600000</y>
  </pos>
  <assets>
   <asset>Virtual Civilian Standard</asset>

--- a/dat/ssys/south_bell.xml
+++ b/dat/ssys/south_bell.xml
@@ -10,7 +10,9 @@
   <x>764.000000</x>
   <y>409.000000</y>
  </pos>
- <assets/>
+ <assets>
+  <asset>Virtual Proteron Unpresence</asset>
+ </assets>
  <jumps>
   <jump target="Aet">
    <autopos/>

--- a/dat/ssys/telika.xml
+++ b/dat/ssys/telika.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssys name="Telika">
+ <general>
+  <radius>16000.000000</radius>
+  <stars>500</stars>
+  <interference>0.000000</interference>
+  <nebula volatility="0.000000">0.000000</nebula>
+ </general>
+ <pos>
+  <x>1165.000000</x>
+  <y>358.738560</y>
+ </pos>
+ <assets/>
+ <jumps>
+  <jump target="Ekta">
+   <autopos/>
+   <hide>1.250000</hide>
+  </jump>
+ </jumps>
+</ssys>

--- a/dat/ssys/telika.xml
+++ b/dat/ssys/telika.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1165.000000</x>
-  <y>358.738560</y>
+  <x>1195.000000</x>
+  <y>325.138560</y>
  </pos>
  <assets/>
  <jumps>

--- a/dat/ssys/telika.xml
+++ b/dat/ssys/telika.xml
@@ -7,8 +7,8 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1195.000000</x>
-  <y>325.138560</y>
+  <x>1177.000000</x>
+  <y>431.138560</y>
  </pos>
  <assets/>
  <jumps>

--- a/dat/ssys/telika.xml
+++ b/dat/ssys/telika.xml
@@ -7,10 +7,16 @@
   <nebula volatility="0.000000">0.000000</nebula>
  </general>
  <pos>
-  <x>1177.000000</x>
-  <y>431.138560</y>
+  <x>1163.000000</x>
+  <y>401.138560</y>
  </pos>
- <assets/>
+ <assets>
+  <asset>Petra</asset>
+  <asset>Telika II</asset>
+  <asset>Telika III</asset>
+  <asset>Telika Station</asset>
+  <asset>Vracha</asset>
+ </assets>
  <jumps>
   <jump target="Ekta">
    <autopos/>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -801,7 +801,6 @@
   <item>Pirate Vendetta</item>
  </tech>
  <tech name="Proteron Military Ships">
-  <item>Proteron Watson</item>
   <item>Proteron Archimedes</item>
   <item>Proteron Derivative</item>
   <item>Proteron Kahan</item>


### PR DESCRIPTION
This adds a series of post-Incident colonies surrounding Protera. Makes the idea of a Proteron invasion seem far less absurd and also will enable pro-Proteron missions better.

Also adjusted the Kahan to have large-sized rather than medium-sized slots, since being all medium-sized made it markedly less powerful than other Destroyers. I might look into making other tweaks to the Proteron ships later but this was the most egregious problem.