### PR TITLE
corrected problem at landing and jumping for the trader escort mission

### DIFF
--- a/dat/missions/neutral/trader_escort.lua
+++ b/dat/missions/neutral/trader_escort.lua
@@ -372,7 +372,6 @@ function timer_traderSafe()
 
    if unsafe then
       unsafe = false
-   else
       for i, j in ipairs( convoy ) do
          continueToDest( j )
       end


### PR DESCRIPTION
The function `timer_traderSafe` was causing the ai goal to be reinitialized any 2 seconds, and was causing the ai to have problems when landing or jumping.