### PR TITLE
Tweaked the commodity modifiers a bit.

### DIFF
--- a/dat/commodity.xml
+++ b/dat/commodity.xml
@@ -15,7 +15,7 @@
   <planet_modifier type="Q">0.8</planet_modifier>
   <planet_modifier type="R">0.8</planet_modifier>
   <period>80</period>
-  <population_modifier>1.0</population_modifier>
+  <population_modifier>0.75</population_modifier>
   <faction_modifier type="Empire">0.8</faction_modifier>
   <faction_modifier type="FLF">1.2</faction_modifier>
   <faction_modifier type="Frontier">1.2</faction_modifier>
@@ -44,7 +44,7 @@
   <planet_modifier type="Y">1.25</planet_modifier>
   <planet_modifier type="Z">1.25</planet_modifier>
   <period>110</period>
-  <population_modifier>0.75</population_modifier>
+  <population_modifier>0.7</population_modifier>
   <faction_modifier type="FLF">1.2</faction_modifier>
   <faction_modifier type="Frontier">1.2</faction_modifier>
  </commodity>

--- a/dat/commodity.xml
+++ b/dat/commodity.xml
@@ -56,7 +56,7 @@
   <standard/>
   <planet_modifier type="2">1.2</planet_modifier>
   <period>70</period>
-  <population_modifier>1.0</population_modifier>
+  <population_modifier>0.75</population_modifier>
   <faction_modifier type="Dvaered">1.2</faction_modifier>
   <faction_modifier type="FLF">1.3</faction_modifier>
   <faction_modifier type="Frontier">1.3</faction_modifier>

--- a/src/economy.c
+++ b/src/economy.c
@@ -667,10 +667,13 @@ static int economy_calcPrice( Planet *planet, Commodity *commodity, CommodityPri
    }
    commodityPrice->price *= scale;
 
-   /*Range seems to go from 0-5, with median being 2.  Increased range will increase safety
-     and so lower prices and improve stability*/
+   /* Range seems to go from 0-5, with median being 2.  Increased range
+    * will increase safety and so lower prices and improve stability */
    commodityPrice->price *= (1 - planet->presenceRange/30.);
    commodityPrice->planetPeriod *= 1 / (1 - planet->presenceRange/30.);
+
+   /* Make sure the price is always positive and non-zero */
+   commodityPrice->price = MAX( commodityPrice->price, 1 );
 
    return 0;
 }


### PR DESCRIPTION
I noticed that the population modifier I gave for food led to incredibly small values for stations with low population, so I changed it from 1 to 0.75. This still leads to very low prices with low populations, but in the realm of dozens rather than easily going as low as 1 or 2.

Also added a thing to make sure the price will never go below 1.