### PR TITLE
Fixed attempts to translate empty strings.

### DIFF
--- a/dat/missions/dvaered/assault_on_unicorn.lua
+++ b/dat/missions/dvaered/assault_on_unicorn.lua
@@ -18,7 +18,7 @@ text[2] = _("As you land, you see a Dvaered military official approaching. Thank
 
 osd_msg = {}
 osd_msg[1] = _("Fly to the Unicorn system.")
-osd_msg[2] = _("")
+osd_msg[2] = ""
 osd_msg2 = _("Destroy some pirates! You have killed %d and have earned %s credits. If finished, return to %s.")
 osd_msg3 = _("You have reached your maximum payment. Return to %s.")
 

--- a/dat/missions/empire/collective/ec03.lua
+++ b/dat/missions/empire/collective/ec03.lua
@@ -36,7 +36,7 @@ text[4] = _([[Your ship touches ground and you once again see the face of Lt. Co
 
 osd_msg = {}
 osd_msg[1] = _("Fly to the %s system")
-osd_msg[2] = _("")
+osd_msg[2] = ""
 osd_msg[3] = _("Return to %s")
 osd_msg["__save"] = true
 osd_msg2 = _("Destroy at least %d drones (%d remaining)")


### PR DESCRIPTION
Empty strings are not valid translation identifiers in gettext and not needed. In both cases it was just placeholder strings until the real strings were placed on top.

🕷️