### PR TITLE
No consideration about known or unknown JP with argument show_hidden …

### DIFF
--- a/dat/gui/brushed.lua
+++ b/dat/gui/brushed.lua
@@ -379,7 +379,7 @@ function update_nav()
          navstring = _("Unknown")
       end
       if autonav_hyp then
-         navstring = (navstring .. " (%s)"):format( autonav_hyp:jumpDist() )
+         navstring = (navstring .. " (%s)"):format( system.cur():jumpDist(autonav_hyp, true, true) )
       end
    else
       navstring = _("none")
@@ -477,7 +477,7 @@ function renderBar( name, value, light, locked, prefix, mod_x, mod_y, heat, stre
       if name == "fuel" then
          show_light = player.jumps() <= 0
          if autonav_hyp ~= nil then
-            show_light = show_light or player.jumps() < autonav_hyp:jumpDist()
+            show_light = show_light or player.jumps() < system.cur():jumpDist(autonav_hyp, true, true)
          end
       else
          show_light = value < 20
@@ -875,7 +875,7 @@ function render( dt )
       if not autonav_hyp:known() then
          name = "Unknown"
       end
-      renderField( name .. " (" .. tostring(autonav_hyp:jumpDist()) .. ")", fields_x + fields_w + 12, fields_y, fields_w, col_text, icon_nav_target )
+      renderField( name .. " (" .. tostring(system.cur():jumpDist(autonav_hyp, true, true)) .. ")", fields_x + fields_w + 12, fields_y, fields_w, col_text, icon_nav_target )
    else
       renderField( _("None"), fields_x + fields_w + 12, fields_y, fields_w, col_unkn, icon_nav_target )
    end

--- a/dat/missions/flf/flf_diversion.lua
+++ b/dat/missions/flf/flf_diversion.lua
@@ -54,7 +54,7 @@ function create ()
    if num_empire == nil then num_empire = 0 end
    if num_flf == nil then num_flf = 0 end
    dv_attention_target = num_dvaereds / 50
-   credits = 200 * (num_dvaereds + num_empire - num_flf) * system.cur():jumpDist( missys ) / 3
+   credits = 200 * (num_dvaereds + num_empire - num_flf) * system.cur():jumpDist( missys, true ) / 3
    credits = credits + rnd.sigma() * 10000
    reputation = math.max( (num_dvaereds + num_empire - num_flf) / 25, 1 )
    if credits < 10000 then misn.finish( false ) end

--- a/dat/missions/flf/flf_patrol.lua
+++ b/dat/missions/flf/flf_patrol.lua
@@ -101,7 +101,7 @@ function create ()
    credits = ships * 30000 - flfships * 1000
    if has_vigilence then credits = credits + 120000 end
    if has_goddard then credits = credits + 270000 end
-   credits = credits * system.cur():jumpDist( missys ) / 3
+   credits = credits * system.cur():jumpDist( missys, true ) / 3
    credits = credits + rnd.sigma() * 8000
 
    local desc

--- a/dat/missions/flf/flf_rogue.lua
+++ b/dat/missions/flf/flf_rogue.lua
@@ -70,7 +70,7 @@ function create ()
    end
 
    credits = ships * 30000 - flfships * 1000
-   credits = credits * system.cur():jumpDist( missys ) / 3
+   credits = credits * system.cur():jumpDist( missys, true ) / 3
    credits = credits + rnd.sigma() * 8000
 
    local desc

--- a/dat/missions/neutral/patrol.lua
+++ b/dat/missions/neutral/patrol.lua
@@ -119,7 +119,7 @@ function create ()
       misn.finish( false )
    end
 
-   jumps_permitted = missys:jumpDist() + 3
+   jumps_permitted = system.cur():jumpDist(missys) + 3
    hostiles = {}
    hostiles["__save"] = true
    hostiles_encountered = false

--- a/dat/missions/neutral/pirbounty_dead.lua
+++ b/dat/missions/neutral/pirbounty_dead.lua
@@ -114,7 +114,7 @@ function create ()
    missys = systems[ rnd.rnd( 1, #systems ) ]
    if not misn.claim( missys ) then misn.finish( false ) end
 
-   jumps_permitted = missys:jumpDist() + rnd.rnd( 5 )
+   jumps_permitted = system.cur():jumpDist(missys) + rnd.rnd( 5 )
    if rnd.rnd() < 0.05 then
       jumps_permitted = jumps_permitted - 1
    end

--- a/dat/missions/neutral/sightseeing.lua
+++ b/dat/missions/neutral/sightseeing.lua
@@ -120,7 +120,7 @@ function create ()
       misn.finish( false )
    end
 
-   credits = missys:jumpDist() * 2500 + attractions * 4000
+   credits = system.cur():jumpDist(missys) * 2500 + attractions * 4000
    credits_nolux = credits + rnd.sigma() * ( credits / 3 )
    credits = credits * rnd.rnd( 2, 6 )
    credits = credits + rnd.sigma() * ( credits / 5 )

--- a/dat/missions/neutral/wastedump.lua
+++ b/dat/missions/neutral/wastedump.lua
@@ -56,8 +56,8 @@ function create ()
    local p, sys
    for i, j in ipairs( dest_planets ) do
       p, sys = planet.get( j )
-      if dist == nil or sys:jumpDist() < dist then
-         dist = sys:jumpDist()
+      if dist == nil or system.cur():jumpDist(sys) < dist then
+         dist = system.cur():jumpDist(sys)
       end
    end
 

--- a/dat/missions/pirate/empbounty_dead.lua
+++ b/dat/missions/pirate/empbounty_dead.lua
@@ -115,7 +115,7 @@ function create ()
       misn.finish( false )
    end
 
-   jumps_permitted = missys:jumpDist() + rnd.rnd( 3, 10 )
+   jumps_permitted = system.cur():jumpDist(missys) + rnd.rnd( 3, 10 )
    if rnd.rnd() < 0.05 then
       jumps_permitted = jumps_permitted - 1
    end

--- a/dat/missions/proteron/dissbounty_dead.lua
+++ b/dat/missions/proteron/dissbounty_dead.lua
@@ -95,7 +95,7 @@ function create ()
    missys = systems[ rnd.rnd( 1, #systems ) ]
    if not misn.claim( missys ) then misn.finish( false ) end
 
-   jumps_permitted = missys:jumpDist() + rnd.rnd( 5 )
+   jumps_permitted = system.cur():jumpDist(missys) + rnd.rnd( 5 )
    if rnd.rnd() < 0.05 then
       jumps_permitted = jumps_permitted - 1
    end

--- a/dat/missions/shadow/shadowvigil.lua
+++ b/dat/missions/shadow/shadowvigil.lua
@@ -311,8 +311,9 @@ function jumpin()
                 hook.timer(35000, "chatter", {pilot = escorts[1], text = commmsg[5]})
                 chattered = true
             end
-            if misssys[4]:jumpDist() <= 2 and misssys[4]:jumpDist() > 0 then -- Encounter
-                ambush = pilot.add(string.format("Shadowvigil Ambush %i", 3 - misssys[4]:jumpDist()), "baddie_norun", vec2.new(0, 0))
+            jp2go = system.cur():jumpDist(misssys[4])
+            if jp2go <= 2 and jp2go > 0 then -- Encounter
+                ambush = pilot.add(string.format("Shadowvigil Ambush %i", 3 - jp2go), "baddie_norun", vec2.new(0, 0))
                 kills = 0
                 for i, j in ipairs(ambush) do
                     if j:exists() then

--- a/dat/missions/soromid/comingout/srm_comingout.lua
+++ b/dat/missions/soromid/comingout/srm_comingout.lua
@@ -84,7 +84,7 @@ osd_desc[1] = _("Go to the %s system and land on the planet %s.")
 function create ()
    misplanet, missys = planet.get( "Durea" )
    -- Note: This mission does not make system claims
-   if missys:jumpDist( system.cur(), true ) < #chatter * 3 / 2 then
+   if system.cur():jumpDist( missys, true ) < #chatter * 3 / 2 then
       misn.finish( false )
    end
 

--- a/dat/missions/soromid/comingout/srm_comingout5.lua
+++ b/dat/missions/soromid/comingout/srm_comingout5.lua
@@ -46,7 +46,7 @@ npc_desc = _("Chelsea seems like they're stressed. Maybe you should see how they
 
 function create ()
    misplanet, missys = planet.get( "The Stinker" )
-   if misplanet == nil or missys == nil or missys:jumpDist() > 4 then
+   if misplanet == nil or missys == nil or system.cur():jumpDist(missys) > 4 then
       misn.finish( false )
    end
 

--- a/src/map.c
+++ b/src/map.c
@@ -2247,8 +2247,8 @@ StarSystem** map_getJumpPath( int* njumps, const char* sysstart,
          if (jp_isFlag( jp, JP_EXITONLY ))
             continue;
 
-         /* Skip hidden jumps if they're unknown and not specifically requested */
-         if (!show_hidden && jp_isFlag( jp, JP_HIDDEN ) && !jp_isKnown(jp))
+         /* Skip hidden jumps if they're not specifically requested */
+         if (!show_hidden && jp_isFlag( jp, JP_HIDDEN ))
             continue;
 
          /* Check to see if it's already in the closed set. */

--- a/src/map.c
+++ b/src/map.c
@@ -2163,7 +2163,8 @@ void map_setZoom(double zoom)
  *    @param[out] njumps Number of jumps in the path.
  *    @param sysstart Name of the system to start from.
  *    @param sysend Name of the system to end at.
- *    @param ignore_known Whether or not to ignore if systems are known.
+ *    @param ignore_known Whether or not to ignore if systems and jump points are known.
+ *    @param show_hidden Whether or not to use hidden jumps points.
  *    @param the old star system (if we're merely extending the list)
  *    @return NULL on failure, the list of njumps elements systems in the path.
  */

--- a/src/nlua_system.c
+++ b/src/nlua_system.c
@@ -372,16 +372,16 @@ static int systemL_nebula( lua_State *L )
  * @brief Gets jump distance from current system, or to another.
  *
  * Does different things depending on the parameter type:
- *    - nil : Gets distance from current system.
- *    - string : Gets distance from system matching name.
- *    - system : Gets distance from system
+ *    - nil : Gets distance to current system.
+ *    - string : Gets distance to system matching name.
+ *    - system : Gets distance to system
  *
- * @usage d = sys:jumpDist() -- Distance from current system.
- * @usage d = sys:jumpDist( "Draygar" ) -- Distance from system Draygar.
- * @usage d = sys:jumpDist( another_sys ) -- Distance from system another_sys.
+ * @usage d = sys:jumpDist() -- Distance from sys to current system.
+ * @usage d = sys:jumpDist( "Draygar" ) -- Distance from sys to system Draygar.
+ * @usage d = sys:jumpDist( another_sys ) -- Distance from sys to another_sys.
  *
- *    @luatparam System s System to get distance from.
- *    @luatparam nil|string|System param See description.
+ *    @luatparam System s Starting system.
+ *    @luatparam nil|string|Goal system param See description.
  *    @luatparam[opt=false] boolean hidden Whether or not to consider hidden jumps.
  *    @luatparam[opt=false] boolean known Whether or not to consider only jumps known by the player.
  *    @luatreturn number Number of jumps to system.
@@ -424,16 +424,16 @@ static int systemL_jumpdistance( lua_State *L )
  * @brief Gets jump path from current system, or to another.
  *
  * Does different things depending on the parameter type:
- *    - nil : Gets path from current system.
- *    - string : Gets path from system matching name.
- *    - system : Gets path from system
+ *    - nil : Gets path to current system.
+ *    - string : Gets path to system matching name.
+ *    - system : Gets path to system
  *
- * @usage jumps = sys:jumpPath() -- Path to current system.
- * @usage jumps = sys:jumpPath( "Draygar" ) -- Path from current sys to Draygar.
+ * @usage jumps = sys:jumpPath() -- Path from sys to current system.
+ * @usage jumps = sys:jumpPath( "Draygar" ) -- Path from sys to Draygar.
  * @usage jumps = system.jumpPath( "Draygar", another_sys ) -- Path from Draygar to another_sys.
  *
- *    @luatparam System s System to get path from.
- *    @luatparam nil|string|System param See description.
+ *    @luatparam System s Starting system.
+ *    @luatparam nil|string|Goal system param See description.
  *    @luatparam[opt=false] boolean hidden Whether or not to consider hidden jumps.
  *    @luatreturn {Jump,...} Table of jumps.
  * @luafunc jumpPath( s, param, hidden )


### PR DESCRIPTION
…in map_getJumpPath

Yes, that sounds very technical. Basically, it reverts a commit by @Deiz : https://github.com/naev/naev/commit/2a81121bfcfaa1de463237a338c2742d9aeb1dc1 (but I couldn't find out why that was done)

The problem that is solved with this PR is that standard cargo and escort mission don't assume anymore that you will use the hidden jumps that you know. (and I checked that it does not make the pathfinder to ignore hidden jumps while traveling). Of course, with this commit, the number of jumps displayed for cargo missions can be overestimated, but actually, the people that give the missions are not supposed to know the hidden jumps, so...

(to have the problem I described, buy a pirate hidden JP map and go to Eridani, and look at escort and cargo mission there)

So 3 possibilities :
* This change was a mistake back then
* This change was relevant back then and no longer now
* What I did breaks other things, but I didn't see what.