### PR TITLE
remove the ugly mass hack in bomber ai

### DIFF
--- a/dat/ai/include/atk_generic.lua
+++ b/dat/ai/include/atk_generic.lua
@@ -172,10 +172,10 @@ function _atk_g_ranged( target, dist )
       else -- In range
          local dir  = ai.face(target)
          if dir < 30 then
-            mem.totmass = p:stats().mass
+            ai.set_shoot_indicator(false)
             ai.weapset( 4 )
-            -- If he managed to shoot, the mass decreased
-            if p:stats().mass < mem.totmass - 0.01 and not ai.timeup(1) then
+            -- If he managed to shoot, reinitialize the timer
+            if ai.shoot_indicator() and not ai.timeup(1) then
                ai.settimer(1, 13000)
             end
          end

--- a/src/ai.c
+++ b/src/ai.c
@@ -243,6 +243,8 @@ static int aiL_refuel( lua_State *L ); /* boolean, boolean refuel() */
 static int aiL_messages( lua_State *L );
 static int aiL_setasterotarget( lua_State *L ); /* setasterotarget( number, number ) */
 static int aiL_gatherablePos( lua_State *L ); /* gatherablepos( number ) */
+static int aiL_shoot_indicator( lua_State *L ); /* get shoot indicator */
+static int aiL_set_shoot_indicator( lua_State *L ); /* set shoot indicator */
 
 
 static const luaL_Reg aiL_methods[] = {
@@ -328,6 +330,8 @@ static const luaL_Reg aiL_methods[] = {
    { "messages", aiL_messages },
    { "setasterotarget", aiL_setasterotarget },
    { "gatherablepos", aiL_gatherablePos },
+   { "shoot_indicator", aiL_shoot_indicator },
+   { "set_shoot_indicator", aiL_set_shoot_indicator },
    {0,0} /* end */
 }; /**< Lua AI Function table. */
 
@@ -3160,6 +3164,32 @@ static int aiL_timeup( lua_State *L )
    n = luaL_checkint(L,1);
 
    lua_pushboolean(L, cur_pilot->timer[n] < 0.);
+   return 1;
+}
+
+
+/**
+ * @brief Set the seeker shoot indicator.
+ *
+ *    @luatparam boolean value to set the shoot indicator to.
+ *    @luafunc set_shoot_indicator()
+ */
+static int aiL_set_shoot_indicator( lua_State *L )
+{
+   cur_pilot->shoot_indicator = lua_toboolean(L,1);
+   return 0;
+}
+
+
+/**
+ * @brief Access the seeker shoot indicator (that is put to true each time a seeker is shot).
+ *
+ *    @luatreturn boolean true if the shoot_indicator is true.
+ *    @luafunc set_shoot_indicator()
+ */
+static int aiL_shoot_indicator( lua_State *L )
+{
+   lua_pushboolean(L, cur_pilot->shoot_indicator);
    return 1;
 }
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -2604,6 +2604,7 @@ void pilot_init( Pilot* pilot, Ship* ship, const char* name, int faction, const 
    /* AI */
    if (ai != NULL)
       ai_pinit( pilot, ai ); /* Must run before ai_create */
+   pilot->shoot_indicator = 0;
 }
 
 
@@ -2723,20 +2724,21 @@ Pilot* pilot_copy( Pilot* src )
    dest->afterburner = NULL;
 
    /* Hooks get cleared. */
-   dest->hooks          = NULL;
-   dest->nhooks         = 0;
+   dest->hooks           = NULL;
+   dest->nhooks          = 0;
 
    /* Copy has no escorts. */
-   dest->escorts        = NULL;
-   dest->nescorts       = 0;
+   dest->escorts         = NULL;
+   dest->nescorts        = 0;
 
    /* AI is not copied. */
-   dest->task           = NULL;
+   dest->task            = NULL;
+   dest->shoot_indicator = 0;
 
    /* Set pointers and friends to NULL. */
    /* Commodities. */
-   dest->commodities    = NULL;
-   dest->ncommodities   = 0;
+   dest->commodities     = NULL;
+   dest->ncommodities    = 0;
    /* Calculate stats. */
    pilot_calcStats(dest);
 

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -407,6 +407,7 @@ typedef struct Pilot_ {
    double tcontrol;  /**< timer for control tick */
    double timer[MAX_AI_TIMERS]; /**< timers for AI */
    Task* task;       /**< current action */
+   unsigned int shoot_indicator; /**< Indicator to inform the AI if a seeker has been shot recently. */
 
    /* Misc */
    double comm_msgTimer; /**< Message timer for the comm. */

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -1132,6 +1132,10 @@ static int pilot_shootWeapon( Pilot* p, PilotOutfitSlot* w, double time )
 
       pilot_updateMass( p );
 
+      /* Make the AI aware a seeker has been shot */
+      if (outfit_isSeeker(w->outfit))
+         p->shoot_indicator = 1;
+
       /* If last ammo was shot, update the range */
       if (w->u.ammo.quantity <= 0) {
          for (j=0; j<PILOT_WEAPON_SETS; j++)


### PR DESCRIPTION
At some point of the bomber AI, we had to know if a shot had been performed (to prevent a bomber from dancing forever in front of an enemy who is dodging). This was done by controlling the mass of the ship before and after the attempt to shoot, which is an ugly hack that could make problems some day (for example if one implements 0-mass missiles).
I created an indicator stored in the pilot's memory to see if a shot was performed.