### PR TITLE
Make it impossible to target unknown or out of range objects

### DIFF
--- a/src/pilot_ew.c
+++ b/src/pilot_ew.c
@@ -231,6 +231,42 @@ int pilot_inRangePlanet( const Pilot *p, int target )
    return 0;
 }
 
+
+/**
+ * @brief Check to see if an asteroid is in sensor range of the pilot.
+ *
+ *    @param p Pilot who is trying to check to see if the asteroid is in sensor range.
+ *    @param ast Asteroid to see if is in sensor range.
+ *    @param fie Field the Asteroid belongs to to see if is in sensor range.
+ *    @return 1 if they are in range, 0 if they aren't.
+ */
+int pilot_inRangeAsteroid( const Pilot *p, int ast, int fie )
+{
+   double d;
+   Asteroid *as;
+   AsteroidAnchor *f;
+   double sense;
+
+   /* pilot must exist */
+   if ( p == NULL )
+      return 0;
+
+   /* Get the asteroid. */
+   f = &cur_system->asteroids[fie];
+   as = &f->asteroids[ast];
+
+   sense = sensor_curRange * p->ew_detect;
+
+   /* Get distance. */
+   d = vect_dist2( &p->solid->pos, &as->pos );
+
+   if (d < sense ) /* By default, asteroid's hide score is 1. It could be made changeable via xml.*/
+      return 1;
+
+   return 0;
+}
+
+
 /**
  * @brief Check to see if a jump point is in sensor range of the pilot.
  *

--- a/src/pilot_ew.h
+++ b/src/pilot_ew.h
@@ -19,6 +19,7 @@ double pilot_sensorRange( void );
 int pilot_inRange( const Pilot *p, double x, double y );
 int pilot_inRangePilot( const Pilot *p, const Pilot *target );
 int pilot_inRangePlanet( const Pilot *p, int target );
+int pilot_inRangeAsteroid( const Pilot *p, int ast, int fie );
 int pilot_inRangeJump( const Pilot *p, int target );
 
 /*

--- a/src/space.c
+++ b/src/space.c
@@ -559,6 +559,8 @@ double system_getClosest( const StarSystem *sys, int *pnt, int *jp, int *ast, in
       p  = sys->planets[i];
       if (p->real != ASSET_REAL)
          continue;
+      if (!planet_isKnown(p))
+         continue;
       td = pow2(x-p->pos.x) + pow2(y-p->pos.y);
       if (td < d) {
          *pnt  = i;
@@ -576,6 +578,10 @@ double system_getClosest( const StarSystem *sys, int *pnt, int *jp, int *ast, in
          if (as->appearing == ASTEROID_INVISIBLE)
             continue;
 
+         /* Skip out of range asteroids */
+         if (!pilot_inRangeAsteroid( player.p, k, i ))
+            continue;
+
          td = pow2(x-as->pos.x) + pow2(y-as->pos.y);
          if (td < d) {
             *pnt  = -1; /* We must clear planet target as asteroid is closer. */
@@ -589,6 +595,8 @@ double system_getClosest( const StarSystem *sys, int *pnt, int *jp, int *ast, in
    /* Jump points. */
    for (i=0; i<sys->njumps; i++) {
       j  = &sys->jumps[i];
+      if (!jp_isKnown(j))
+         continue;
       td = pow2(x-j->pos.x) + pow2(y-j->pos.y);
       if (td < d) {
          *pnt  = -1; /* We must clear planet target as jump point is closer. */


### PR DESCRIPTION
Because otherwise, when clicking randomly in an unseeable asteroid field far away, one gets the confusing message "Asteroid targeted". Same thing for unknown JP and planets
By the way, I added a proper function to check if an asteroid is in range and I updated a bit the way targeted asteroids are displayed in radar.