### PR TITLE
system_getPresence return positive or zero value

### DIFF
--- a/src/space.c
+++ b/src/space.c
@@ -4279,7 +4279,7 @@ double system_getPresence( StarSystem *sys, int faction )
    /* Go through the array, looking for the faction. */
    for (i = 0; i < sys->npresence; i++) {
       if (sys->presence[i].faction == faction)
-         return sys->presence[i].value;
+         return MAX(sys->presence[i].value, 0);
    }
 
    /* If it's not in there, it's zero. */


### PR DESCRIPTION
The function used to return negative values when there was a virtual unpresence. I'm not sure, but I think it's not the desired behaviour. I saw it because it was breaking the guerilla spawning of pirates in Alteris form Delta Pavonis because of the Dvaered unpresence there.

If this commit breaks something else, I guess I'll put the max in `pilot_choosePoint`.