### PR TITLE
Fixed the way the game determines if commodities should be added, restored Commodity Run

### DIFF
--- a/dat/assets/sindbad.xml
+++ b/dat/assets/sindbad.xml
@@ -22,7 +22,6 @@
    <refuel/>
    <bar/>
    <missions/>
-   <commodity/>
    <outfits/>
    <shipyard/>
    <blackmarket/>

--- a/dat/events/flf/flf_catastrophe.lua
+++ b/dat/events/flf/flf_catastrophe.lua
@@ -88,8 +88,9 @@ end
 
 function enter_bar ()
    local flf_missions = {
-      "Eliminate a Dvaered Patrol", "Divert the Dvaered Forces",
-      "Eliminate an Empire Patrol", "FLF Pirate Disturbance", "Rogue FLF" }
+      "FLF Commodity Run", "Eliminate a Dvaered Patrol",
+      "Divert the Dvaered Forces", "Eliminate an Empire Patrol",
+      "FLF Pirate Disturbance", "Rogue FLF" }
    if not anyMissionActive( flf_missions ) then
       if bar_hook ~= nil then hook.rm( bar_hook ) end
       if abort_hook ~= nil then hook.rm( abort_hook ) end

--- a/dat/mission.xml
+++ b/dat/mission.xml
@@ -1452,6 +1452,45 @@
    <faction>Za'lek</faction>
   </avail>
  </mission>
+ <mission name="Commodity Run">
+  <lua>neutral/commodity_run</lua>
+  <avail>
+   <priority>5</priority>
+   <cond>var.peek("commodity_runs_active") == nil or var.peek("commodity_runs_active") &lt; 3</cond>
+   <chance>90</chance>
+   <location>Computer</location>
+   <faction>Dvaered</faction>
+   <faction>Empire</faction>
+   <faction>Frontier</faction>
+   <faction>Goddard</faction>
+   <faction>Independent</faction>
+   <faction>Sirius</faction>
+   <faction>Soromid</faction>
+   <faction>Thurion</faction>
+   <faction>Trader</faction>
+   <faction>Za'lek</faction>
+  </avail>
+ </mission>
+ <mission name="FLF Commodity Run">
+  <lua>flf/flf_commodity_run</lua>
+  <avail>
+   <priority>5</priority>
+   <cond>var.peek("commodity_runs_active") == nil or var.peek("commodity_runs_active") &lt; 3</cond>
+   <chance>90</chance>
+   <location>Computer</location>
+   <faction>FLF</faction>
+  </avail>
+ </mission>
+ <mission name="Pirate Commodity Run">
+  <lua>pirate/pirate_commodity_run</lua>
+  <avail>
+   <priority>5</priority>
+   <cond>var.peek("commodity_runs_active") == nil or var.peek("commodity_runs_active") &lt; 3</cond>
+   <chance>90</chance>
+   <location>Computer</location>
+   <faction>Pirate</faction>
+  </avail>
+ </mission>
  <mission name="Trader Escort">
   <lua>neutral/trader_escort</lua>
   <avail>

--- a/dat/missions/flf/flf_commodity_run.lua
+++ b/dat/missions/flf/flf_commodity_run.lua
@@ -30,5 +30,5 @@ cargo_land_p2[3] = _("%s%s are unloaded from your vessel by a team of FLF soldie
 osd_title = _("FLF Supply Run")
 
 
-commchoices = { "Food", "Ore", "Industrial Goods", "Medicine" }
+commchoices = { "Food", "Ore", "Industrial Goods", "Medicine", "Water" }
 

--- a/dat/missions/flf/flf_commodity_run.lua
+++ b/dat/missions/flf/flf_commodity_run.lua
@@ -1,0 +1,34 @@
+--[[
+
+   FLF Commodity Delivery Mission
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--]]
+
+require "dat/missions/neutral/commodity_run.lua"
+
+misn_title = _("FLF: %s Supply Run")
+misn_desc = _("There is a need for more %s at this base. Find a planet where you can buy this commodity and bring as much of it back as possible.")
+
+cargo_land_p2 = {}
+cargo_land_p2[1] = _("%s%s are carried out of your ship and tallied. After making sure nothing was missed from your cargo hold, you are paid %s credits, thanked for assisting the FLF's operations, and dismissed.")
+cargo_land_p2[2] = _("%s%s are quickly and efficiently unloaded and transported to the storage facility. The FLF officer in charge thanks you with a credit chip worth %s credits.")
+cargo_land_p2[3] = _("%s%s are unloaded from your vessel by a team of FLF soldiers who are in no rush to finish, eventually delivering %s credits after the number of tonnes is determined.")
+
+osd_title = _("FLF Supply Run")
+
+
+commchoices = { "Food", "Ore", "Industrial Goods", "Medicine" }
+

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -1,0 +1,135 @@
+--[[
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License version 3 as
+   published by the Free Software Foundation.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+--
+
+   Commodity delivery missions.
+--]]
+
+require "dat/scripts/numstring.lua"
+
+--Mission Details
+misn_title = _("%s Delivery")
+misn_reward = _("%s credits per ton")
+misn_desc = _("There is an insufficient supply of %s on this planet to satisfy the current demand. Go to any planet which sells this commodity and bring as much of it back as possible.")
+
+cargo_land_title = _("Delivery success!")
+
+cargo_land_p1 = {}
+cargo_land_p1[1] = _("The crates of ")
+cargo_land_p1[2] = _("The drums of ")
+cargo_land_p1[3] = _("The containers of ")
+
+cargo_land_p2 = {}
+cargo_land_p2[1] = _("%s%s are carried out of your ship and tallied. After several different men double-check the register to confirm the amount, you are paid %s credits and summarily dismissed.")
+cargo_land_p2[2] = _("%s%s are quickly and efficiently unloaded, labeled, and readied for distribution. The delivery manager thanks you with a credit chip worth %s credits.")
+cargo_land_p2[3] = _("%s%s are unloaded from your vessel by a team of dockworkers who are in no rush to finish, eventually delivering %s credits after the number of tonnes is determined.")
+cargo_land_p2[4] = _("%s%s are unloaded by robotic drones that scan and tally the contents. The human overseerer hands you %s credits when they finish.")
+
+osd_title = _("Commodity Delivery")
+osd_msg    = {}
+osd_msg[1] = _("Buy as much %s as possible")
+osd_msg[2] = _("Take the %s to %s in the %s system")
+osd_msg["__save"] = true
+
+
+-- TODO: find a better way to index all available commodities
+commchoices = { "Food", "Ore", "Industrial Goods", "Medicine", "Luxury Goods" }
+
+
+function update_active_runs( change )
+   local current_runs = var.peek( "commodity_runs_active" )
+   if current_runs == nil then current_runs = 0 end
+   var.push( "commodity_runs_active", math.max( 0, current_runs + change ) )
+
+   -- Note: This causes a delay (defined in create()) after accepting,
+   -- completing, or aborting a commodity run mission.  This is
+   -- intentional.
+   var.push( "last_commodity_run", time.tonumber( time.get() ) )
+end
+
+
+function create ()
+   -- Note: this mission does not make any system claims.
+ 
+   misplanet = planet.cur()
+   missys = system.cur()
+   
+   chosen_comm = commchoices[ rnd.rnd( 1, #commchoices ) ]
+   local mult = rnd.rnd( 1, 3 ) + math.abs( rnd.threesigma() * 2 )
+   price = commodity.price( chosen_comm ) * mult
+
+   local last_run = var.peek( "last_commodity_run" )
+   if last_run ~= nil then
+      local delay = time.create( 0, 7, 0 )
+      if time.get() < time.fromnumber( last_run ) + delay then
+         misn.finish(false)
+      end
+   end
+
+   for i, j in ipairs( missys:planets() ) do
+      for k, v in pairs( j:commoditiesSold() ) do
+         if v:name() == chosen_comm then
+            misn.finish(false)
+         end
+      end
+   end
+
+   -- Set Mission Details
+   misn.setTitle( misn_title:format( chosen_comm ) )
+   misn.markerAdd( system.cur(), "computer" )
+   misn.setDesc( misn_desc:format( chosen_comm ) )
+   misn.setReward( misn_reward:format( numstring( price ) ) )
+    
+end
+
+
+function accept ()
+   misn.accept()
+   update_active_runs( 1 )
+
+   osd_msg[1] = osd_msg[1]:format( chosen_comm )
+   osd_msg[2] = osd_msg[2]:format( chosen_comm, misplanet:name(), missys:name() )
+   misn.osdCreate( osd_title, osd_msg )
+
+   hook.enter( "enter" )
+   hook.land( "land" )
+end
+
+
+function enter ()
+   if pilot.cargoHas( player.pilot(), chosen_comm ) > 0 then
+      misn.osdActive( 2 )
+   else
+      misn.osdActive( 1 )
+   end
+end
+
+
+function land ()
+   local amount = pilot.cargoHas( player.pilot(), chosen_comm )
+   local reward = amount * price
+
+   if planet.cur() == misplanet and amount > 0 then
+      local txt = string.format(  cargo_land_p2[ rnd.rnd( 1, #cargo_land_p2 ) ], cargo_land_p1[ rnd.rnd( 1, #cargo_land_p1 ) ], chosen_comm, numstring( reward ) )
+      tk.msg( cargo_land_title, txt )
+      pilot.cargoRm( player.pilot(), chosen_comm, amount )
+      player.pay( reward )
+      update_active_runs( -1 )
+      misn.finish( true )
+   end
+end
+
+
+function abort ()
+   update_active_runs( -1 )
+end
+

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -42,7 +42,9 @@ osd_msg["__save"] = true
 
 
 -- TODO: find a better way to index all available commodities
-commchoices = { "Food", "Ore", "Industrial Goods", "Medicine", "Luxury Goods" }
+commchoices = {
+   "Food", "Ore", "Industrial Goods", "Medicine", "Luxury Goods", "Gold",
+   "Diamond", "Water" }
 
 
 function update_active_runs( change )

--- a/dat/missions/pirate/pirate_commodity_run.lua
+++ b/dat/missions/pirate/pirate_commodity_run.lua
@@ -1,0 +1,31 @@
+--[[
+
+   Pirate Commodity Delivery Mission
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--]]
+
+require "dat/missions/neutral/commodity_run.lua"
+
+misn_title = _("Exploit the Demand for %s")
+misn_desc = _("Pirates have been demanding a lot of %s lately, and that's driving the price up. If you find some of it and bring it back, you can make some good money off of them.")
+
+cargo_land_p2 = {}
+cargo_land_p2[1] = _("%s%s are bought by the boatload, eventually earning you %s credits.")
+cargo_land_p2[2] = _("%s%s are quickly sold out, earning you %s credits.")
+cargo_land_p2[3] = _("%s%s are eventually all sold to the pirates, though it takes some time. Your total earnings in the end amount to %s credits.")
+
+osd_title = _("Pirate Sales")
+

--- a/src/space.c
+++ b/src/space.c
@@ -1934,11 +1934,15 @@ static int planet_parse( Planet *planet, const xmlNodePtr parent, Commodity **st
    xmlNodePtr node, cur, ccur;
    unsigned int flags;
    Commodity *com;
+   Commodity **comms;
+   int ncomms;
 
    /* Clear up memory for sane defaults. */
    flags          = 0;
    planet->real   = ASSET_REAL;
    planet->hide   = 0.01;
+   comms          = NULL;
+   ncomms         = 0;
 
    /* Get the name. */
    xmlr_attr( parent, "name", planet->name );
@@ -2052,50 +2056,30 @@ static int planet_parse( Planet *planet, const xmlNodePtr parent, Commodity **st
 
             else if (xml_isNode(cur, "commodities")) {
                ccur = cur->children;
-
-               /* First, store all the standard commodities and prices. */
-               planet->ncommodities = stdNb;
-               mem = stdNb;
-               if (stdNb > 0) {
-                  planet->commodityPrice = malloc( stdNb * sizeof(CommodityPrice) );
-                  planet->commodities    = malloc( stdNb * sizeof(Commodity*) );
-                  for (i=0; i<stdNb; i++) {
-                     planet->commodities[i]          = stdList[i];
-                     planet->commodityPrice[i].price = planet->commodities[i]->price;
-                  }
-               }
+               mem = 0;
 
                do {
                   if (xml_isNode(ccur,"commodity")) {
-
                      /* If the commodity is standard, don't re-add it. */
                      com = commodity_get( xml_get(ccur) );
                      if (com->standard == 1)
                         continue;
 
-                     planet->ncommodities++;
-                     /* Memory must grow. */
-                     if (planet->ncommodities > mem) {
+                     ncomms++;
+                     if (ncomms > mem) {
                         if (mem == 0)
                            mem = CHUNK_SIZE_SMALL;
                         else
                            mem *= 2;
-                        planet->commodities = realloc(planet->commodities,
-                              mem * sizeof(Commodity*));
-                        planet->commodityPrice = realloc(planet->commodityPrice,
-                              mem * sizeof(CommodityPrice));
+
+                        if (comms == NULL)
+                           comms = malloc( mem * sizeof(Commodity*) );
+                        else
+                           comms = realloc( comms, mem * sizeof(Commodity*) );
                      }
-                     planet->commodities[planet->ncommodities-1] = com;
-                     /* Set commodity price on this planet to the base price */
-                     planet->commodityPrice[planet->ncommodities-1].price =
-                       planet->commodities[planet->ncommodities-1]->price;
+                     comms[ncomms-1] = com;
                   }
                } while (xml_nextNode(ccur));
-               /* Shrink to minimum size. */
-               planet->commodities = realloc(planet->commodities,
-                     planet->ncommodities * sizeof(Commodity*));
-               planet->commodityPrice = realloc(planet->commodityPrice,
-                     planet->ncommodities * sizeof(CommodityPrice));
             }
 
             else if (xml_isNode(cur, "blackmarket")) {
@@ -2142,6 +2126,51 @@ static int planet_parse( Planet *planet, const xmlNodePtr parent, Commodity **st
             "presence" );
    }
 #undef MELEMENT
+
+   /* Build commodities list */
+   if (planet_hasService(planet, PLANET_SERVICE_COMMODITY)) {
+      /* First, store all the standard commodities and prices. */
+      planet->ncommodities = stdNb;
+      mem = stdNb;
+      if (stdNb > 0) {
+         planet->commodityPrice = malloc( stdNb * sizeof(CommodityPrice) );
+         planet->commodities    = malloc( stdNb * sizeof(Commodity*) );
+         for (i=0; i<stdNb; i++) {
+            planet->commodities[i]          = stdList[i];
+            planet->commodityPrice[i].price = planet->commodities[i]->price;
+         }
+      }
+
+      /* Now add extra commodities */
+      for (i=0; i<ncomms; i++) {
+         com = comms[i];
+
+         planet->ncommodities++;
+         /* Memory must grow. */
+         if (planet->ncommodities > mem) {
+            if (mem == 0)
+               mem = CHUNK_SIZE_SMALL;
+            else
+               mem *= 2;
+            planet->commodities = realloc(planet->commodities,
+                  mem * sizeof(Commodity*));
+            planet->commodityPrice = realloc(planet->commodityPrice,
+                  mem * sizeof(CommodityPrice));
+         }
+         planet->commodities[planet->ncommodities-1] = com;
+         /* Set commodity price on this planet to the base price */
+         planet->commodityPrice[planet->ncommodities-1].price
+            = planet->commodities[planet->ncommodities-1]->price;
+      }
+      /* Shrink to minimum size. */
+      planet->commodities = realloc(planet->commodities,
+            planet->ncommodities * sizeof(Commodity*));
+      planet->commodityPrice = realloc(planet->commodityPrice,
+            planet->ncommodities * sizeof(CommodityPrice));
+   }
+   /* Free temporary comms list. */
+   if (comms != NULL)
+      free(comms);
 
    /* Square to allow for linear multiplication with squared distances. */
    planet->hide = pow2(planet->hide);


### PR DESCRIPTION
The previous way it was doing things, commodities were added to planets if (and only if) they had a commodities list, whether it had entries or not, regardless of whether the commodity service was available. There are a lot of problems with that, so I changed it so that commodities get added to any asset with the commodities service, instead.

Also restored the Commodity Run mission for use where commodities are not available at all.