### PR TITLE
Added outlines to text and improved the tk look.

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -534,7 +534,7 @@ void background_getTextures(unsigned int *n, glTexture ***imgs)
   background_image_t *bkg;
   *n = array_size( bkg_image_arr_bk );
   *imgs = malloc( sizeof(glTexture**)*(*n) );
-  for ( i=0; i<*n; i++ ){
+  for ( i=0; i<*n; i++ ) {
     bkg = &bkg_image_arr_bk[i];
     if ( bkg->image != NULL )
       (*imgs)[i] = gl_dupTexture(bkg->image);

--- a/src/board.c
+++ b/src/board.c
@@ -149,14 +149,14 @@ void player_board (void)
    wdw = window_create( "Boarding", -1, -1, BOARDING_WIDTH, BOARDING_HEIGHT );
 
    window_addText( wdw, 20, -30, 120, 60,
-         0, "txtCargo", &gl_smallFont, &cBlack,
+         0, "txtCargo", &gl_smallFont, NULL,
          _("Credits:\n"
          "Cargo:\n"
          "Fuel:\n"
          "Ammo:\n")
          );
    window_addText( wdw, 80, -30, 120, 60,
-         0, "txtData", &gl_smallFont, &cBlack, NULL );
+         0, "txtData", &gl_smallFont, NULL, NULL );
 
    window_addButton( wdw, 20, 20, BUTTON_WIDTH, BUTTON_HEIGHT,
          "btnStealCredits", _("Credits"), board_stealCreds);

--- a/src/colour.c
+++ b/src/colour.c
@@ -95,14 +95,14 @@ const glColour cFuel          =  { .r = 0.9, .g = 0.1, .b = 0.4, .a = 1.  }; /**
 
 /* Deiz's Super Font Palette */
 
-const glColour cFontRed       =  { .r = 1.0, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Red font colour. */
-const glColour cFontGreen     =  { .r = 0.4, .g = 0.8, .b = 0.2, .a = 1.  }; /**< Green font colour. */
-const glColour cFontBlue      =  { .r = 0.2, .g = 0.4, .b = 0.8, .a = 1.  }; /**< Blue font colour. */
-const glColour cFontOrange    =  { .r = 1.0, .g = 0.6, .b = 0.0, .a = 1.  }; /**< Orange font colour. */
-const glColour cFontYellow    =  { .r = 0.9, .g = 1.0, .b = 0.3, .a = 1.  }; /**< Yellow font colour. */
+const glColour cFontRed       =  { .r = 1.0, .g = 0.4, .b = 0.4, .a = 1.  }; /**< Red font colour. */
+const glColour cFontGreen     =  { .r = 0.6, .g = 1.0, .b = 0.4, .a = 1.  }; /**< Green font colour. */
+const glColour cFontBlue      =  { .r = 0.4, .g = 0.6, .b = 1.0, .a = 1.  }; /**< Blue font colour. */
+const glColour cFontOrange    =  { .r = 1.0, .g = 0.7, .b = 0.2, .a = 1.  }; /**< Orange font colour. */
+const glColour cFontYellow    =  { .r = 1.0, .g = 1.0, .b = 0.5, .a = 1.  }; /**< Yellow font colour. */
 const glColour cFontWhite     =  { .r = 0.95, .g = 0.95, .b = 0.95, .a = 1.  }; /**< White font colour. */
 const glColour cFontGrey      =  { .r = 0.7, .g = 0.7, .b = 0.7, .a = 1.  }; /**< Grey font colour. */
-const glColour cFontPurple    =  { .r = 0.9, .g = 0.3, .b = 0.9, .a = 1.  }; /**< Purple font colour. */
+const glColour cFontPurple    =  { .r = 1.0, .g = 0.3, .b = 1.0, .a = 1.  }; /**< Purple font colour. */
 
 
 /**

--- a/src/colour.c
+++ b/src/colour.c
@@ -101,7 +101,7 @@ const glColour cFontBlue      =  { .r = 0.2, .g = 0.4, .b = 0.8, .a = 1.  }; /**
 const glColour cFontOrange    =  { .r = 1.0, .g = 0.6, .b = 0.0, .a = 1.  }; /**< Orange font colour. */
 const glColour cFontYellow    =  { .r = 0.9, .g = 1.0, .b = 0.3, .a = 1.  }; /**< Yellow font colour. */
 const glColour cFontWhite     =  { .r = 0.95, .g = 0.95, .b = 0.95, .a = 1.  }; /**< White font colour. */
-const glColour cFontGrey      =  { .r = 0.6, .g = 0.6, .b = 0.6, .a = 1.  }; /**< Grey font colour. */
+const glColour cFontGrey      =  { .r = 0.7, .g = 0.7, .b = 0.7, .a = 1.  }; /**< Grey font colour. */
 const glColour cFontPurple    =  { .r = 0.9, .g = 0.3, .b = 0.9, .a = 1.  }; /**< Purple font colour. */
 
 

--- a/src/colour.c
+++ b/src/colour.c
@@ -55,7 +55,7 @@ const glColour cDarkBlue   = { .r=0.10, .g=0.10, .b=0.60, .a=1. }; /**< Dark Blu
 const glColour cBlue       = { .r=0.20, .g=0.20, .b=0.80, .a=1. }; /**< Blue */
 const glColour cLightBlue  = { .r=0.40, .g=0.40, .b=1.00, .a=1. }; /**< Light Blue */
 const glColour cPrimeBlue  = { .r=0.00, .g=0.00, .b=1.00, .a=1. }; /**< Primary Blue */
-const glColour cCyan       = { .r=0.00, .g=1.00, .b=1.00, .a=1. }; /* Cyan. */
+const glColour cCyan       = { .r=0.00, .g=1.00, .b=1.00, .a=1. }; /**< Cyan. */
 /* Purples. */
 const glColour cPurple     = { .r=0.90, .g=0.10, .b=0.90, .a=1. }; /**< Purple */
 const glColour cDarkPurple = { .r=0.68, .g=0.18, .b=0.64, .a=1. }; /**< Dark Purple */
@@ -70,8 +70,6 @@ const glColour cAqua       = { .r=0.00, .g=0.75, .b=1.00, .a=1. }; /**< Aqua */
  * game specific
  */
 const glColour cBlackHilight  =  { .r = 0.0, .g = 0.0, .b = 0.0, .a = 0.4 }; /**< Hilight colour over black background. */
-const glColour cConsole       =  { .r = 0.1, .g = 0.9, .b = 0.1, .a = 1.  }; /**< Console colour */
-const glColour cDConsole      =  { .r = 0.0, .g = 0.4, .b = 0.0, .a = 1.  }; /**< Dark Console colour */
 /* toolkit */
 const glColour cHilight       =  { .r = 0.1, .g = 0.9, .b = 0.1, .a = 0.3 }; /**< Hilight colour */
 /* objects */
@@ -100,12 +98,11 @@ const glColour cFuel          =  { .r = 0.9, .g = 0.1, .b = 0.4, .a = 1.  }; /**
 const glColour cFontRed       =  { .r = 0.8, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Red font colour. */
 const glColour cFontGreen     =  { .r = 0.4, .g = 0.8, .b = 0.2, .a = 1.  }; /**< Green font colour. */
 const glColour cFontBlue      =  { .r = 0.2, .g = 0.4, .b = 0.8, .a = 1.  }; /**< Blue font colour. */
-const glColour cFontYellow    =  { .r = 0.9, .g = 0.8, .b = 0.0, .a = 1.  }; /**< Yellow font colour. */
+const glColour cFontOrange    =  { .r = 1.0, .g = 0.6, .b = 0.0, .a = 1.  }; /**< Orange font colour. */
+const glColour cFontYellow    =  { .r = 0.9, .g = 1.0, .b = 0.3, .a = 1.  }; /**< Yellow font colour. */
 const glColour cFontWhite     =  { .r = 0.8, .g = 0.8, .b = 0.8, .a = 1.  }; /**< White font colour. */
+const glColour cFontGrey      =  { .r = 0.4, .g = 0.4, .b = 0.4, .a = 1.  }; /**< Grey font colour. */
 const glColour cFontPurple    =  { .r = 0.7, .g = 0.3, .b = 0.7, .a = 1.  }; /**< Purple font colour. */
-const glColour cFontFriendly  =  { .r = 0.3, .g = 0.9, .b = 0.3, .a = 1.  }; /**< Friendly font colour. */
-const glColour cFontHostile   =  { .r = 0.9, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Hostile font colour. */
-const glColour cFontNeutral   =  { .r = 1.0, .g = 0.9, .b = 0.0, .a = 1.  }; /**< Neutral font colour. */
 
 
 /**

--- a/src/colour.c
+++ b/src/colour.c
@@ -100,8 +100,8 @@ const glColour cFontGreen     =  { .r = 0.4, .g = 0.8, .b = 0.2, .a = 1.  }; /**
 const glColour cFontBlue      =  { .r = 0.2, .g = 0.4, .b = 0.8, .a = 1.  }; /**< Blue font colour. */
 const glColour cFontOrange    =  { .r = 1.0, .g = 0.6, .b = 0.0, .a = 1.  }; /**< Orange font colour. */
 const glColour cFontYellow    =  { .r = 0.9, .g = 1.0, .b = 0.3, .a = 1.  }; /**< Yellow font colour. */
-const glColour cFontWhite     =  { .r = 0.8, .g = 0.8, .b = 0.8, .a = 1.  }; /**< White font colour. */
-const glColour cFontGrey      =  { .r = 0.4, .g = 0.4, .b = 0.4, .a = 1.  }; /**< Grey font colour. */
+const glColour cFontWhite     =  { .r = 0.9, .g = 0.9, .b = 0.9, .a = 1.  }; /**< White font colour. */
+const glColour cFontGrey      =  { .r = 0.6, .g = 0.6, .b = 0.6, .a = 1.  }; /**< Grey font colour. */
 const glColour cFontPurple    =  { .r = 0.7, .g = 0.3, .b = 0.7, .a = 1.  }; /**< Purple font colour. */
 
 

--- a/src/colour.c
+++ b/src/colour.c
@@ -71,7 +71,7 @@ const glColour cAqua       = { .r=0.00, .g=0.75, .b=1.00, .a=1. }; /**< Aqua */
  */
 const glColour cBlackHilight  =  { .r = 0.0, .g = 0.0, .b = 0.0, .a = 0.4 }; /**< Hilight colour over black background. */
 /* toolkit */
-const glColour cHilight       =  { .r = 0.1, .g = 0.9, .b = 0.1, .a = 0.3 }; /**< Hilight colour */
+const glColour cHilight       =  { .r = 0.1, .g = 0.9, .b = 0.1, .a = 0.6 }; /**< Hilight colour */
 /* objects */
 const glColour cInert         =  { .r = 0.6, .g = 0.6, .b = 0.6, .a = 1.  }; /**< Inert object colour */
 const glColour cMapInert      =  { .r = 0.4, .g = 0.4, .b = 0.4, .a = 1. }; /**< Inert object map screen text colour */
@@ -95,14 +95,14 @@ const glColour cFuel          =  { .r = 0.9, .g = 0.1, .b = 0.4, .a = 1.  }; /**
 
 /* Deiz's Super Font Palette */
 
-const glColour cFontRed       =  { .r = 0.8, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Red font colour. */
+const glColour cFontRed       =  { .r = 1.0, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Red font colour. */
 const glColour cFontGreen     =  { .r = 0.4, .g = 0.8, .b = 0.2, .a = 1.  }; /**< Green font colour. */
 const glColour cFontBlue      =  { .r = 0.2, .g = 0.4, .b = 0.8, .a = 1.  }; /**< Blue font colour. */
 const glColour cFontOrange    =  { .r = 1.0, .g = 0.6, .b = 0.0, .a = 1.  }; /**< Orange font colour. */
 const glColour cFontYellow    =  { .r = 0.9, .g = 1.0, .b = 0.3, .a = 1.  }; /**< Yellow font colour. */
-const glColour cFontWhite     =  { .r = 0.9, .g = 0.9, .b = 0.9, .a = 1.  }; /**< White font colour. */
+const glColour cFontWhite     =  { .r = 0.95, .g = 0.95, .b = 0.95, .a = 1.  }; /**< White font colour. */
 const glColour cFontGrey      =  { .r = 0.6, .g = 0.6, .b = 0.6, .a = 1.  }; /**< Grey font colour. */
-const glColour cFontPurple    =  { .r = 0.7, .g = 0.3, .b = 0.7, .a = 1.  }; /**< Purple font colour. */
+const glColour cFontPurple    =  { .r = 0.9, .g = 0.3, .b = 0.9, .a = 1.  }; /**< Purple font colour. */
 
 
 /**

--- a/src/colour.h
+++ b/src/colour.h
@@ -51,6 +51,7 @@ extern const glColour cDarkBlue;
 extern const glColour cBlue;
 extern const glColour cLightBlue;
 extern const glColour cPrimeBlue;
+extern const glColour cCyan;
 extern const glColour cPurple;
 extern const glColour cDarkPurple;
 extern const glColour cBrown;
@@ -65,8 +66,6 @@ extern const glColour cAqua;
  * game specific
  */
 extern const glColour cBlackHilight;
-extern const glColour cConsole;
-extern const glColour cDConsole;
 /* toolkit */
 extern const glColour cHilight;
 /* objects */
@@ -93,12 +92,11 @@ extern const glColour cFuel;
 extern const glColour cFontRed;
 extern const glColour cFontGreen;
 extern const glColour cFontBlue;
+extern const glColour cFontOrange;
 extern const glColour cFontYellow;
 extern const glColour cFontWhite;
+extern const glColour cFontGrey;
 extern const glColour cFontPurple;
-extern const glColour cFontFriendly;
-extern const glColour cFontHostile;
-extern const glColour cFontNeutral;
 
 const glColour* col_fromName( const char* name );
 

--- a/src/console.c
+++ b/src/console.c
@@ -248,7 +248,7 @@ static void cli_render( double bx, double by, double w, double h, void *data )
    for (i=start; i<array_size(cli_buffer); i++)
       gl_printMaxRaw( cli_font, w, bx,
             by + h - (i+1-start)*(cli_font->h+5),
-            &cBlack, cli_buffer[i] );
+            &cFontWhite, cli_buffer[i] );
 }
 
 

--- a/src/console.c
+++ b/src/console.c
@@ -266,7 +266,7 @@ static int cli_keyhandler( unsigned int wid, SDL_Keycode key, SDL_Keymod mod )
       /* Go up in history. */
       case SDLK_UP:
          for (i=cli_history; i>=0; i--) {
-            if (strncmp(cli_buffer[i], "\aD>", 3) == 0) {
+            if (strncmp(cli_buffer[i], "\aC>", 3) == 0) {
                /* Strip escape codes from beginning and end */
                str = nstrndup(cli_buffer[i]+5, strlen(cli_buffer[i])-7);
                if (i == cli_history &&
@@ -292,7 +292,7 @@ static int cli_keyhandler( unsigned int wid, SDL_Keycode key, SDL_Keymod mod )
 
          /* Find next buffer. */
          for (i=cli_history+1; i<array_size(cli_buffer); i++) {
-            if (strncmp(cli_buffer[i], "\aD>", 3) == 0) {
+            if (strncmp(cli_buffer[i], "\aC>", 3) == 0) {
                str = nstrndup(cli_buffer[i]+5, strlen(cli_buffer[i])-7);
                window_setInput( wid, "inpInput", str );
                free(str);
@@ -485,7 +485,7 @@ static void cli_input( unsigned int wid, char *unused )
       return;
 
    /* Put the message in the console. */
-   nsnprintf( buf, CLI_MAX_INPUT+7, "\aD%s %s\a0",
+   nsnprintf( buf, CLI_MAX_INPUT+7, "\aC%s %s\a0",
          cli_firstline ? "> " : ">>", str );
    cli_addMessage( buf );
 

--- a/src/dev_mapedit.c
+++ b/src/dev_mapedit.c
@@ -193,67 +193,67 @@ void mapedit_open( unsigned int wid_unused, char *unused )
 
    /* Main title. */
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290, 20, 0, "txtSLastLoaded",
-         NULL, &cBlack, "Last loaded Map" );
+         NULL, NULL, "Last loaded Map" );
    textPos++;
    linesPos++;
 
    /* Filename. */
    curLines = 1;
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, gl_smallFont.h+5, 0, "txtSFileName",
-         &gl_smallFont, &cBlack, "File Name:" );
+         &gl_smallFont, NULL, "File Name:" );
    window_addText( wid, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtFileName",
-         &gl_smallFont, &cBlack, "N/A" );
+         &gl_smallFont, NULL, "N/A" );
    textPos++;
    linesPos+=curLines+1;
 
    /* Map name. */
    curLines = 3;
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, gl_smallFont.h+5, 0, "txtSMapName",
-         &gl_smallFont, &cBlack, "Map Name:" );
+         &gl_smallFont, NULL, "Map Name:" );
    window_addText( wid, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtMapName",
-         &gl_smallFont, &cBlack, "N/A" );
+         &gl_smallFont, NULL, "N/A" );
    textPos++;
    linesPos+=curLines+1;
 
    /* Map description. */
    curLines = 5;
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, gl_smallFont.h+5, 0, "txtSDescription",
-         &gl_smallFont, &cBlack, "Description:" );
+         &gl_smallFont, NULL, "Description:" );
    window_addText( wid, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtDescription",
-         &gl_smallFont, &cBlack, "N/A" );
+         &gl_smallFont, NULL, "N/A" );
    textPos++;
    linesPos+=(curLines+1);
 
    /* Loaded Map # of systems. */
    curLines = 1;
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, 20, 0, "txtSLoadedNumSystems",
-         &gl_smallFont, &cBlack, "Number of Systems (limited to 100):" );
+         &gl_smallFont, NULL, "Number of Systems (limited to 100):" );
    window_addText( wid, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtLoadedNumSystems",
-         &gl_smallFont, &cBlack, "N/A" );
+         &gl_smallFont, NULL, "N/A" );
    textPos++;
    linesPos+=curLines+1;
 
    /* Main title */
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290, 20, 0, "txtSCurentMap",
-         NULL, &cBlack, "Current Map" );
+         NULL, NULL, "Current Map" );
    textPos++;
    linesPos++;
 
    /* Current Map # of systems. */
    curLines = 1;
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, 20, 0, "txtSCurrentNumSystems",
-         &gl_smallFont, &cBlack, "Number of Systems (limited to 100):" );
+         &gl_smallFont, NULL, "Number of Systems (limited to 100):" );
    window_addText( wid, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtCurrentNumSystems",
-         &gl_smallFont, &cBlack, "N/A" );
+         &gl_smallFont, NULL, "N/A" );
    textPos++;
    linesPos+=curLines+1;
 
    /* Presence. */
    curLines = 5;
    window_addText( wid, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, 20, 0, "txtSPresence",
-         &gl_smallFont, &cBlack, "Presence:" );
+         &gl_smallFont, NULL, "Presence:" );
    window_addText( wid, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtPresence",
-         &gl_smallFont, &cBlack, "No selection" );
+         &gl_smallFont, NULL, "No selection" );
    textPos++;
    linesPos+=curLines+1;
 
@@ -263,7 +263,7 @@ void mapedit_open( unsigned int wid_unused, char *unused )
 
    /* Selected text. */
    window_addText( wid, 140, 10, SCREEN_W - 350 - 30 - 30 - BUTTON_WIDTH - 20, 30, 0,
-         "txtSelected", &gl_smallFont, &cBlack, NULL );
+         "txtSelected", &gl_smallFont, NULL, NULL );
 
    /* Deselect everything. */
    mapedit_deselect();
@@ -803,7 +803,7 @@ void mapedit_saveMapMenu_open (void)
    /* Filename. */
    curLines = 1;
    window_addText( mapedit_widSave, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, gl_smallFont.h+5, 0, "txtSFileName",
-         &gl_smallFont, &cBlack, "File Name (.xml):" );
+         &gl_smallFont, NULL, "File Name (.xml):" );
    window_addInput ( mapedit_widSave, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, 5+curLines*(gl_smallFont.h+5), "inpFileName", MAPEDIT_FILENAME_MAX, 1, NULL );
    textPos++;
    linesPos+=curLines+1;
@@ -811,7 +811,7 @@ void mapedit_saveMapMenu_open (void)
    /* Map name. */
    curLines = 3;
    window_addText( mapedit_widSave, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, gl_smallFont.h+5, 0, "txtSMapName",
-         &gl_smallFont, &cBlack, "Map Name:" );
+         &gl_smallFont, NULL, "Map Name:" );
    window_addInput ( mapedit_widSave, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, 5+curLines*(gl_smallFont.h+5), "inpMapName", MAPEDIT_NAME_MAX, 0, NULL );
    textPos++;
    linesPos+=curLines+1;
@@ -819,7 +819,7 @@ void mapedit_saveMapMenu_open (void)
    /* Map description. */
    curLines = 5;
    window_addText( mapedit_widSave, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, gl_smallFont.h+5, 0, "txtSDescription",
-         &gl_smallFont, &cBlack, "Description:" );
+         &gl_smallFont, NULL, "Description:" );
    window_addInput( mapedit_widSave, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, 5+curLines*(gl_smallFont.h+5), "inpDescription", MAPEDIT_DESCRIPTION_MAX, 0, NULL );
    textPos++;
    linesPos+=(curLines+1);
@@ -827,9 +827,9 @@ void mapedit_saveMapMenu_open (void)
    /* Loaded Map # of systems. */
    curLines = 1;
    window_addText( mapedit_widSave, -20, -40-textPos*20-linesPos*(gl_smallFont.h+5), 290-10, 20, 0, "txtSLoadedNumSystems",
-         &gl_smallFont, &cBlack, "Number of Systems (limited to 100):" );
+         &gl_smallFont, NULL, "Number of Systems (limited to 100):" );
    window_addText( mapedit_widSave, -20, -40-textPos*20-(linesPos+1)*(gl_smallFont.h+5), 290-20, curLines*(gl_smallFont.h+5), 0, "txtLoadedNumSystems",
-         &gl_smallFont, &cBlack, "N/A" );
+         &gl_smallFont, NULL, "N/A" );
    textPos++;
    linesPos+=curLines+1;
 
@@ -908,7 +908,7 @@ void mapedit_loadMapMenu_open (void)
 
    /* Map info text. */
    window_addText( mapedit_widLoad, -20, -40, MAPEDIT_OPEN_TXT_WIDTH, MAPEDIT_OPEN_HEIGHT-40-20-2*(BUTTON_HEIGHT+20),
-         0, "txtMapInfo", NULL, &cBlack, NULL );
+         0, "txtMapInfo", NULL, NULL, NULL );
 
    window_addList( mapedit_widLoad, 20, -50,
          MAPEDIT_OPEN_WIDTH-MAPEDIT_OPEN_TXT_WIDTH-60, MAPEDIT_OPEN_HEIGHT-110,

--- a/src/dev_sysedit.c
+++ b/src/dev_sysedit.c
@@ -240,7 +240,7 @@ void sysedit_open( StarSystem *sys )
    /* Selected text. */
    nsnprintf( buf, sizeof(buf), _("Radius: %.0f"), sys->radius );
    window_addText( wid, 140, 10, SCREEN_W - 80 - 30 - 30 - BUTTON_WIDTH - 20, 30, 0,
-         "txtSelected", &gl_smallFont, &cBlack, buf );
+         "txtSelected", &gl_smallFont, NULL, buf );
 
    /* Actual viewport. */
    window_addCust( wid, 20, -40, SCREEN_W - 150, SCREEN_H - 100,
@@ -1254,9 +1254,9 @@ static void sysedit_editPnt( void )
    y = -40;
    nsnprintf( buf, sizeof(buf), _("Name: ") );
    w = gl_printWidthRaw( NULL, buf );
-   window_addText( wid, 20, y, 180, 15, 0, "txtNameLabel", &gl_smallFont, &cBlack, buf );
+   window_addText( wid, 20, y, 180, 15, 0, "txtNameLabel", &gl_smallFont, NULL, buf );
    nsnprintf( buf, sizeof(buf), "%s", p->name );
-   window_addText( wid, 20 + w, y, 180, 15, 0, "txtName", &gl_smallFont, &cBlack, buf );
+   window_addText( wid, 20 + w, y, 180, 15, 0, "txtName", &gl_smallFont, NULL, buf );
    window_addButton( wid, -20, y - gl_defFont.h/2. + BUTTON_HEIGHT/2., bw, BUTTON_HEIGHT, "btnRename",
          _("Rename"), sysedit_btnRename );
    window_addButton( wid, -20 - 15 - bw, y - gl_defFont.h/2. + BUTTON_HEIGHT/2., bw, BUTTON_HEIGHT, "btnFaction",
@@ -1264,9 +1264,9 @@ static void sysedit_editPnt( void )
 
    y -= gl_defFont.h + 5;
 
-   window_addText( wid, 20, y, 180, 15, 0, "txtFactionLabel", &gl_smallFont, &cBlack, _("Faction: ") );
+   window_addText( wid, 20, y, 180, 15, 0, "txtFactionLabel", &gl_smallFont, NULL, _("Faction: ") );
    nsnprintf( buf, sizeof(buf), "%s", p->faction > 0 ? faction_name( p->faction ) : _("None") );
-   window_addText( wid, 20 + w, y, 180, 15, 0, "txtFaction", &gl_smallFont, &cBlack, buf );
+   window_addText( wid, 20 + w, y, 180, 15, 0, "txtFaction", &gl_smallFont, NULL, buf );
    y -= gl_defFont.h + 5;
 
    /* Input widgets and labels. */
@@ -1274,7 +1274,7 @@ static void sysedit_editPnt( void )
    s = _("Population");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtPop",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 5, y, 80, 20, "inpPop", 12, 1, NULL );
    window_setInputFilter( wid, "inpPop",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`." );
@@ -1283,14 +1283,14 @@ static void sysedit_editPnt( void )
    s = _("Class");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtClass",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 5, y, 30, 20, "inpClass", 1, 1, NULL );
    x += 30 + 10;
 
    s = _("Land");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtLand",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 5, y, 150, 20, "inpLand", 20, 1, NULL );
    y -= gl_defFont.h + 15;
 
@@ -1299,7 +1299,7 @@ static void sysedit_editPnt( void )
    s = _("Presence");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtPresence",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 5, y, 60, 20, "inpPresence", 5, 1, NULL );
    window_setInputFilter( wid, "inpPresence",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1308,7 +1308,7 @@ static void sysedit_editPnt( void )
    s = _("Range");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtPresenceRange",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 5, y, 30, 20, "inpPresenceRange", 1, 1, NULL );
    window_setInputFilter( wid, "inpPresenceRange",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`." );
@@ -1317,7 +1317,7 @@ static void sysedit_editPnt( void )
    s = _("hide");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtHide",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 5, y, 50, 20, "inpHide", 4, 1, NULL );
    window_setInputFilter( wid, "inpHide",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1410,9 +1410,9 @@ static void sysedit_editJump( void )
    y = -40;
    nsnprintf( buf, sizeof(buf), _("Target: ") );
    w = gl_printWidthRaw( NULL, buf );
-   window_addText( wid, 20, y, 180, 15, 0, "txtTargetLabel", &gl_smallFont, &cBlack, buf );
+   window_addText( wid, 20, y, 180, 15, 0, "txtTargetLabel", &gl_smallFont, NULL, buf );
    nsnprintf( buf, sizeof(buf), "%s", j->target->name );
-   window_addText( wid, 20 + w, y, 180, 15, 0, "txtName", &gl_smallFont, &cBlack, buf );
+   window_addText( wid, 20 + w, y, 180, 15, 0, "txtName", &gl_smallFont, NULL, buf );
 
    y -= gl_defFont.h + 10;
 
@@ -1437,7 +1437,7 @@ static void sysedit_editJump( void )
    s = _("Hide"); /* TODO: if inpType == 0 disable hide box */
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtHide",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x + l + 8, y, 50, 20, "inpHide", 4, 1, NULL );
    window_setInputFilter( wid, "inpHide",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1510,7 +1510,7 @@ static void sysedit_planetDesc( unsigned int wid, char *unused )
          "btnClose", _("Close"), sysedit_planetDescClose );
 
    /* Description label and text. */
-   window_addText( wid, x, y, w, gl_defFont.h, 0, "txtDescriptionLabel", &gl_defFont, &cBlack,
+   window_addText( wid, x, y, w, gl_defFont.h, 0, "txtDescriptionLabel", &gl_defFont, NULL,
          _("Landing Description") );
    y -= gl_defFont.h + 10;
    window_addInput( wid, x, y, w, h, "txtDescription", 1024, 0,
@@ -1522,7 +1522,7 @@ static void sysedit_planetDesc( unsigned int wid, char *unused )
    window_setInput( wid, "txtDescription", desc );
 
    /* Bar description label and text. */
-   window_addText( wid, x, y, w, gl_defFont.h, 0, "txtBarDescriptionLabel", &gl_defFont, &cBlack,
+   window_addText( wid, x, y, w, gl_defFont.h, 0, "txtBarDescriptionLabel", &gl_defFont, NULL,
          _("Bar Description") );
    y -= gl_defFont.h + 10;
    window_addInput( wid, x, y, w, h, "txtBarDescription", 1024, 0,

--- a/src/dev_uniedit.c
+++ b/src/dev_uniedit.c
@@ -221,13 +221,13 @@ void uniedit_open( unsigned int wid_unused, char *unused )
 
    /* Presence. */
    window_addText( wid, -20, -140, 100, 20, 0, "txtSPresence",
-         &gl_smallFont, &cBlack, _("Presence:") );
+         &gl_smallFont, NULL, _("Presence:") );
    window_addText( wid, -10, -140-gl_smallFont.h-5, 110, 100, 0, "txtPresence",
-         &gl_smallFont, &cBlack, _("N/A") );
+         &gl_smallFont, NULL, _("N/A") );
 
    /* Selected text. */
    window_addText( wid, 140, 10, SCREEN_W - 80 - 30 - 30 - BUTTON_WIDTH - 20, 30, 0,
-         "txtSelected", &gl_smallFont, &cBlack, NULL );
+         "txtSelected", &gl_smallFont, NULL, NULL );
 
    /* Actual viewport. */
    window_addCust( wid, 20, -40, SCREEN_W - 150, SCREEN_H - 100,
@@ -1248,7 +1248,7 @@ static void uniedit_editSys (void)
    /* Rename button. */
    y = -45;
    nsnprintf( buf, sizeof(buf), _("Name: \an%s"), (uniedit_nsys > 1) ? _("\arvarious") : uniedit_sys[0]->name );
-   window_addText( wid, x, y, 180, 15, 0, "txtName", &gl_smallFont, &cBlack, buf );
+   window_addText( wid, x, y, 180, 15, 0, "txtName", &gl_smallFont, NULL, buf );
    window_addButton( wid, 200, y+3, BUTTON_WIDTH, 21, "btnRename", _("Rename"), uniedit_btnEditRename );
 
    /* New row. */
@@ -1258,7 +1258,7 @@ static void uniedit_editSys (void)
    s = _("Radius");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtRadius",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 7, y, 80, 20, "inpRadius", 10, 1, NULL );
    window_setInputFilter( wid, "inpRadius",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1266,7 +1266,7 @@ static void uniedit_editSys (void)
    s = _("(Scales asset positions)");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtRadiusComment",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
 
    /* New row. */
    x = 20;
@@ -1275,7 +1275,7 @@ static void uniedit_editSys (void)
    s = _("Stars");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtStars",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 7, y, 50, 20, "inpStars", 4, 1, NULL );
    window_setInputFilter( wid, "inpStars",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1284,7 +1284,7 @@ static void uniedit_editSys (void)
    s = _("Interference");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtInterference",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 7, y, 55, 20, "inpInterference", 5, 1, NULL );
    window_setInputFilter( wid, "inpInterference",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1296,7 +1296,7 @@ static void uniedit_editSys (void)
    s = _("Nebula");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtNebula",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 7, y, 50, 20, "inpNebula", 4, 1, NULL );
    window_setInputFilter( wid, "inpNebula",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );
@@ -1305,7 +1305,7 @@ static void uniedit_editSys (void)
    s = _("Volatility");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtVolatility",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x += l + 7, y, 50, 20, "inpVolatility", 4, 1, NULL );
    window_setInputFilter( wid, "inpVolatility",
          "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]{}()-=*/\\'\"~<>!@#$%^&|_`" );

--- a/src/dialogue.c
+++ b/src/dialogue.c
@@ -141,7 +141,7 @@ void dialogue_alert( const char *fmt, ... )
    wdw = window_create( _("Warning"), -1, -1, 300, 90 + h );
    window_setData( wdw, &done );
    window_addText( wdw, 20, -30, 260, h,  0, "txtAlert",
-         &gl_smallFont, &cBlack, msg );
+         &gl_smallFont, NULL, msg );
    window_addButton( wdw, 135, 20, 50, 30, "btnOK", _("OK"),
          dialogue_close );
 
@@ -269,7 +269,7 @@ void dialogue_msgRaw( const char* caption, const char *msg )
    msg_wid = window_create( caption, -1, -1, w, 110 + h );
    window_setData( msg_wid, &done );
    window_addText( msg_wid, 20, -40, w-40, h,  0, "txtMsg",
-         font, &cBlack, msg );
+         font, NULL, msg );
    window_addButton( msg_wid, (w-50)/2, 20, 50, 30, "btnOK", _("OK"),
          dialogue_close );
 
@@ -316,7 +316,7 @@ void dialogue_msgImgRaw( const char* caption, const char *msg, const char *img, 
 
    /* Add the text box */
    window_addText( msg_wid, img_width+40, -40, w-40, h,  0, "txtMsg",
-         font, &cBlack, msg );
+         font, NULL, msg );
 
    /* Add a placeholder rectangle for the image */
    window_addRect( msg_wid, 20, -40, img_width, img_height,
@@ -379,7 +379,7 @@ int dialogue_YesNoRaw( const char* caption, const char *msg )
    window_setData( wid, &done );
    /* text */
    window_addText( wid, 20, -40, w-40, h,  0, "txtYesNo",
-         font, &cBlack, msg );
+         font, NULL, msg );
    /* buttons */
    window_addButtonKey( wid, w/2-50-10, 20, 50, 30, "btnYes", _("Yes"),
          dialogue_YesNoClose, SDLK_y );
@@ -478,7 +478,7 @@ char* dialogue_inputRaw( const char* title, int min, int max, const char *msg )
    window_setCancel( input_dialogue.input_wid, dialogue_cancel );
    /* text */
    window_addText( input_dialogue.input_wid, 30, -30, 200, h,  0, "txtInput",
-         &gl_smallFont, &cBlack, msg );
+         &gl_smallFont, NULL, msg );
    /* input */
    window_addInput( input_dialogue.input_wid, 20, -50-h, 200, 20, "inpInput", max, 1, NULL );
    window_setInputFilter( input_dialogue.input_wid, "inpInput", "/" ); /* Remove illegal stuff. */
@@ -697,7 +697,7 @@ int dialogue_listPanelRaw( const char* title, char **items, int nitems, int extr
    wid = window_create( title, -1, -1, winw, winh );
    window_setData( wid, &done );
    window_addText( wid, 20, -40, w-40, text_height,  0, "txtMsg",
-         font, &cBlack, msg );
+         font, NULL, msg );
    window_setAccept( wid, dialogue_listClose );
    window_setCancel( wid, dialogue_listCancel );
 
@@ -757,7 +757,7 @@ void dialogue_makeChoice( const char *caption, const char *msg, int opts )
    choice_wid     = window_create( caption, -1, -1, w, h+100+40*choice_nopts );
    /* text */
    window_addText( choice_wid, 20, -40, w-40, h,  0, "txtChoice",
-         font, &cBlack, msg );
+         font, NULL, msg );
 }
 /**
  * @brief Add a choice to the dialog.

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -301,16 +301,16 @@ void equipment_open( unsigned int wid )
    x = 20 + sw + 20 + 180 + 20 + 30;
    y = -190;
    window_addText( wid, x, y,
-         100, h+y, 0, "txtSDesc", &gl_smallFont, &cBlack, buf );
+         100, h+y, 0, "txtSDesc", &gl_smallFont, NULL, buf );
    x += 100;
    window_addText( wid, x, y,
-         w - x - 20, h+y, 0, "txtDDesc", &gl_smallFont, &cBlack, NULL );
+         w - x - 20, h+y, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
 
    /* Generate lists. */
    window_addText( wid, 30, -20,
-         130, 200, 0, "txtShipTitle", &gl_defFont, &cBlack, _("Available Ships") );
+         130, 200, 0, "txtShipTitle", &gl_defFont, NULL, _("Available Ships") );
    window_addText( wid, 30, -40-sh-20,
-         130, 200, 0, "txtOutfitTitle", &gl_defFont, &cBlack, _("Available Outfits") );
+         130, 200, 0, "txtOutfitTitle", &gl_defFont, NULL, _("Available Outfits") );
    equipment_genLists( wid );
 
    /* Separator. */
@@ -369,7 +369,7 @@ static void equipment_renderColumn( double x, double y, double w, double h,
    if ((o != NULL) && (lst[0].sslot->slot.type == o->slot.type))
       c = &cGreen;
    else
-      c = &cBlack;
+      c = &cFontWhite;
    gl_printMidRaw( &gl_smallFont, 60.,
          x-15., y+h+10., c, txt );
 
@@ -556,7 +556,7 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    y = by + bh - 30 - h;
 
    gl_printMidRaw( &gl_smallFont, w,
-      x, y + h + 10., &cBlack, _("CPU Free") );
+      x, y + h + 10., &cFontWhite, _("CPU Free") );
 
    percent = (p->cpu_max > 0) ? CLAMP(0., 1., (float)p->cpu / (float)p->cpu_max) : 0.;
    toolkit_drawRect( x, y, w * percent, h, &cFontGreen, NULL );
@@ -565,12 +565,12 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    toolkit_drawOutline( x, y, w, h, 2., dc, NULL  );
    gl_printMid( &gl_smallFont, w,
       x, y + h / 2. - gl_smallFont.h / 2.,
-      &cBlack, "%d / %d", p->cpu, p->cpu_max );
+      &cFontWhite, "%d / %d", p->cpu, p->cpu_max );
 
    y -= h;
 
    gl_printMidRaw( &gl_smallFont, w,
-      x, y, &cBlack, _("Mass Limit Left") );
+      x, y, &cFontWhite, _("Mass Limit Left") );
 
    y -= gl_smallFont.h + h;
 
@@ -582,7 +582,7 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    toolkit_drawOutline( x, y, w, h, 2., dc, NULL  );
    gl_printMid( &gl_smallFont, w,
       x, y + h / 2. - gl_smallFont.h / 2.,
-      &cBlack, "%.0f / %.0f", p->stats.engine_limit - p->solid->mass, p->stats.engine_limit );
+      &cFontWhite, "%.0f / %.0f", p->stats.engine_limit - p->solid->mass, p->stats.engine_limit );
 
    if (p->stats.engine_limit > 0. && p->solid->mass > p->stats.engine_limit) {
       y -= h;

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -367,7 +367,7 @@ static void equipment_renderColumn( double x, double y, double w, double h,
 
    /* Render text. */
    if ((o != NULL) && (lst[0].sslot->slot.type == o->slot.type))
-      c = &cDConsole;
+      c = &cGreen;
    else
       c = &cBlack;
    gl_printMidRaw( &gl_smallFont, 60.,
@@ -398,7 +398,7 @@ static void equipment_renderColumn( double x, double y, double w, double h,
       bc = *dc;
       bc.a = 0.4;
       if (i==selected)
-         c = &cDConsole;
+         c = &cGreen;
       else
          c = &bc;
       toolkit_drawRect( x, y, w, h, c, NULL );
@@ -642,7 +642,7 @@ static void equipment_renderOverlayColumn( double x, double y, double w, double 
                   c = &cRed;
                else {
                   display = _("Right click to remove");
-                  c = &cDConsole;
+                  c = &cGreen;
                }
             }
             else if ((wgt->outfit != NULL) &&
@@ -653,7 +653,7 @@ static void equipment_renderOverlayColumn( double x, double y, double w, double 
                   c = &cRed;
                else {
                   display = _("Right click to add");
-                  c = &cDConsole;
+                  c = &cGreen;
                }
             }
          }
@@ -763,7 +763,7 @@ static void equipment_renderOverlaySlots( double bx, double by, double bw, doubl
          return;
 
       pos = snprintf( alt, sizeof(alt),
-            "\aS%s", sp_display( slot->sslot->slot.spid ) );
+            "\aR%s", sp_display( slot->sslot->slot.spid ) );
       if (slot->sslot->slot.exclusive && (pos < (int)sizeof(alt)))
          pos += snprintf( &alt[pos], sizeof(alt)-pos,
                _(" [exclusive]") );
@@ -787,7 +787,7 @@ static void equipment_renderOverlaySlots( double bx, double by, double bw, doubl
          "%s",
          o->name );
    if ((o->slot.spid!=0) && (pos < (int)sizeof(alt)))
-      pos += snprintf( &alt[pos], sizeof(alt)-pos, _("\n\aSSlot %s\a0"),
+      pos += snprintf( &alt[pos], sizeof(alt)-pos, _("\n\aRSlot %s\a0"),
             sp_display( o->slot.spid ) );
    if (pos < (int)sizeof(alt))
       pos += snprintf( &alt[pos], sizeof(alt)-pos, "\n\n%s", o->desc_short );
@@ -1524,7 +1524,7 @@ static void equipment_genOutfitList( unsigned int wid )
          alt[i] = malloc( l );
          p  = snprintf( &alt[i][0], l, "%s\n", o->name );
          if ((o->slot.spid!=0) && (p < l))
-            p += snprintf( &alt[i][p], l-p, _("\aSSlot %s\a0\n"),
+            p += snprintf( &alt[i][p], l-p, _("\aRSlot %s\a0\n"),
                   sp_display( o->slot.spid ) );
          if (p < l)
             p += snprintf( &alt[i][p], l-p, "\n%s", o->desc_short );
@@ -1569,9 +1569,9 @@ static void equipment_genOutfitList( unsigned int wid )
 static char eq_qCol( double cur, double base, int inv )
 {
    if (cur > 1.2*base)
-      return (inv) ? 'r' : 'D';
+      return (inv) ? 'r' : 'g';
    else if (cur < 0.8*base)
-      return (inv) ? 'D' : 'r';
+      return (inv) ? 'g' : 'r';
    return '0';
 }
 

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -586,7 +586,7 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    if (p->stats.engine_limit > 0. && p->solid->mass > p->stats.engine_limit) {
       y -= h;
       gl_printMid( &gl_smallFont, w,
-         x, y, &cFontRed, _("%.0f%% Slower"),
+         x, y, &cFontRed, _("!! %.0f%% Slower !!"),
          (1. - p->speed / p->speed_base) * 100);
    }
 
@@ -1398,7 +1398,7 @@ static void equipment_genOutfitList( unsigned int wid )
       equipment_outfitFilterCore
    };
    const char *tabnames[] = {
-      _("All"), _("\ab W "), _("\ag U "), _("\ap S "), _("\aRCore")
+      _("All"), "\ab W ", "\ag U ", "\ap S ", _("\aRCore")
    };
 
    int active, i, l, p, noutfits;
@@ -1571,8 +1571,21 @@ static char eq_qCol( double cur, double base, int inv )
 }
 
 
+/**
+ * @brief Gets the symbol for comparing a current value vs a ship base value.
+ */
+static const char* eq_qSym( double cur, double base, int inv )
+{
+   if (cur > 1.2*base)
+      return (inv) ? "!! " : "";
+   else if (cur < 0.8*base)
+      return (inv) ? "" : "!! ";
+   return "";
+}
+
+
 #define EQ_COMP( cur, base, inv ) \
-eq_qCol( cur, base, inv ), cur
+eq_qCol( cur, base, inv ), eq_qSym( cur, base, inv ), cur
 /**
  * @brief Updates the player's ship window.
  *    @param wid Window to update.
@@ -1622,18 +1635,18 @@ void equipment_updateShips( unsigned int wid, char* str )
          "%s credits\n"
          "\n"
          "%.0f\a0 tonnes\n"
-         "\a%c%s\a0 average\n"
-         "\a%c%.0f\a0 kN/tonne\n"
-         "\a%c%.0f\a0 m/s (max \a%c%.0f\a0 m/s)\n"
-         "\a%c%.0f\a0 deg/s\n"
-         "\a%c%.0f%%\n"
+         "%s average\n"
+         "\a%c%s%.0f\a0 kN/tonne\n"
+         "\a%c%s%.0f\a0 m/s (max \a%c%s%.0f\a0 m/s)\n"
+         "\a%c%s%.0f\a0 deg/s\n"
+         "%.0f%%\n"
          "\n"
-         "\a%c%.0f%%\n"
-         "\a%c%.0f\a0 MJ (\a%c%.1f\a0 MW)\n"
-         "\a%c%.0f\a0 MJ (\a%c%.1f\a0 MW)\n"
-         "\a%c%.0f\a0 MJ (\a%c%.1f\a0 MW)\n"
-         "%d / \a%c%d\a0 tonnes\n"
-         "%d / \a%c%d\a0 units (%d jumps)\n"
+         "\a%c%s%.0f%%\n"
+         "\a%c%s%.0f\a0 MJ (\a%c%s%.1f\a0 MW)\n"
+         "\a%c%s%.0f\a0 MJ (\a%c%s%.1f\a0 MW)\n"
+         "\a%c%s%.0f\a0 MJ (\a%c%s%.1f\a0 MW)\n"
+         "%d / \a%c%s%d\a0 tonnes\n"
+         "%d units (%d jumps)\n"
          "\n"
          "\a%c%s\a0"),
          /* Generic. */
@@ -1643,13 +1656,13 @@ void equipment_updateShips( unsigned int wid, char* str )
       buf2,
       /* Movement. */
       ship->solid->mass,
-      '0', nt,
+      nt,
       EQ_COMP( ship->thrust/ship->solid->mass, ship->ship->thrust/ship->ship->mass, 0 ),
       EQ_COMP( ship->speed, ship->ship->speed, 0 ),
       EQ_COMP( solid_maxspeed( ship->solid, ship->speed, ship->thrust ),
             solid_maxspeed( ship->solid, ship->ship->speed, ship->ship->thrust), 0 ),
       EQ_COMP( ship->turn*180./M_PI, ship->ship->turn*180./M_PI, 0 ),
-      EQ_COMP( ship->ship->dt_default * 100, ship->ship->dt_default * 100, 0 ),
+      ship->ship->dt_default * 100,
       /* Health. */
       EQ_COMP( ship->dmg_absorb * 100, ship->ship->dmg_absorb * 100, 0 ),
       EQ_COMP( ship->shield_max, ship->ship->shield, 0 ),
@@ -1660,7 +1673,7 @@ void equipment_updateShips( unsigned int wid, char* str )
       EQ_COMP( ship->energy_regen, ship->ship->energy_regen, 0 ),
       /* Misc. */
       pilot_cargoUsed(ship), EQ_COMP( cargo, ship->ship->cap_cargo, 0 ),
-      ship->fuel, EQ_COMP( ship->fuel_max, ship->ship->fuel, 0 ), pilot_getJumps(ship),
+      ship->fuel, pilot_getJumps(ship),
       pilot_checkSpaceworthy(ship) ? 'r' : '0', errorReport );
    window_modifyText( wid, "txtDDesc", buf );
 

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -538,7 +538,7 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    double percent;
    double x, y;
    double w, h;
-   const glColour *lc, *c, *dc;
+   const glColour *lc, *dc;
 
    /* Must have selected ship. */
    if (eq_wgt.selected == NULL)
@@ -548,7 +548,6 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
 
    /* Render CPU and energy bars. */
    lc = &cWhite;
-   c = &cGrey80;
    dc = &cGrey60;
    w = 120;
    h = 20;
@@ -559,9 +558,9 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
       x, y + h + 10., &cFontWhite, _("CPU Free") );
 
    percent = (p->cpu_max > 0) ? CLAMP(0., 1., (float)p->cpu / (float)p->cpu_max) : 0.;
-   toolkit_drawRect( x, y, w * percent, h, &cFontGreen, NULL );
-   toolkit_drawRect( x + w * percent, y, w * (1.-percent), h, &cFontRed, NULL );
-   toolkit_drawOutline( x, y, w, h, 1., lc, c  );
+   toolkit_drawRect( x, y, w * percent, h, &cFriend, NULL );
+   toolkit_drawRect( x + w * percent, y, w * (1.-percent), h, &cHostile, NULL );
+   toolkit_drawOutline( x, y, w, h, 1., lc, NULL  );
    toolkit_drawOutline( x, y, w, h, 2., dc, NULL  );
    gl_printMid( &gl_smallFont, w,
       x, y + h / 2. - gl_smallFont.h / 2.,
@@ -576,9 +575,9 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
 
    percent = (p->stats.engine_limit > 0) ? CLAMP(0., 1.,
       (p->stats.engine_limit - p->solid->mass) / p->stats.engine_limit) : 0.;
-   toolkit_drawRect( x, y, w * percent, h, &cFontGreen, NULL );
+   toolkit_drawRect( x, y, w * percent, h, &cFriend, NULL );
    toolkit_drawRect( x + w * percent, y, w * (1.-percent), h, &cRestricted, NULL );
-   toolkit_drawOutline( x, y, w, h, 1., lc, c  );
+   toolkit_drawOutline( x, y, w, h, 1., lc, NULL  );
    toolkit_drawOutline( x, y, w, h, 2., dc, NULL  );
    gl_printMid( &gl_smallFont, w,
       x, y + h / 2. - gl_smallFont.h / 2.,
@@ -816,7 +815,6 @@ static void equipment_renderShip( double bx, double by,
       double bw, double bh, double x, double y, Pilot* p )
 {
    int sx, sy;
-   const glColour *lc, *c, *dc;
    unsigned int tick;
    double dt;
    double px, py;
@@ -864,11 +862,8 @@ static void equipment_renderShip( double bx, double by,
       gl_renderCross(px + v.x, py + v.y, 7, &cRadar_player);
       glLineWidth( 1. );
    }
-   lc = toolkit_colLight;
-   c  = toolkit_col;
-   dc = toolkit_colDark;
-   toolkit_drawOutline( x - 4., y-4., w+7., h+2., 1., lc, c  );
-   toolkit_drawOutline( x - 4., y-4., w+7., h+2., 2., dc, NULL  );
+   toolkit_drawOutline( x - 4., y-4., w+7., h+2., 1., toolkit_colLight, NULL  );
+   toolkit_drawOutline( x - 4., y-4., w+7., h+2., 2., toolkit_colDark, NULL  );
 }
 /**
  * @brief Handles a mouse press in column.

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -367,7 +367,7 @@ static void equipment_renderColumn( double x, double y, double w, double h,
 
    /* Render text. */
    if ((o != NULL) && (lst[0].sslot->slot.type == o->slot.type))
-      c = &cGreen;
+      c = &cFontGreen;
    else
       c = &cFontWhite;
    gl_printMidRaw( &gl_smallFont, 60.,
@@ -385,7 +385,7 @@ static void equipment_renderColumn( double x, double y, double w, double h,
          else if (lst[i].active)
             dc = &cFontBlue;
          else
-            dc = &cInert;
+            dc = &cFontGrey;
       }
       else
          dc = outfit_slotSizeColour( &lst[i].sslot->slot );
@@ -638,10 +638,10 @@ static void equipment_renderOverlayColumn( double x, double y, double w, double 
                top = 1;
                display = pilot_canEquip( wgt->selected, &lst[i], NULL );
                if (display != NULL)
-                  c = &cRed;
+                  c = &cFontRed;
                else {
                   display = _("Right click to remove");
-                  c = &cGreen;
+                  c = &cFontGreen;
                }
             }
             else if ((wgt->outfit != NULL) &&
@@ -649,10 +649,10 @@ static void equipment_renderOverlayColumn( double x, double y, double w, double 
                top = 0;
                display = pilot_canEquip( wgt->selected, &lst[i], wgt->outfit );
                if (display != NULL)
-                  c = &cRed;
+                  c = &cFontRed;
                else {
                   display = _("Right click to add");
-                  c = &cGreen;
+                  c = &cFontGreen;
                }
             }
          }

--- a/src/faction.c
+++ b/src/faction.c
@@ -954,7 +954,7 @@ const glColour* faction_getColour( int f )
 
 
 /**
- * @brief Gets the faction character associated to it's standing with the player.
+ * @brief Gets the faction character associated to its standing with the player.
  *
  * Use this to do something like "\a%c", faction_getColourChar( some_faction ) in the
  *  font print routines.

--- a/src/font.c
+++ b/src/font.c
@@ -570,18 +570,20 @@ void gl_printRaw( const glFont *ft_font,
     * ultimately replaced with use of signed distance fields or some
     * other more efficient method (signed distance fields seem to be
     * the "right" solution). */
-   gl_printRawBase( ft_font, x - 1, y, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x + 1, y, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x, y - 1, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x, y + 1, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x - 2, y, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x + 2, y, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x, y - 2, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x, y + 2, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x - 1, y - 1, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x - 1, y + 1, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x + 1, y - 1, &cBlack, text, 1 );
-   gl_printRawBase( ft_font, x + 1, y + 1, &cBlack, text, 1 );
+   if ( (c == NULL) || (c->a >= 1.) ) {
+      gl_printRawBase( ft_font, x - 1, y, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x + 1, y, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x, y - 1, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x, y + 1, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x - 2, y, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x + 2, y, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x, y - 2, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x, y + 2, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x - 1, y - 1, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x - 1, y + 1, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x + 1, y - 1, &cBlack, text, 1 );
+      gl_printRawBase( ft_font, x + 1, y + 1, &cBlack, text, 1 );
+   }
 
    gl_printRawBase( ft_font, x, y, c, text, 0 );
 }
@@ -675,18 +677,20 @@ int gl_printMaxRaw( const glFont *ft_font, const int max,
     * ultimately replaced with use of signed distance fields or some
     * other more efficient method (signed distance fields seem to be
     * the "right" solution). */
-   gl_printMaxRawBase( ft_font, max, x - 1, y, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x + 1, y, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x, y - 1, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x, y + 1, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x - 2, y, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x + 2, y, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x, y - 2, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x, y + 2, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x - 1, y - 1, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x - 1, y + 1, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x + 1, y - 1, &cBlack, text, 1 );
-   gl_printMaxRawBase( ft_font, max, x + 1, y + 1, &cBlack, text, 1 );
+   if ( (c == NULL) || (c->a >= 1.) ) {
+      gl_printMaxRawBase( ft_font, max, x - 1, y, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x + 1, y, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x, y - 1, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x, y + 1, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x - 2, y, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x + 2, y, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x, y - 2, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x, y + 2, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x - 1, y - 1, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x - 1, y + 1, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x + 1, y - 1, &cBlack, text, 1 );
+      gl_printMaxRawBase( ft_font, max, x + 1, y + 1, &cBlack, text, 1 );
+   }
 
    return gl_printMaxRawBase( ft_font, max, x, y, c, text, 0 );
 }
@@ -784,18 +788,20 @@ int gl_printMidRaw( const glFont *ft_font, const int width,
     * ultimately replaced with use of signed distance fields or some
     * other more efficient method (signed distance fields seem to be
     * the "right" solution). */
-   gl_printMidRawBase( ft_font, width, x - 1, y, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x + 1, y, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x, y - 1, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x, y + 1, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x - 2, y, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x + 2, y, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x, y - 2, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x, y + 2, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x - 1, y - 1, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x - 1, y + 1, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x + 1, y - 1, &cBlack, text, 1 );
-   gl_printMidRawBase( ft_font, width, x + 1, y + 1, &cBlack, text, 1 );
+   if ( (c == NULL) || (c->a >= 1.) ) {
+      gl_printMidRawBase( ft_font, width, x - 1, y, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x + 1, y, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x, y - 1, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x, y + 1, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x - 2, y, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x + 2, y, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x, y - 2, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x, y + 2, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x - 1, y - 1, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x - 1, y + 1, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x + 1, y - 1, &cBlack, text, 1 );
+      gl_printMidRawBase( ft_font, width, x + 1, y + 1, &cBlack, text, 1 );
+   }
 
    return gl_printMidRawBase( ft_font, width, x, y, c, text, 0 );
 }
@@ -920,18 +926,20 @@ int gl_printTextRaw( const glFont *ft_font,
     * ultimately replaced with use of signed distance fields or some
     * other more efficient method (signed distance fields seem to be
     * the "right" solution). */
-   gl_printTextRawBase( ft_font, width, height, bx - 1, by, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx + 1, by, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx, by - 1, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx, by + 1, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx - 2, by, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx + 2, by, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx, by - 2, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx, by + 2, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx - 1, by - 1, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx - 1, by + 1, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx + 1, by - 1, &cBlack, text, 1 );
-   gl_printTextRawBase( ft_font, width, height, bx + 1, by + 1, &cBlack, text, 1 );
+   if ( (c == NULL) || (c->a >= 1.) ) {
+      gl_printTextRawBase( ft_font, width, height, bx - 1, by, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx + 1, by, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx, by - 1, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx, by + 1, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx - 2, by, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx + 2, by, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx, by - 2, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx, by + 2, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx - 1, by - 1, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx - 1, by + 1, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx + 1, by - 1, &cBlack, text, 1 );
+      gl_printTextRawBase( ft_font, width, height, bx + 1, by + 1, &cBlack, text, 1 );
+   }
 
    return gl_printTextRawBase( ft_font, width, height, bx, by, c, text, 0 );
 }

--- a/src/font.c
+++ b/src/font.c
@@ -150,7 +150,7 @@ static glFontGlyph* gl_fontGetGlyph( glFontStash *stsh, uint32_t ch );
  * when gl_fontRenderEnd() is called, saving lots of opengl calls.
  */
 static void gl_fontRenderStart( const glFontStash *stsh, double x, double y, const glColour *c );
-static int gl_fontRenderGlyph( glFontStash *stsh, uint32_t ch, const glColour *c, int state );
+static int gl_fontRenderGlyph( glFontStash *stsh, uint32_t ch, const glColour *c, int state, int forceColor );
 static void gl_fontRenderEnd (void);
 
 
@@ -520,19 +520,18 @@ int gl_printWidthForText( const glFont *ft_font, const char *text,
 
 
 /**
- * @brief Prints text on screen.
- *
- * Defaults ft_font to gl_defFont if NULL.
+ * @brief Wrapped by gl_printRaw.
  *
  *    @param ft_font Font to use
  *    @param x X position to put text at.
  *    @param y Y position to put text at.
  *    @param c Colour to use (uses white if NULL)
- *    @param str String to display.
+ *    @param text String to display.
+ *    @param forceColor Whether or not to force the color.
  */
-void gl_printRaw( const glFont *ft_font,
+static void gl_printRawBase( const glFont *ft_font,
       const double x, const double y,
-      const glColour* c, const char *text )
+      const glColour* c, const char *text, int forceColor )
 {
    int s;
    size_t i;
@@ -547,8 +546,40 @@ void gl_printRaw( const glFont *ft_font,
    i = 0;
    gl_fontRenderStart(stsh, x, y, c);
    while ((ch = u8_nextchar( text, &i )))
-      s = gl_fontRenderGlyph( stsh, ch, c, s );
+      s = gl_fontRenderGlyph( stsh, ch, c, s, forceColor );
    gl_fontRenderEnd();
+}
+
+
+/**
+ * @brief Prints text on screen.
+ *
+ * Defaults ft_font to gl_defFont if NULL.
+ *
+ *    @param ft_font Font to use
+ *    @param x X position to put text at.
+ *    @param y Y position to put text at.
+ *    @param c Colour to use (uses white if NULL)
+ *    @param str String to display.
+ */
+void gl_printRaw( const glFont *ft_font,
+      const double x, const double y,
+      const glColour* c, const char *text )
+{
+   gl_printRawBase( ft_font, x - 1, y, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x + 1, y, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x, y - 1, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x, y + 1, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x - 2, y, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x + 2, y, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x, y - 2, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x, y + 2, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x - 1, y - 1, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x - 1, y + 1, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x + 1, y - 1, &cBlack, text, 1 );
+   gl_printRawBase( ft_font, x + 1, y + 1, &cBlack, text, 1 );
+
+   gl_printRawBase( ft_font, x, y, c, text, 0 );
 }
 
 
@@ -583,19 +614,20 @@ void gl_print( const glFont *ft_font,
 
 
 /**
- * @brief Behaves like gl_printRaw but stops displaying text after a certain distance.
+ * @brief Wrapped by gl_printMaxRaw.
  *
  *    @param ft_font Font to use.
  *    @param max Maximum length to reach.
  *    @param x X position to display text at.
  *    @param y Y position to display text at.
  *    @param c Colour to use (NULL defaults to white).
- *    @param fmt String to display formatted like printf.
+ *    @param text String to display.
+ *    @param forceColor Whether or not to force the color.
  *    @return The number of characters it had to suppress.
  */
-int gl_printMaxRaw( const glFont *ft_font, const int max,
+static int gl_printMaxRawBase( const glFont *ft_font, const int max,
       const double x, const double y,
-      const glColour* c, const char *text )
+      const glColour* c, const char *text, int forceColor )
 {
    int s;
    size_t ret, i;
@@ -613,11 +645,45 @@ int gl_printMaxRaw( const glFont *ft_font, const int max,
    gl_fontRenderStart(stsh, x, y, c);
    i = 0;
    while ((ch = u8_nextchar( text, &i )) && (i <= ret))
-      s = gl_fontRenderGlyph( stsh, ch, c, s );
+      s = gl_fontRenderGlyph( stsh, ch, c, s, forceColor );
    gl_fontRenderEnd();
 
    return ret;
 }
+
+
+/**
+ * @brief Behaves like gl_printRaw but stops displaying text after a certain distance.
+ *
+ *    @param ft_font Font to use.
+ *    @param max Maximum length to reach.
+ *    @param x X position to display text at.
+ *    @param y Y position to display text at.
+ *    @param c Colour to use (NULL defaults to white).
+ *    @param text String to display.
+ *    @return The number of characters it had to suppress.
+ */
+int gl_printMaxRaw( const glFont *ft_font, const int max,
+      const double x, const double y,
+      const glColour* c, const char *text )
+{
+   gl_printMaxRawBase( ft_font, max, x - 1, y, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x + 1, y, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x, y - 1, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x, y + 1, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x - 2, y, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x + 2, y, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x, y - 2, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x, y + 2, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x - 1, y - 1, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x - 1, y + 1, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x + 1, y - 1, &cBlack, text, 1 );
+   gl_printMaxRawBase( ft_font, max, x + 1, y + 1, &cBlack, text, 1 );
+
+   return gl_printMaxRawBase( ft_font, max, x, y, c, text, 0 );
+}
+
+
 /**
  * @brief Behaves like gl_print but stops displaying text after reaching a certain length.
  *
@@ -649,21 +715,20 @@ int gl_printMax( const glFont *ft_font, const int max,
 
 
 /**
- * @brief Displays text centered in position and width.
- *
- * Will truncate if text is too long.
+ * @brief Wrapped by gl_printMidRaw.
  *
  *    @param ft_font Font to use.
  *    @param width Width of area to center in.
  *    @param x X position to display text at.
  *    @param y Y position to display text at.
  *    @param c Colour to use for text (NULL defaults to white).
- *    @param fmt Text to display formatted like printf.
+ *    @param text String to display.
+ *    @param forceColor Whether or not to force the color.
  *    @return The number of characters it had to truncate.
  */
-int gl_printMidRaw( const glFont *ft_font, const int width,
+static int gl_printMidRawBase( const glFont *ft_font, const int width,
       double x, const double y,
-      const glColour* c, const char *text )
+      const glColour* c, const char *text, int forceColor )
 {
    /*float h = ft_font->h / .63;*/ /* slightly increase fontsize */
    int n, s;
@@ -683,11 +748,47 @@ int gl_printMidRaw( const glFont *ft_font, const int width,
    gl_fontRenderStart(stsh, x, y, c);
    i = 0;
    while ((ch = u8_nextchar( text, &i )) && (i <= ret))
-      s = gl_fontRenderGlyph( stsh, ch, c, s );
+      s = gl_fontRenderGlyph( stsh, ch, c, s, forceColor );
    gl_fontRenderEnd();
 
    return ret;
 }
+
+
+/**
+ * @brief Displays text centered in position and width.
+ *
+ * Will truncate if text is too long.
+ *
+ *    @param ft_font Font to use.
+ *    @param width Width of area to center in.
+ *    @param x X position to display text at.
+ *    @param y Y position to display text at.
+ *    @param c Colour to use for text (NULL defaults to white).
+ *    @param text String to display.
+ *    @return The number of characters it had to truncate.
+ */
+int gl_printMidRaw( const glFont *ft_font, const int width,
+      double x, const double y,
+      const glColour* c, const char *text )
+{
+   gl_printMidRawBase( ft_font, width, x - 1, y, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x + 1, y, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x, y - 1, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x, y + 1, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x - 2, y, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x + 2, y, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x, y - 2, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x, y + 2, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x - 1, y - 1, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x - 1, y + 1, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x + 1, y - 1, &cBlack, text, 1 );
+   gl_printMidRawBase( ft_font, width, x + 1, y + 1, &cBlack, text, 1 );
+
+   return gl_printMidRawBase( ft_font, width, x, y, c, text, 0 );
+}
+
+
 /**
  * @brief Displays text centered in position and width.
  *
@@ -721,9 +822,7 @@ int gl_printMid( const glFont *ft_font, const int width,
 
 
 /**
- * @brief Prints a block of text that fits in the dimensions given.
- *
- * Positions are based on origin being top-left.
+ * @brief Wrapped by gl_printTextRaw.
  *
  *    @param ft_font Font to use.
  *    @param width Maximum width to print to.
@@ -731,14 +830,14 @@ int gl_printMid( const glFont *ft_font, const int width,
  *    @param bx X position to display text at.
  *    @param by Y position to display text at.
  *    @param c Colour to use (NULL defaults to white).
- *    @param fmt Text to display formatted like printf.
+ *    @param text String to display.
+ *    @param forceColor Whether or not to force the color.
  *    @return 0 on success.
- * prints text with line breaks included to a maximum width and height preset
  */
-int gl_printTextRaw( const glFont *ft_font,
+static int gl_printTextRawBase( const glFont *ft_font,
       const int width, const int height,
       double bx, double by,
-      const glColour* c, const char *text )
+      const glColour* c, const char *text, int forceColor )
 {
    int p, s;
    double x,y;
@@ -768,7 +867,7 @@ int gl_printTextRaw( const glFont *ft_font,
       gl_fontRenderStart(stsh, x, y, c);
       for (i=p; i<ret; ) {
          ch = u8_nextchar( text, &i);
-         s = gl_fontRenderGlyph( stsh, ch, c, s );
+         s = gl_fontRenderGlyph( stsh, ch, c, s, forceColor );
       }
       gl_fontRenderEnd();
 
@@ -782,6 +881,43 @@ int gl_printTextRaw( const glFont *ft_font,
 
 
    return 0;
+}
+
+
+/**
+ * @brief Prints a block of text that fits in the dimensions given.
+ *
+ * Positions are based on origin being top-left.
+ *
+ *    @param ft_font Font to use.
+ *    @param width Maximum width to print to.
+ *    @param height Maximum height to print to.
+ *    @param bx X position to display text at.
+ *    @param by Y position to display text at.
+ *    @param c Colour to use (NULL defaults to white).
+ *    @param text String to display.
+ *    @return 0 on success.
+ * prints text with line breaks included to a maximum width and height preset
+ */
+int gl_printTextRaw( const glFont *ft_font,
+      const int width, const int height,
+      double bx, double by,
+      const glColour* c, const char *text )
+{
+   gl_printTextRawBase( ft_font, width, height, bx - 1, by, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx + 1, by, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx, by - 1, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx, by + 1, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx - 2, by, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx + 2, by, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx, by - 2, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx, by + 2, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx - 1, by - 1, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx - 1, by + 1, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx + 1, by - 1, &cBlack, text, 1 );
+   gl_printTextRawBase( ft_font, width, height, bx + 1, by + 1, &cBlack, text, 1 );
+
+   return gl_printTextRawBase( ft_font, width, height, bx, by, c, text, 0 );
 }
 
 
@@ -1144,7 +1280,7 @@ static glFontGlyph* gl_fontGetGlyph( glFontStash *stsh, uint32_t ch )
 /**
  * @brief Renders a character.
  */
-static int gl_fontRenderGlyph( glFontStash* stsh, uint32_t ch, const glColour *c, int state )
+static int gl_fontRenderGlyph( glFontStash* stsh, uint32_t ch, const glColour *c, int state, int forceColor )
 {
    double a;
    const glColour *col;
@@ -1154,17 +1290,19 @@ static int gl_fontRenderGlyph( glFontStash* stsh, uint32_t ch, const glColour *c
       return 1;
    }
    if (state == 1) {
-      col = gl_fontGetColour( ch );
-      a   = (c==NULL) ? 1. : c->a;
-      if (col == NULL) {
-         if (c==NULL)
-            gl_uniformColor(shaders.font.color, &cWhite);
+      if (!forceColor) {
+         col = gl_fontGetColour( ch );
+         a   = (c==NULL) ? 1. : c->a;
+         if (col == NULL) {
+            if (c==NULL)
+               gl_uniformColor(shaders.font.color, &cWhite);
+            else
+               gl_uniformColor(shaders.font.color, c);
+         }
          else
-            gl_uniformColor(shaders.font.color, c);
+            gl_uniformAColor(shaders.font.color, col, a);
+         font_lastCol = col;
       }
-      else
-         gl_uniformAColor(shaders.font.color, col, a);
-      font_lastCol = col;
       return 0;
    }
 

--- a/src/font.c
+++ b/src/font.c
@@ -1047,20 +1047,18 @@ static const glColour* gl_fontGetColour( uint32_t ch )
       case 'r': col = &cFontRed; break;
       case 'g': col = &cFontGreen; break;
       case 'b': col = &cFontBlue; break;
+      case 'o': col = &cFontOrange; break;
       case 'y': col = &cFontYellow; break;
       case 'w': col = &cFontWhite; break;
       case 'p': col = &cFontPurple; break;
       case 'n': col = &cBlack; break;
       /* Fancy states. */
-      case 'F': col = &cFriend; break;
-      case 'H': col = &cHostile; break;
-      case 'N': col = &cNeutral; break;
-      case 'I': col = &cMapInert; break;
-      case 'R': col = &cRestricted; break;
-      case 'S': col = &cDRestricted; break;
-      case 'M': col = &cMapNeutral; break;
-      case 'C': col = &cConsole; break;
-      case 'D': col = &cDConsole; break;
+      case 'F': col = &cFontGreen; break; /**< Friendly */
+      case 'H': col = &cFontRed; break; /**< Hostile */
+      case 'N': col = &cFontYellow; break; /**< Neutral */
+      case 'I': col = &cFontGrey; break; /**< Inert */
+      case 'R': col = &cFontOrange; break; /**< Restricted */
+      case 'C': col = &cFontGreen; break; /**< Console */
       case '0': col = NULL; break;
       default: col = NULL; break;
    }

--- a/src/font.c
+++ b/src/font.c
@@ -1187,7 +1187,7 @@ static const glColour* gl_fontGetColour( uint32_t ch )
       case 'y': col = &cFontYellow; break;
       case 'w': col = &cFontWhite; break;
       case 'p': col = &cFontPurple; break;
-      case 'n': col = &cBlack; break;
+      case 'n': col = &cFontGrey; break;
       /* Fancy states. */
       case 'F': col = &cFontGreen; break; /**< Friendly */
       case 'H': col = &cFontRed; break; /**< Hostile */

--- a/src/font.c
+++ b/src/font.c
@@ -566,6 +566,10 @@ void gl_printRaw( const glFont *ft_font,
       const double x, const double y,
       const glColour* c, const char *text )
 {
+   /* TODO: This method works, but is inefficient. Should probably be
+    * ultimately replaced with use of signed distance fields or some
+    * other more efficient method (signed distance fields seem to be
+    * the "right" solution). */
    gl_printRawBase( ft_font, x - 1, y, &cBlack, text, 1 );
    gl_printRawBase( ft_font, x + 1, y, &cBlack, text, 1 );
    gl_printRawBase( ft_font, x, y - 1, &cBlack, text, 1 );
@@ -667,6 +671,10 @@ int gl_printMaxRaw( const glFont *ft_font, const int max,
       const double x, const double y,
       const glColour* c, const char *text )
 {
+   /* TODO: This method works, but is inefficient. Should probably be
+    * ultimately replaced with use of signed distance fields or some
+    * other more efficient method (signed distance fields seem to be
+    * the "right" solution). */
    gl_printMaxRawBase( ft_font, max, x - 1, y, &cBlack, text, 1 );
    gl_printMaxRawBase( ft_font, max, x + 1, y, &cBlack, text, 1 );
    gl_printMaxRawBase( ft_font, max, x, y - 1, &cBlack, text, 1 );
@@ -772,6 +780,10 @@ int gl_printMidRaw( const glFont *ft_font, const int width,
       double x, const double y,
       const glColour* c, const char *text )
 {
+   /* TODO: This method works, but is inefficient. Should probably be
+    * ultimately replaced with use of signed distance fields or some
+    * other more efficient method (signed distance fields seem to be
+    * the "right" solution). */
    gl_printMidRawBase( ft_font, width, x - 1, y, &cBlack, text, 1 );
    gl_printMidRawBase( ft_font, width, x + 1, y, &cBlack, text, 1 );
    gl_printMidRawBase( ft_font, width, x, y - 1, &cBlack, text, 1 );
@@ -904,6 +916,10 @@ int gl_printTextRaw( const glFont *ft_font,
       double bx, double by,
       const glColour* c, const char *text )
 {
+   /* TODO: This method works, but is inefficient. Should probably be
+    * ultimately replaced with use of signed distance fields or some
+    * other more efficient method (signed distance fields seem to be
+    * the "right" solution). */
    gl_printTextRawBase( ft_font, width, height, bx - 1, by, &cBlack, text, 1 );
    gl_printTextRawBase( ft_font, width, height, bx + 1, by, &cBlack, text, 1 );
    gl_printTextRawBase( ft_font, width, height, bx, by - 1, &cBlack, text, 1 );

--- a/src/gui.c
+++ b/src/gui.c
@@ -1358,6 +1358,12 @@ void gui_renderAsteroid( const Asteroid* a, double w, double h, double res, int 
 void gui_renderPlayer( double res, int overlay )
 {
    double x, y, r;
+   glColour textCol = { cRadar_player.r, cRadar_player.g, cRadar_player.b, 0.99 };
+   /* XXX: textCol is a hack to prevent the text from overly obscuring
+    * overlay display of other things. Effectively disables outlines for
+    * the text. Should ultimately be replaced with some other method of
+    * rendering the text, since the problem could be caused by as little
+    * as a font change, but using this fix for now. */
 
    if (overlay) {
       x = player.p->solid->pos.x / res + SCREEN_W / 2;
@@ -1374,7 +1380,7 @@ void gui_renderPlayer( double res, int overlay )
    gl_renderCross( x, y, r, &cRadar_player );
 
    if (overlay)
-      gl_printRaw( &gl_smallFont, x+r+5., y-gl_smallFont.h/2., &cRadar_player, _("You") );
+      gl_printRaw( &gl_smallFont, x+r+5., y-gl_smallFont.h/2., &textCol, _("You") );
 }
 
 
@@ -1556,6 +1562,12 @@ void gui_renderPlanet( int ind, RadarShape shape, double w, double h, double res
    gl_endSolidProgram();
 
    /* Render name. */
+   /* XXX: Hack to prevent the text from overly obscuring overlay
+    * display of other things. Effectively disables outlines for this
+    * text. Should ultimately be replaced with some other method of
+    * rendering the text, since the problem could be caused by as little
+    * as a font change, but using this fix for now. */
+   col.a = MIN( col.a, 0.99 );
    if (overlay)
       gl_printRaw( &gl_smallFont, cx+vr+5., cy, &col, planet->name );
 }
@@ -1644,6 +1656,12 @@ void gui_renderJumpPoint( int ind, RadarShape shape, double w, double h, double 
    gl_endSolidProgram();
 
    /* Render name. */
+   /* XXX: Hack to prevent the text from overly obscuring overlay
+    * display of other things. Effectively disables outlines for this
+    * text. Should ultimately be replaced with some other method of
+    * rendering the text, since the problem could be caused by as little
+    * as a font change, but using this fix for now. */
+   col.a = MIN( col.a, 0.99 );
    if (overlay)
       gl_printRaw( &gl_smallFont, cx+vr+5., cy, &col, sys_isKnown(jp->target) ? jp->target->name : _("Unknown") );
 }

--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -483,7 +483,7 @@ void osd_render (void)
       for (i=ll->active; i<ll->nitems; i++) {
          x = osd_x;
          w = osd_w;
-         c = (ll->active == i) ? NULL : &cGrey70;
+         c = (ll->active == i) ? &cFontWhite : &cFontGrey;
          for (j=0; j<ll->items[i].nchunks; j++) {
             gl_printMaxRaw( &gl_smallFont, w, x, p,
                   c, ll->items[i].chunks[j] );

--- a/src/info.c
+++ b/src/info.c
@@ -197,7 +197,7 @@ static void info_openMain( unsigned int wid )
    /* pilot generics */
    nt = ntime_pretty( ntime_get(), 2 );
    window_addText( wid, 40, 20, 120, h-80,
-         0, "txtDPilot", &gl_smallFont, &cBlack,
+         0, "txtDPilot", &gl_smallFont, NULL,
          _("Pilot:\n"
          "Date:\n"
          "Combat Rating:\n"
@@ -223,7 +223,7 @@ static void info_openMain( unsigned int wid )
          player.p->fuel, pilot_getJumps(player.p) );
    window_addText( wid, 140, 20,
          200, h-80,
-         0, "txtPilot", &gl_smallFont, &cBlack, str );
+         0, "txtPilot", &gl_smallFont, NULL, str );
    free(nt);
 
    /* menu */
@@ -240,7 +240,7 @@ static void info_openMain( unsigned int wid )
    for (i=0; i<nlicenses; i++)
       licenses[i] = strdup(buf[i]);
    window_addText( wid, -20, -40, w-80-200-40, 20, 1, "txtList",
-         NULL, &cBlack, _("Licenses") );
+         NULL, NULL, _("Licenses") );
    window_addList( wid, -20, -70, w-80-200-40, h-110-BUTTON_HEIGHT,
          "lstLicenses", licenses, nlicenses, 0, NULL );
 }
@@ -390,7 +390,7 @@ static void info_openShip( unsigned int wid )
 
    /* Text. */
    window_addText( wid, 40, -60, 100, h-60, 0, "txtSDesc", &gl_smallFont,
-         &cBlack,
+         NULL,
          _("Name:\n"
          "Model:\n"
          "Class:\n"
@@ -414,7 +414,7 @@ static void info_openShip( unsigned int wid )
          "Stats:\n")
          );
    window_addText( wid, 140, -60, w-300., h-60, 0, "txtDDesc", &gl_smallFont,
-         &cBlack, NULL );
+         NULL, NULL );
 
    /* Custom widget. */
    equipment_slotWidget( wid, -20, -40, 180, h-60, &info_eq );
@@ -697,19 +697,19 @@ static void weapons_renderLegend( double bx, double by, double bw, double bh, vo
    double y;
 
    y = by+bh-20;
-   gl_print( &gl_defFont, bx, y, &cBlack, _("Legend") );
+   gl_print( &gl_defFont, bx, y, &cFontWhite, _("Legend") );
 
    y -= 20.;
    toolkit_drawRect( bx, y, 10, 10, &cFontBlue, NULL );
-   gl_print( &gl_smallFont, bx+20, y, &cBlack, _("Outfit that can be activated") );
+   gl_print( &gl_smallFont, bx+20, y, &cFontWhite, _("Outfit that can be activated") );
 
    y -= 15.;
    toolkit_drawRect( bx, y, 10, 10, &cFontYellow, NULL );
-   gl_print( &gl_smallFont, bx+20, y, &cBlack, _("Secondary Weapon (Right click toggles)") );
+   gl_print( &gl_smallFont, bx+20, y, &cFontWhite, _("Secondary Weapon (Right click toggles)") );
 
    y -= 15.;
    toolkit_drawRect( bx, y, 10, 10, &cFontRed, NULL );
-   gl_print( &gl_smallFont, bx+20, y, &cBlack, _("Primary Weapon (Left click toggles)") );
+   gl_print( &gl_smallFont, bx+20, y, &cFontWhite, _("Primary Weapon (Left click toggles)") );
 }
 
 
@@ -914,9 +914,9 @@ static void info_openStandings( unsigned int wid )
 
    /* Text. */
    window_addText( wid, lw+40, 0, (w-(lw+60)), 20, 1, "txtName",
-         &gl_defFont, &cBlack, NULL );
+         &gl_defFont, NULL, NULL );
    window_addText( wid, lw+40, 0, (w-(lw+60)), 20, 1, "txtStanding",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
 
    /* Gets the faction standings. */
    info_factions  = faction_getKnown( &n );
@@ -1003,12 +1003,12 @@ static void info_openMissions( unsigned int wid )
    /* text */
    window_addText( wid, 300+40, -60,
          200, 40, 0, "txtSReward",
-         &gl_smallFont, &cBlack, _("Reward:") );
+         &gl_smallFont, NULL, _("Reward:") );
    window_addText( wid, 300+100, -60,
-         140, 40, 0, "txtReward", &gl_smallFont, &cBlack, NULL );
+         140, 40, 0, "txtReward", &gl_smallFont, NULL, NULL );
    window_addText( wid, 300+40, -100,
          w - (300+40+40), h - BUTTON_HEIGHT - 120, 0,
-         "txtDesc", &gl_smallFont, &cBlack, NULL );
+         "txtDesc", &gl_smallFont, NULL, NULL );
 
    /* Put a map. */
    map_show( wid, 20, 20, 300, 260, 0.75 );
@@ -1296,15 +1296,15 @@ static void info_openShipLog( unsigned int wid )
    texth = gl_printHeightRaw( &gl_smallFont, w, "Select log type" );
    window_addText( wid, 20, 80 + BUTTON_HEIGHT + LOGSPACING,
                    w - 40, texth, 0,
-                   "logDesc1", &gl_smallFont, &cBlack, _("Select log type:") );
+                   "logDesc1", &gl_smallFont, NULL, _("Select log type:") );
    
    window_addText( wid, 20, 60 + BUTTON_HEIGHT + 3* LOGSPACING / 4,
                    w - 40, texth, 0,
-                   "logDesc2", &gl_smallFont, &cBlack, _("Select title of log of interest:") );
+                   "logDesc2", &gl_smallFont, NULL, _("Select title of log of interest:") );
 
    window_addText( wid, 20, 40 + BUTTON_HEIGHT + LOGSPACING / 2,
                    w - 40, texth, 0,
-                   "logDesc3", &gl_smallFont, &cBlack, _("Log entries:") );
+                   "logDesc3", &gl_smallFont, NULL, _("Log entries:") );
 
 #undef LOGSPACING
    /* list */

--- a/src/info.c
+++ b/src/info.c
@@ -1129,22 +1129,14 @@ static void shiplog_menu_update( unsigned int wid, char* str )
    int logType,log, logMsg;
    int nentries;
    char **logentries;
-   char *tmp;
+
    if(!logWidgetsReady)
       return;
+
    /*This is called when something is selected.
      If a new log type has been selected, need to regenerate the log lists.
      If a new log has been selected, need to regenerate the entries.*/
-   if ( !strcmp(str, "lstLogEntries" ) ) {
-      /* Has selected a log entry, so display it */
-      logMsg = toolkit_getListPos( wid, "lstLogEntries");
-      if ( logMsg == selectedLogMsg ) {
-         /* If already selected, show...*/
-         tmp = toolkit_getList ( wid, "lstLogEntries");
-         if ( tmp != NULL ) {
-            dialogue_msgRaw( _("Log message"),tmp);
-         }
-      }
+   if ( strcmp(str, "lstLogEntries" ) == 0 ) {
       selectedLogMsg = logMsg;
    } else {
       /* has selected a type of log or a log */
@@ -1236,14 +1228,14 @@ static void info_shiplogMenuDelete( unsigned int wid, char* str )
    int ret, logid;
    (void) str;
 
-   if ( !strcmp("All",logs[selectedLog] )) { /* All logs of selected type */
-      if ( !strcmp("All",logTypes[selectedLogType]) ) { /* All logs! */
+   if ( strcmp("All", logs[selectedLog]) == 0 ) { /* All logs of selected type */
+      if ( strcmp("All", logTypes[selectedLogType]) == 0 ) { /* All logs! */
          ret = dialogue_YesNoRaw( _("Delete all mission logs?"), _("Are you sure?  Really?") );
          if ( ret ) {
             shiplog_clear();
             selectedLog = 0;
             selectedLogType = 0;
-            shiplog_menu_genList(wid,0);
+            shiplog_menu_genList(wid, 0);
          }
       } else {
          nsnprintf(buf, 256, "Delete all logs of type %s?", logTypes[selectedLogType]);
@@ -1261,7 +1253,7 @@ static void info_shiplogMenuDelete( unsigned int wid, char* str )
       if ( ret ) {
          /* There could be several logs of the same name, so make sure we get the correct one. */
          /* selectedLog-1 since not including the "All" */
-         logid = shiplog_getIdOfLogOfType ( logTypes[selectedLogType], selectedLog-1 );
+         logid = shiplog_getIdOfLogOfType( logTypes[selectedLogType], selectedLog-1 );
          if ( logid >= 0 )
             shiplog_delete( logid );
          selectedLog = 0;
@@ -1269,6 +1261,16 @@ static void info_shiplogMenuDelete( unsigned int wid, char* str )
          shiplog_menu_genList(wid, 0);
       }
    }
+}
+
+static void info_shiplogView( unsigned int wid, char *str )
+{
+   char *tmp;
+   (void) str;
+
+   tmp = toolkit_getList( wid, "lstLogEntries");
+   if ( tmp != NULL )
+      dialogue_msgRaw( _("Log message"), tmp);
 }
 
 
@@ -1292,6 +1294,9 @@ static void info_openShipLog( unsigned int wid )
    window_addButton( wid, -40 - BUTTON_WIDTH, 20,
          BUTTON_WIDTH, BUTTON_HEIGHT, "btnDeleteLog", _("Delete"),
          info_shiplogMenuDelete );
+   window_addButton( wid, -60 - BUTTON_WIDTH * 2, 20, BUTTON_WIDTH,
+         BUTTON_HEIGHT, "btnViewLog", _("View Entry"),
+         info_shiplogView );
    /* Description text */
    texth = gl_printHeightRaw( &gl_smallFont, w, "Select log type" );
    window_addText( wid, 20, 80 + BUTTON_HEIGHT + LOGSPACING,

--- a/src/intro.c
+++ b/src/intro.c
@@ -335,7 +335,7 @@ static int intro_draw_text( scroll_buf_t *sb_list, double offset,
    do {
       if (NULL != list_iter->text) {
          stop = 0;
-         gl_print( &intro_font, x, y, &cConsole, list_iter->text );
+         gl_print( &intro_font, x, y, &cFontGreen, list_iter->text );
       }
 
       y -= line_height;

--- a/src/land.c
+++ b/src/land.c
@@ -299,20 +299,20 @@ static void bar_open( unsigned int wid )
    /* Bar description. */
    window_addText( wid, iw + 40, -40,
          w - iw - 60, dh, 0,
-         "txtDescription", &gl_smallFont, &cBlack,
+         "txtDescription", &gl_smallFont, NULL,
          land_planet->bar_description );
 
    /* Add portrait text. */
    th = -40 - dh - 40;
    window_addText( wid, iw + 40, th,
          w - iw - 60, gl_defFont.h, 1,
-         "txtPortrait", &gl_defFont, &cBlack, NULL );
+         "txtPortrait", &gl_defFont, NULL, NULL );
 
    /* Add mission description text. */
    th -= 20 + PORTRAIT_HEIGHT + 20 + 20;
    window_addText( wid, iw + 60, th,
          w - iw - 100, h + th - (2*bh+60), 0,
-         "txtMission", &gl_smallFont, &cBlack, NULL );
+         "txtMission", &gl_smallFont, NULL, NULL );
 
    /* Generate the mission list. */
    bar_genList( wid );
@@ -559,23 +559,23 @@ static void misn_open( unsigned int wid )
    y = -60;
    window_addText( wid, w/2 + 10, y,
          w/2 - 30, 40, 0,
-         "txtSDate", NULL, &cBlack,
+         "txtSDate", NULL, NULL,
          _("Date:\n"
          "Free Space:"));
    window_addText( wid, w/2 + 110, y,
          w/2 - 90, 40, 0,
-         "txtDate", NULL, &cBlack, NULL );
+         "txtDate", NULL, NULL, NULL );
    y -= 2 * gl_defFont.h + 50;
    window_addText( wid, w/2 + 10, y,
          w/2 - 30, 20, 0,
-         "txtSReward", &gl_smallFont, &cBlack, _("Reward:") );
+         "txtSReward", &gl_smallFont, NULL, _("Reward:") );
    window_addText( wid, w/2 + 70, y,
          w/2 - 90, 20, 0,
-         "txtReward", &gl_smallFont, &cBlack, NULL );
+         "txtReward", &gl_smallFont, NULL, NULL );
    y -= 20;
    window_addText( wid, w/2 + 10, y,
          w/2 - 30, h/2-90, 0,
-         "txtDesc", &gl_smallFont, &cBlack, NULL );
+         "txtDesc", &gl_smallFont, NULL, NULL );
 
    /* map */
    map_show( wid, 20, 20,
@@ -1156,7 +1156,7 @@ static void land_createMainTab( unsigned int wid )
    window_addImage( wid, 20, -40, 400, 400, "imgPlanet", gfx_exterior, 1 );
    window_addText( wid, 440, -20-offset,
          w-460, h-20-offset-60-LAND_BUTTON_HEIGHT*2, 0,
-         "txtPlanetDesc", &gl_smallFont, &cBlack, land_planet->description);
+         "txtPlanetDesc", &gl_smallFont, NULL, land_planet->description);
 
    /*
     * buttons
@@ -1170,7 +1170,7 @@ static void land_createMainTab( unsigned int wid )
    if (!planet_hasService(land_planet, PLANET_SERVICE_REFUEL)) {
       window_addText( land_windows[0], -20, 20 + (LAND_BUTTON_HEIGHT + 20) + 20,
                200, gl_defFont.h, 1, "txtRefuel",
-               &gl_defFont, &cBlack, _("No refueling services.") );
+               &gl_defFont, NULL, _("No refueling services.") );
    }
 }
 

--- a/src/land_outfits.c
+++ b/src/land_outfits.c
@@ -136,11 +136,11 @@ void outfits_open( unsigned int wid )
 
    /* the descriptive text */
    window_addText( wid, 20 + iw + 20 + 128 + 20, -60,
-         280, 160, 0, "txtOutfitName", &gl_defFont, &cBlack, NULL );
+         280, 160, 0, "txtOutfitName", &gl_defFont, NULL, NULL );
    window_addText( wid, 20 + iw + 20 + 128 + 20, -60 - gl_defFont.h - 20,
-         280, 320, 0, "txtDescShort", &gl_smallFont, &cBlack, NULL );
+         280, 320, 0, "txtDescShort", &gl_smallFont, NULL, NULL );
    window_addText( wid, 20 + iw + 20, -60-128-10,
-         60, 160, 0, "txtSDesc", &gl_smallFont, &cBlack,
+         60, 160, 0, "txtSDesc", &gl_smallFont, NULL,
          _("Owned:\n"
          "\n"
          "Slot:\n"
@@ -151,7 +151,7 @@ void outfits_open( unsigned int wid )
          "Money:\n"
          "License:\n") );
    window_addText( wid, 20 + iw + 20 + 60, -60-128-10,
-         250, 160, 0, "txtDDesc", &gl_smallFont, &cBlack, NULL );
+         250, 160, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
    window_addText( wid, 20 + iw + 20, -60-128-10-160,
          w-(iw+80), 180, 0, "txtDescription",
          &gl_smallFont, NULL, NULL );
@@ -801,7 +801,7 @@ static void outfits_renderMod( double bx, double by, double w, double h, void *d
    if (q==1) return; /* Ignore no modifier. */
 
    nsnprintf( buf, 8, "%dx", q );
-   gl_printMid( &gl_smallFont, w, bx, by, &cBlack, buf );
+   gl_printMid( &gl_smallFont, w, bx, by, &cFontWhite, buf );
 }
 
 

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -109,7 +109,7 @@ void shipyard_open( unsigned int wid )
 
    /* stat text */
    window_addText( wid, -40, -240, 128, 400, 0, "txtStats",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
 
    /* text */
    buf = _("Model:\n"
@@ -137,9 +137,9 @@ void shipyard_open( unsigned int wid )
    th = gl_printHeightRaw( &gl_smallFont, 100, buf );
    y  = -55;
    window_addText( wid, 40+iw+20, y,
-         100, th, 0, "txtSDesc", &gl_smallFont, &cBlack, buf );
+         100, th, 0, "txtSDesc", &gl_smallFont, NULL, buf );
    window_addText( wid, 40+iw+20+100, y,
-         w-(40+iw+20+100)-20, th, 0, "txtDDesc", &gl_smallFont, &cBlack, NULL );
+         w-(40+iw+20+100)-20, th, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
    y -= th;
    window_addText( wid, 20+iw+40, y,
          w-(20+iw+40) - 180, 185, 0, "txtDescription",
@@ -565,7 +565,7 @@ static void shipyard_renderSlots( double bx, double by, double bw, double bh, vo
 
    /* Draw rotated text. */
    y -= 10;
-   gl_print( &gl_smallFont, bx, y, &cBlack, _("Slots:") );
+   gl_print( &gl_smallFont, bx, y, &cFontWhite, _("Slots:") );
 
    x = bx + 10.;
    w = bw - 10.;
@@ -597,7 +597,7 @@ static void shipyard_renderSlotsRow( double bx, double by, double bw, char *str,
    x = bx;
 
    /* Print text. */
-   gl_print( &gl_smallFont, bx, by, &cBlack, str );
+   gl_print( &gl_smallFont, bx, by, &cFontWhite, str );
 
    /* Draw squares. */
    for (i=0; i<n; i++) {
@@ -609,8 +609,3 @@ static void shipyard_renderSlotsRow( double bx, double by, double bw, char *str,
       toolkit_drawRect( x, by, 10, 10, c, NULL );
    }
 }
-
-
-
-
-

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -572,15 +572,15 @@ static void shipyard_renderSlots( double bx, double by, double bw, double bh, vo
 
    /* Weapon slots. */
    y -= 20;
-   shipyard_renderSlotsRow( x, y, w, _("W"), ship->outfit_weapon, ship->outfit_nweapon );
+   shipyard_renderSlotsRow( x, y, w, "W", ship->outfit_weapon, ship->outfit_nweapon );
 
    /* Utility slots. */
    y -= 20;
-   shipyard_renderSlotsRow( x, y, w, _("U"), ship->outfit_utility, ship->outfit_nutility );
+   shipyard_renderSlotsRow( x, y, w, "U", ship->outfit_utility, ship->outfit_nutility );
 
    /* Structure slots. */
    y -= 20;
-   shipyard_renderSlotsRow( x, y, w, _("S"), ship->outfit_structure, ship->outfit_nstructure );
+   shipyard_renderSlotsRow( x, y, w, "S", ship->outfit_structure, ship->outfit_nstructure );
 }
 
 

--- a/src/land_trade.c
+++ b/src/land_trade.c
@@ -82,7 +82,7 @@ void commodity_exchange_open( unsigned int wid )
 
    /* text */
    window_addText( wid, -20, -190, LAND_BUTTON_WIDTH, 100, 0,
-         "txtSInfo", &gl_smallFont, &cBlack,
+         "txtSInfo", &gl_smallFont, NULL,
          _("You have:\n"
            "Purchased at:\n"
            "Market Price:\n"
@@ -91,10 +91,10 @@ void commodity_exchange_open( unsigned int wid )
            "Av price here:\n"
            "Av price all:") );
    window_addText( wid, -20, -190, LAND_BUTTON_WIDTH/2, 100, 0,
-         "txtDInfo", &gl_smallFont, &cBlack, NULL );
+         "txtDInfo", &gl_smallFont, NULL, NULL );
    window_addText( wid, -40, -300, LAND_BUTTON_WIDTH-20,
          h-140-LAND_BUTTON_HEIGHT, 0,
-         "txtDesc", &gl_smallFont, &cBlack, NULL );
+         "txtDesc", &gl_smallFont, NULL, NULL );
 
    /* goods list */
    if (land_planet->ncommodities > 0) {
@@ -372,5 +372,5 @@ void commodity_renderMod( double bx, double by, double w, double h, void *data )
       commodity_mod = q;
    }
    nsnprintf( buf, 8, "%dx", q );
-   gl_printMid( &gl_smallFont, w, bx, by, &cBlack, buf );
+   gl_printMid( &gl_smallFont, w, bx, by, &cFontWhite, buf );
 }

--- a/src/load.c
+++ b/src/load.c
@@ -335,7 +335,7 @@ void load_loadGameMenu (void)
 
    /* Player text. */
    window_addText( wid, -20, -40, 200, LOAD_HEIGHT-40-20-2*(BUTTON_HEIGHT+20),
-         0, "txtPilot", NULL, &cBlack, NULL );
+         0, "txtPilot", NULL, NULL, NULL );
 
    window_addList( wid, 20, -50,
          LOAD_WIDTH-200-60, LOAD_HEIGHT-110,

--- a/src/map.c
+++ b/src/map.c
@@ -245,7 +245,7 @@ void map_open (void)
 
    /* System Name */
    window_addText( wid, -90 + 80, y, 160, 20, 1, "txtSysname",
-         &gl_defFont, &cBlack, cur->name );
+         &gl_defFont, NULL, cur->name );
    y -= 10;
 
    /* Faction image */
@@ -254,37 +254,37 @@ void map_open (void)
 
    /* Faction */
    window_addText( wid, x, y, 90, 20, 0, "txtSFaction",
-         &gl_smallFont, &cBlack, _("Faction:") );
+         &gl_smallFont, NULL, _("Faction:") );
    window_addText( wid, x + 50, y-gl_smallFont.h-5, rw, 100, 0, "txtFaction",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
    y -= 2 * gl_smallFont.h + 5 + 15;
 
    /* Standing */
    window_addText( wid, x, y, 90, 20, 0, "txtSStanding",
-         &gl_smallFont, &cBlack, _("Standing:") );
+         &gl_smallFont, NULL, _("Standing:") );
    window_addText( wid, x + 50, y-gl_smallFont.h-5, rw, 100, 0, "txtStanding",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
    y -= 2 * gl_smallFont.h + 5 + 15;
 
    /* Presence. */
    window_addText( wid, x, y, 90, 20, 0, "txtSPresence",
-         &gl_smallFont, &cBlack, _("Presence:") );
+         &gl_smallFont, NULL, _("Presence:") );
    window_addText( wid, x + 50, y-gl_smallFont.h-5, rw, 100, 0, "txtPresence",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
    y -= 2 * gl_smallFont.h + 5 + 15;
 
    /* Planets */
    window_addText( wid, x, y, 90, 20, 0, "txtSPlanets",
-         &gl_smallFont, &cBlack, _("Planets:") );
+         &gl_smallFont, NULL, _("Planets:") );
    window_addText( wid, x + 50, y-gl_smallFont.h-5, rw, 150, 0, "txtPlanets",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
    y -= 2 * gl_smallFont.h + 5 + 15;
 
    /* Services */
    window_addText( wid, x, y, 90, 20, 0, "txtSServices",
-         &gl_smallFont, &cBlack, _("Services:") );
+         &gl_smallFont, NULL, _("Services:") );
    window_addText( wid, x + 50, y-gl_smallFont.h-5, rw, 100, 0, "txtServices",
-         &gl_smallFont, &cBlack, NULL );
+         &gl_smallFont, NULL, NULL );
 
    /* Close button */
    window_addButton( wid, -20, 20, BUTTON_WIDTH, BUTTON_HEIGHT,
@@ -308,7 +308,7 @@ void map_open (void)
    window_addButton( wid, 80, 20, 30, 30, "btnZoomOut", "-", map_buttonZoom );
    /* Situation text */
    window_addText( wid, 140, 10, w - 80 - 30 - 30 - 60, 30, 0,
-                   "txtSystemStatus", &gl_smallFont, &cBlack, NULL );
+                   "txtSystemStatus", &gl_smallFont, NULL, NULL );
 
    map_genModeList();
 

--- a/src/map.c
+++ b/src/map.c
@@ -560,7 +560,7 @@ static void map_update( unsigned int wid )
          /* Use map grey instead of default neutral colour */
          l += nsnprintf( &buf[l], PATH_MAX-l, "%s\a0%s: \a%c%.0f",
                         (l==0)?"":"\n", faction_shortname(sys->presence[i].faction),
-                        (t=='N')?'M':t, sys->presence[i].value);
+                        t, sys->presence[i].value);
       }
       else
          unknownPresence += sys->presence[i].value;
@@ -569,7 +569,7 @@ static void map_update( unsigned int wid )
    }
    if (unknownPresence != 0)
       l += nsnprintf( &buf[l], PATH_MAX-l, "%s\a0%s: \a%c%.0f",
-                     (l==0)?"":"\n", _("Unknown"), 'M', unknownPresence);
+                     (l==0)?"":"\n", _("Unknown"), 'N', unknownPresence);
    if (hasPresence == 0)
       nsnprintf(buf, PATH_MAX, "N/A");
    window_moveWidget( wid, "txtSPresence", x, y );
@@ -592,10 +592,6 @@ static void map_update( unsigned int wid )
       /* Colourize output. */
       planet_updateLand(sys->planets[i]);
       t = planet_getColourChar(sys->planets[i]);
-      if (t == 'N')
-         t = 'M';
-      else if (t == 'R')
-         t = 'S';
 
       if (!hasPlanets)
          p += nsnprintf( &buf[p], PATH_MAX-p, "\a%c%s\an",

--- a/src/map.c
+++ b/src/map.c
@@ -392,12 +392,13 @@ static void map_update_commod_av_price()
 static void map_update( unsigned int wid )
 {
    int i;
-   StarSystem* sys;
+   StarSystem *sys;
    int f, h, x, y;
    unsigned int services;
    int l;
    int hasPresence, hasPlanets;
    char t;
+   const char *sym;
    char buf[PATH_MAX];
    int p;
    glTexture *logo;
@@ -556,7 +557,7 @@ static void map_update( unsigned int wid )
          continue;
       hasPresence = 1;
       if (faction_isKnown( sys->presence[i].faction )) {
-         t           = faction_getColourChar(sys->presence[i].faction);
+         t = faction_getColourChar(sys->presence[i].faction);
          /* Use map grey instead of default neutral colour */
          l += nsnprintf( &buf[l], PATH_MAX-l, "%s\a0%s: \a%c%.0f",
                         (l==0)?"":"\n", faction_shortname(sys->presence[i].faction),
@@ -592,13 +593,14 @@ static void map_update( unsigned int wid )
       /* Colourize output. */
       planet_updateLand(sys->planets[i]);
       t = planet_getColourChar(sys->planets[i]);
+      sym = planet_getSymbol(sys->planets[i]);
 
       if (!hasPlanets)
-         p += nsnprintf( &buf[p], PATH_MAX-p, "\a%c%s\an",
-               t, sys->planets[i]->name );
+         p += nsnprintf( &buf[p], PATH_MAX-p, "\a%c%s%s\an",
+               t, sym, sys->planets[i]->name );
       else
-         p += nsnprintf( &buf[p], PATH_MAX-p, ",\n\a%c%s\an",
-               t, sys->planets[i]->name );
+         p += nsnprintf( &buf[p], PATH_MAX-p, ",\n\a%c%s%s\an",
+               t, sym, sys->planets[i]->name );
       hasPlanets = 1;
       if (p > PATH_MAX)
          break;
@@ -1608,7 +1610,7 @@ static int map_mouse( unsigned int wid, SDL_Event* event, double mx, double my,
             
             if ((pow2(mx-x)+pow2(my-y)) < t) {
                if (map_selected != -1) {
-                  if ( sys == system_getIndex( map_selected ) ){
+                  if ( sys == system_getIndex( map_selected ) ) {
                      map_system_open( map_selected );
                      map_drag = 0;
                   }

--- a/src/map_find.c
+++ b/src/map_find.c
@@ -589,12 +589,6 @@ static char map_getPlanetColourChar( Planet *p )
    planet_updateLand(p);
    colcode = planet_getColourChar(p);
 
-   /* Remap colour codes bit for simplicity and contrast. */
-   if (colcode == 'N' || colcode == 'F')
-      colcode = 'M';
-   else if (colcode == 'R')
-      colcode = 'S';
-
    return colcode;
 }
 

--- a/src/map_find.c
+++ b/src/map_find.c
@@ -660,11 +660,11 @@ static void map_addOutfitDetailFields(unsigned int wid, int x, int y, int w, int
    window_addImage( wid, iw, -50-128, 0, 0, "imgOutfit", NULL, 1 );
 
    window_addText( wid, iw + 128 + 20, -60,
-         280, 160, 0, "txtOutfitName", &gl_defFont, &cBlack, NULL );
+         280, 160, 0, "txtOutfitName", &gl_defFont, NULL, NULL );
    window_addText( wid, iw + 128 + 20, -60 - gl_defFont.h - 20,
-         280, 160, 0, "txtDescShort", &gl_smallFont, &cBlack, NULL );
+         280, 160, 0, "txtDescShort", &gl_smallFont, NULL, NULL );
    window_addText( wid, iw+20, -60-128-10,
-         60, 160, 0, "txtSDesc", &gl_smallFont, &cBlack,
+         60, 160, 0, "txtSDesc", &gl_smallFont, NULL,
          _("Owned:\n"
          "\n"
          "Slot:\n"
@@ -675,7 +675,7 @@ static void map_addOutfitDetailFields(unsigned int wid, int x, int y, int w, int
          "Money:\n"
          "License:\n") );
    window_addText( wid, iw+20, -60-128-10,
-         280, 160, 0, "txtDDesc", &gl_smallFont, &cBlack, NULL );
+         280, 160, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
    window_addText( wid, iw+20, -60-128-10-160,
          w-(iw+80), 180, 0, "txtDescription",
          &gl_smallFont, NULL, NULL );
@@ -1077,7 +1077,7 @@ void map_inputFind( unsigned int parent, char* str )
    /* Text. */
    y = -40;
    window_addText( wid, 20, y, 300, gl_defFont.h+4, 0,
-         "txtDescription", &gl_defFont, &cBlack,
+         "txtDescription", &gl_defFont, NULL,
          _("Enter keyword to search for:") );
    y -= 30;
 

--- a/src/map_overlay.c
+++ b/src/map_overlay.c
@@ -192,6 +192,12 @@ void ovr_render( double dt )
    double w, h, res;
    double x,y;
    glColour c = { .r=0., .g=0., .b=0., .a=0.5 };
+   glColour textCol = { cRadar_hilight.r, cRadar_hilight.g, cRadar_hilight.b, 0.99 };
+   /* XXX: textCol is a hack to prevent the text from overly obscuring
+    * overlay display of other things. Effectively disables outlines for
+    * the text. Should ultimately be replaced with some other method of
+    * rendering the text, since the problem could be caused by as little
+    * as a font change, but using this fix for now. */
 
    /* Must be open. */
    if (!ovr_open)
@@ -243,7 +249,7 @@ void ovr_render( double dt )
       x = player.autonav_pos.x / res + w / 2.;
       y = player.autonav_pos.y / res + h / 2.;
       gl_renderCross( x, y, 5., &cRadar_hilight );
-      gl_printRaw( &gl_smallFont, x+10., y-gl_smallFont.h/2., &cRadar_hilight, _("GOTO") );
+      gl_printRaw( &gl_smallFont, x+10., y-gl_smallFont.h/2., &textCol, _("GOTO") );
    }
 
    /* render the asteroids */
@@ -271,6 +277,12 @@ static void ovr_mrkRenderAll( double res )
    int i;
    ovr_marker_t *mrk;
    double x, y;
+   glColour textCol = { cRadar_hilight.r, cRadar_hilight.g, cRadar_hilight.b, 0.99 };
+   /* XXX: textCol is a hack to prevent the text from overly obscuring
+    * overlay display of other things. Effectively disables outlines for
+    * the text. Should ultimately be replaced with some other method of
+    * rendering the text, since the problem could be caused by as little
+    * as a font change, but using this fix for now. */
 
    if (ovr_markers == NULL)
       return;
@@ -283,7 +295,7 @@ static void ovr_mrkRenderAll( double res )
       gl_renderCross( x, y, 5., &cRadar_hilight );
 
       if (mrk->text != NULL)
-         gl_printRaw( &gl_smallFont, x+10., y-gl_smallFont.h/2., &cRadar_hilight, mrk->text );
+         gl_printRaw( &gl_smallFont, x+10., y-gl_smallFont.h/2., &textCol, mrk->text );
    }
 }
 

--- a/src/map_system.c
+++ b/src/map_system.c
@@ -187,7 +187,7 @@ void map_system_open( int sys_selected )
    window_setCancel( wid, map_system_close );
    window_handleKeys( wid, map_system_keyHandler );
    window_addText( wid, 40, h-30, 160, 20, 1, "txtSysname",
-         &gl_defFont, &cDConsole, cur_sys_sel->name );
+         &gl_defFont, &cFontGreen, cur_sys_sel->name );
    window_addImage( wid, -90 + 32, h-30, 0, 0, "imgFaction", NULL, 0 );
    /* Close button */
    window_addButton( wid, -20, 20, BUTTON_WIDTH, BUTTON_HEIGHT,
@@ -312,7 +312,8 @@ static void map_system_render( double bx, double by, double w, double h, void *d
 	   iw = iw * p->gfx_space->w / p->gfx_space->h;
 	 gl_blitScale( p->gfx_space, bx+2, by+(nshow-j-1)*pitch + (pitch-ih)/2 + offset, iw, ih, &cWhite );
        }
-       gl_printRaw( &gl_smallFont,bx+5+pitch, by+(nshow-j-0.5)*pitch + offset,cur_planet_sel==j?&cGreen:&cWhite, p->name );
+       gl_printRaw( &gl_smallFont, bx + 5 + pitch, by + (nshow-j-0.5)*pitch + offset,
+            (cur_planet_sel == j ? &cFontGreen : &cFontWhite), p->name );
      }
    }
    /* draw the star */
@@ -348,9 +349,11 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    }else{
       /* no nebula or star images - probably due to nebula */
       txtHeight=gl_printHeightRaw( &gl_smallFont,pitch,_("Obscured by the nebula") );
-      gl_printTextRaw( &gl_smallFont, pitch, txtHeight, (bx+2), (by+(nshow-0.5)*pitch + offset), &cRed, _("Obscured by the nebula") );
+      gl_printTextRaw( &gl_smallFont, pitch, txtHeight, (bx+2),
+            (by + (nshow-0.5)*pitch + offset), &cFontRed, _("Obscured by the nebula") );
    }
-   gl_printRaw( &gl_smallFont,bx+5+pitch, by+(nshow-0.5)*pitch + offset,cur_planet_sel==0?&cGreen:&cWhite, sys->name );
+   gl_printRaw( &gl_smallFont, bx + 5 + pitch, by + (nshow-0.5)*pitch + offset,
+         (cur_planet_sel == 0 ? &cFontGreen : &cFontWhite), sys->name );
    if ( cur_planet_sel == 0 && nBgImgs > 0 ){
       /* make use of space to draw a nice nebula */
       double imgw,imgh;
@@ -444,7 +447,8 @@ static void map_system_render( double bx, double by, double w, double h, void *d
          /* display the logo */
          logo = faction_logoSmall( f );
          if ( logo != NULL ){
-            gl_blitScale( logo, bx+pitch+nameWidth+200, by+h-21, 20, 20, &cWhite );
+            gl_blitScale( logo, bx + pitch + nameWidth + 200,
+                  by + h - 21, 20, 20, &cWhite );
          }
       }
       /* Get presence. */
@@ -468,7 +472,8 @@ static void map_system_render( double bx, double by, double w, double h, void *d
       if (hasPresence == 0)
          cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Presence: N/A\n"));
       txtHeight=gl_printHeightRaw(&gl_smallFont,(w - nameWidth-pitch-60)/2,buf);
-      gl_printTextRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, txtHeight, bx+10+pitch+nameWidth, by + h - 10-txtHeight, &cWhite, buf );
+      gl_printTextRaw( &gl_smallFont, (w - nameWidth - pitch - 60) / 2, txtHeight,
+            bx + 10 + pitch + nameWidth, by + h - 10 - txtHeight, &cFontWhite, buf );
       
       /* Jumps. */
       for(  i=0; i<sys->njumps; i++ ){
@@ -489,10 +494,11 @@ static void map_system_render( double bx, double by, double w, double h, void *d
         char factionBuf[64];
         logo = faction_logoSmall( p->faction );
         if ( logo != NULL ){
-           gl_blitScale( logo, bx+pitch+nameWidth+200, by+h-21, 20, 20, &cWhite );
+           gl_blitScale( logo, bx + pitch + nameWidth + 200, by + h - 21, 20, 20, &cWhite );
          }
         nsnprintf( factionBuf, 64, "%s", faction_shortname( p->faction ) );
-        gl_printTextRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, 20, bx+pitch+nameWidth+230, by + h - 31, &cWhite, factionBuf );
+        gl_printTextRaw( &gl_smallFont, (w - nameWidth-pitch - 60) / 2, 20,
+            bx+pitch+nameWidth + 230, by + h - 31, &cFontWhite, factionBuf );
 
      }
 
@@ -528,13 +534,15 @@ static void map_system_render( double bx, double by, double w, double h, void *d
            infocnt+=nsnprintf( &infobuf[infocnt], sizeof(infobuf)-infocnt, "\n\n%s", p->bar_description );
         }
      }
-     gl_printTextRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, txtHeight, bx+10+pitch+nameWidth, by + h - 10-txtHeight, &cWhite, buf );
+     gl_printTextRaw( &gl_smallFont, (w - nameWidth - pitch - 60) / 2, txtHeight,
+         bx + 10 + pitch + nameWidth, by + h - 10 - txtHeight, &cFontWhite, buf );
    }
 
    /* show the trade/outfit/ship info */
    if ( infobuf[0]!='\0' ){
       txtHeight=gl_printHeightRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, infobuf );
-      gl_printTextRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, txtHeight, bx+10+pitch+nameWidth, by + 10, &cGrey80, infobuf );
+      gl_printTextRaw( &gl_smallFont, (w - nameWidth - pitch - 60) / 2, txtHeight,
+            bx + 10 + pitch + nameWidth, by + 10, &cFontGrey, infobuf );
    }
 }
 

--- a/src/map_system.c
+++ b/src/map_system.c
@@ -114,7 +114,7 @@ int map_system_load( void )
  */
 void map_system_exit( void )
 {
-   for( unsigned int i=0; i<nBgImgs; i++ ){
+   for( unsigned int i=0; i<nBgImgs; i++ ) {
       gl_freeTexture( bgImages[i] );
    }
    nBgImgs = 0;
@@ -125,11 +125,11 @@ void map_system_exit( void )
 /**
  * @brief Close the map window.
  */
-void map_system_close( unsigned int wid, char *str ){
-   if ( cur_sys_sel != cur_system ){
+void map_system_close( unsigned int wid, char *str ) {
+   if ( cur_sys_sel != cur_system ) {
      space_gfxUnload( cur_sys_sel );
    }
-   for( unsigned int i=0; i<nBgImgs; i++ ){
+   for( unsigned int i=0; i<nBgImgs; i++ ) {
       gl_freeTexture( bgImages[i] );
    }
    nBgImgs = 0;
@@ -163,7 +163,7 @@ void map_system_open( int sys_selected )
    StarSystem *tmp_sys;
    /* Destroy window if exists. */
    wid = window_get( MAP_SYSTEM_WDWNAME );
-   if ( wid > 0 ){
+   if ( wid > 0 ) {
       window_destroy( wid );
       return;
    }
@@ -198,7 +198,7 @@ void map_system_open( int sys_selected )
    window_disableButton( wid, "btnBuyCommodPrice");
 
    /* Load the planet gfx if necessary */
-   if ( cur_sys_sel != cur_system ){
+   if ( cur_sys_sel != cur_system ) {
      space_gfxLoad( cur_sys_sel );
    }
    /* get textures for the stars.  The first will be the nebula */
@@ -211,7 +211,7 @@ void map_system_open( int sys_selected )
    background_clear();
    background_load ( cur_system->background );
    background_getTextures( &nBgImgs, &bgImages);
-   if ( nBgImgs <= 1 ){
+   if ( nBgImgs <= 1 ) {
       starCnt = 0;
    }
    background_clear();
@@ -282,10 +282,10 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    glTexture *logo;
    int offset;
    phase++;
-   if ( phase > 150 ){
+   if ( phase > 150 ) {
       phase = 0;
       starCnt++;
-      if ( starCnt >= nBgImgs ){
+      if ( starCnt >= nBgImgs ) {
          if ( nBgImgs <= 1)
             starCnt = 0;
          else
@@ -297,13 +297,13 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    
    j=0;
    offset = h - pitch*nshow;
-   for( i=0; i<sys->nplanets; i++ ){
+   for( i=0; i<sys->nplanets; i++ ) {
      p=sys->planets[i];
-     if( planet_isKnown(p) && (p->real == ASSET_REAL) ){
+     if( planet_isKnown(p) && (p->real == ASSET_REAL) ) {
        j++;
-       if( p->gfx_space == NULL){
+       if( p->gfx_space == NULL) {
           WARN( _("No gfx for %s...\n"),p->name );
-       }else{
+       } else {
 	 ih=pitch;
 	 iw = ih;
 	 if ( p->gfx_space->w > p->gfx_space->h )
@@ -319,7 +319,7 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    /* draw the star */
    ih=pitch;
    iw=ih;
-   if ( nBgImgs > 0 ){
+   if ( nBgImgs > 0 ) {
       if ( bgImages[starCnt]->w > bgImages[starCnt]->h )
          ih = ih * bgImages[starCnt]->h / bgImages[starCnt]->w;
       else if ( bgImages[starCnt]->w < bgImages[starCnt]->h )
@@ -328,12 +328,12 @@ static void map_system_render( double bx, double by, double w, double h, void *d
       if ( phase > 120 && nBgImgs > 2 )
          ccol.a = cos ( (phase-121)/30. *M_PI/2.);
       gl_blitScale( bgImages[starCnt], bx+2 , by+(nshow-1)*pitch + (pitch-ih)/2 + offset, iw , ih, &ccol );
-      if ( phase > 120 && nBgImgs > 2){
+      if ( phase > 120 && nBgImgs > 2) {
          /* fade in the next star */
          ih=pitch;
          iw=ih;
          i = starCnt + 1;
-         if ( i >= (int)nBgImgs ){
+         if ( i >= (int)nBgImgs ) {
             if ( nBgImgs <= 1 )
                i=0;
             else
@@ -346,7 +346,7 @@ static void map_system_render( double bx, double by, double w, double h, void *d
          ccol.a = 1 - ccol.a;
          gl_blitScale( bgImages[i], bx+2, by+(nshow-1)*pitch + (pitch-ih)/2 + offset, iw, ih, &ccol );
       }
-   }else{
+   } else {
       /* no nebula or star images - probably due to nebula */
       txtHeight=gl_printHeightRaw( &gl_smallFont,pitch,_("Obscured by the nebula") );
       gl_printTextRaw( &gl_smallFont, pitch, txtHeight, (bx+2),
@@ -354,18 +354,18 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    }
    gl_printRaw( &gl_smallFont, bx + 5 + pitch, by + (nshow-0.5)*pitch + offset,
          (cur_planet_sel == 0 ? &cFontGreen : &cFontWhite), sys->name );
-   if ( cur_planet_sel == 0 && nBgImgs > 0 ){
+   if ( cur_planet_sel == 0 && nBgImgs > 0 ) {
       /* make use of space to draw a nice nebula */
       double imgw,imgh;
       iw = w - 50 - pitch - nameWidth;
       ih = h - 110;
       imgw = bgImages[0]->w;
       imgh = bgImages[0]->h;
-      if ( (ih * imgw) / imgh > iw ){
+      if ( (ih * imgw) / imgh > iw ) {
          /* image is wider per height than the space allows - use all width */
          int newih = (int)((iw * imgh) / imgw);
          gl_blitScale( bgImages[0], bx + 10 + pitch + nameWidth, by + (ih-newih)/2, iw, newih, &cWhite );
-      }else{
+      } else {
          /* image is higher, so use all height. */
          int newiw = (int)((ih * imgw) / imgh);
          gl_blitScale( bgImages[0], bx + 10 + pitch + nameWidth + (iw-newiw)/2, by, newiw, ih, &cWhite );
@@ -385,13 +385,13 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    gl_renderRect( bx+pitch+3-ih, by+(nshow-cur_planet_sel)*pitch-iw + offset, ih, iw, &ccol );
    cnt=0;
    buf[0]='\0';
-   if ( cur_planet_sel == 0 ){
+   if ( cur_planet_sel == 0 ) {
       int infopos=0;
      /* display sun information */
      /* Nebula. */
       cnt+=nsnprintf( buf, sizeof(buf), _("System: %s\n%d star system\n"), sys->name, nBgImgs>0 ? nBgImgs-1 : 0 );
      
-      if (sys->nebu_density > 0. ){
+      if (sys->nebu_density > 0. ) {
          /* Volatility */
          if (sys->nebu_volatility > 700.)
             cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Nebula: Volatile, ") );
@@ -409,44 +409,44 @@ static void map_system_render( double bx, double by, double w, double h, void *d
             cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Light\n") );
          else
             cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Medium\n") );
-      }else
+      } else
          cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Nebula: None\n") );
       
       /* Interference. */
-      if (sys->interference > 0. ){
+      if (sys->interference > 0. ) {
          if (sys->interference > 700.)
             cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Interference: Dense\n") );
          else if (sys->interference < 300.)
             cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Interference: Light\n") );
       }
       /* Asteroids. */
-      if (sys->nasteroids > 0 ){
+      if (sys->nasteroids > 0 ) {
          density = 0.;
-         for( i=0; i<sys->nasteroids; i++ ){
+         for( i=0; i<sys->nasteroids; i++ ) {
             density += sys->asteroids[i].area * sys->asteroids[i].density;
          }
          cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _(" Asteroid Field density %g\n"), density );
       }
       /* Faction */
       f = -1;
-      for( i=0; i<sys->nplanets; i++ ){
-         if (sys->planets[i]->real == ASSET_REAL && planet_isKnown( sys->planets[i] ) ){
-            if ((f==-1) && (sys->planets[i]->faction>0) ){
+      for( i=0; i<sys->nplanets; i++ ) {
+         if (sys->planets[i]->real == ASSET_REAL && planet_isKnown( sys->planets[i] ) ) {
+            if ((f==-1) && (sys->planets[i]->faction>0) ) {
                f = sys->planets[i]->faction;
-            }else if (f != sys->planets[i]->faction &&  (sys->planets[i]->faction>0) ){
+            } else if (f != sys->planets[i]->faction &&  (sys->planets[i]->faction>0) ) {
                cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Faction: Multiple\n") );
                break;
             }
          }
       }
-      if (f == -1 ){
+      if (f == -1 ) {
          cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Faction: N/A\n") );
       }  else {
          if (i==sys->nplanets) /* saw them all and all the same */
             cnt += nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Faction: %s\nStanding: %s\n"), faction_longname(f), faction_getStandingText( f ) );
          /* display the logo */
          logo = faction_logoSmall( f );
-         if ( logo != NULL ){
+         if ( logo != NULL ) {
             gl_blitScale( logo, bx + pitch + nameWidth + 200,
                   by + h - 21, 20, 20, &cWhite );
          }
@@ -454,16 +454,16 @@ static void map_system_render( double bx, double by, double w, double h, void *d
       /* Get presence. */
       hasPresence = 0;
       unknownPresence = 0;
-      for( i=0; i < sys->npresence; i++ ){
+      for( i=0; i < sys->npresence; i++ ) {
          if (sys->presence[i].value <= 0)
             continue;
          hasPresence = 1;
-         if ( faction_isKnown( sys->presence[i].faction ) ){
+         if ( faction_isKnown( sys->presence[i].faction ) ) {
             t = faction_getColourChar( sys->presence[i].faction );
             cnt += nsnprintf( &buf[cnt], sizeof( buf ) - cnt, "\a0%s: \a%c%.0f\n",
                               faction_shortname( sys->presence[i].faction ),
                               t, sys->presence[i].value);
-         }else
+         } else
             unknownPresence += sys->presence[i].value;
       }
       if (unknownPresence != 0)
@@ -476,24 +476,24 @@ static void map_system_render( double bx, double by, double w, double h, void *d
             bx + 10 + pitch + nameWidth, by + h - 10 - txtHeight, &cFontWhite, buf );
       
       /* Jumps. */
-      for(  i=0; i<sys->njumps; i++ ){
-         if ( jp_isUsable ( &sys->jumps[i] ) ){
+      for(  i=0; i<sys->njumps; i++ ) {
+         if ( jp_isUsable ( &sys->jumps[i] ) ) {
             if ( infopos == 0) /* First jump */
                infopos = nsnprintf( infobuf, PATH_MAX, _("   Jump points to:\n") );
-            if ( sys_isKnown( sys->jumps[i].target ) ){
+            if ( sys_isKnown( sys->jumps[i].target ) ) {
                infopos+=nsnprintf( &infobuf[infopos], PATH_MAX-infopos, "     %s\n", sys->jumps[i].target->name );
-            }else{
+            } else {
                infopos+=nsnprintf( &infobuf[infopos], PATH_MAX-infopos, _("     Unkown system\n") );
             }
          }
       }
-   }else{
+   } else {
      /* display planet info */
      p=cur_planetObj_sel;
-     if ( p->faction > 0 ){/* show the faction */
+     if ( p->faction > 0 ) {/* show the faction */
         char factionBuf[64];
         logo = faction_logoSmall( p->faction );
-        if ( logo != NULL ){
+        if ( logo != NULL ) {
            gl_blitScale( logo, bx + pitch + nameWidth + 200, by + h - 21, 20, 20, &cWhite );
          }
         nsnprintf( factionBuf, 64, "%s", faction_shortname( p->faction ) );
@@ -505,11 +505,11 @@ static void map_system_render( double bx, double by, double w, double h, void *d
      cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Planet: %s\nPlanetary class: %s    Population: %ld\n"), p->name, p->class, p->population );
      if (!planet_hasService( p, PLANET_SERVICE_INHABITED ))
         cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("No space port here\n") );
-     else if (p->can_land || p->bribed ){
+     else if (p->can_land || p->bribed ) {
         cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("You can land here\n") );
-     }else if ( areEnemies( FACTION_PLAYER, p->faction ) ){
+     } else if ( areEnemies( FACTION_PLAYER, p->faction ) ) {
         cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("Not advisable to land here\n") );
-     }else{
+     } else {
         cnt+=nsnprintf( &buf[cnt], sizeof(buf)-cnt, _("You cannot land here\n") );
      }
      /* Add a description */
@@ -517,7 +517,7 @@ static void map_system_render( double bx, double by, double w, double h, void *d
      
      txtHeight=gl_printHeightRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, buf );
 
-     if ( infobuf[0] == '\0' ){
+     if ( infobuf[0] == '\0' ) {
         int infocnt=0;
         /* show some additional information */
         infocnt=nsnprintf( infobuf, sizeof(infobuf), "%s\n"
@@ -530,7 +530,7 @@ static void map_system_render( double bx, double by, double w, double h, void *d
                           planet_hasService( p, PLANET_SERVICE_COMMODITY) ? _("This system has a trade outlet") : _("This system does not have a trade outlet"),
                           planet_hasService( p, PLANET_SERVICE_OUTFITS) ? _("This system sells ship equipment") : _("This system does not sell ship equipment"),
                           planet_hasService( p, PLANET_SERVICE_SHIPYARD) ? _("This system sells ships") : _("This system does not sell ships"));
-        if ( p->bar_description && planet_hasService( p, PLANET_SERVICE_BAR ) ){
+        if ( p->bar_description && planet_hasService( p, PLANET_SERVICE_BAR ) ) {
            infocnt+=nsnprintf( &infobuf[infocnt], sizeof(infobuf)-infocnt, "\n\n%s", p->bar_description );
         }
      }
@@ -539,7 +539,7 @@ static void map_system_render( double bx, double by, double w, double h, void *d
    }
 
    /* show the trade/outfit/ship info */
-   if ( infobuf[0]!='\0' ){
+   if ( infobuf[0]!='\0' ) {
       txtHeight=gl_printHeightRaw( &gl_smallFont, (w - nameWidth-pitch-60)/2, infobuf );
       gl_printTextRaw( &gl_smallFont, (w - nameWidth - pitch - 60) / 2, txtHeight,
             bx + 10 + pitch + nameWidth, by + 10, &cFontGrey, infobuf );
@@ -566,10 +566,10 @@ static int map_system_mouse( unsigned int wid, SDL_Event* event, double mx, doub
      /* Must be in bounds. */
      if ((mx < 0.) || (mx > w) || (my < 0.) || (my > h))
             return 0;
-     if (mx < pitch && my > 0){
+     if (mx < pitch && my > 0) {
         offset = h - pitch*nshow;
 
-        if ( cur_planet_sel != (h-my-offset ) / pitch ){
+        if ( cur_planet_sel != (h-my-offset ) / pitch ) {
            cur_planet_sel = ( h-my-offset ) / pitch  ;
            map_system_updateSelected( wid );
 
@@ -581,7 +581,7 @@ static int map_system_mouse( unsigned int wid, SDL_Event* event, double mx, doub
 }
 
 
-static void map_system_array_update( unsigned int wid, char* str ){
+static void map_system_array_update( unsigned int wid, char* str ) {
    char *name;
    Outfit *outfit;
    Ship *ship;
@@ -591,11 +591,11 @@ static void map_system_array_update( unsigned int wid, char* str ){
    char buf2[ECON_CRED_STRLEN], buf4[PATH_MAX];
    
    name = toolkit_getImageArray( wid, str );
-   if ( name == NULL ){
+   if ( name == NULL ) {
       infobuf[0]='\0';
       return;
    }
-   if ( !strcmp( str, MAPSYS_OUTFITS ) ){
+   if ( !strcmp( str, MAPSYS_OUTFITS ) ) {
       outfit = outfit_get( name );
 
       /* new text */
@@ -610,7 +610,7 @@ static void map_system_array_update( unsigned int wid, char* str ){
 
       mass = outfit->mass;
       if ( (outfit_isLauncher(outfit) || outfit_isFighterBay(outfit)) &&
-          (outfit_ammo(outfit) != NULL) ){
+          (outfit_ammo(outfit) != NULL) ) {
          mass += outfit_amount( outfit ) * outfit_ammo( outfit )->mass;
       }
       nsnprintf( infobuf, PATH_MAX,
@@ -628,7 +628,7 @@ static void map_system_array_update( unsigned int wid, char* str ){
                  buf2,
                  buf4 );
       
-   }else if ( !strcmp( str, MAPSYS_SHIPS ) ){
+   } else if ( !strcmp( str, MAPSYS_SHIPS ) ) {
       ship = ship_get( name );
 
    /* update text */
@@ -637,9 +637,9 @@ static void map_system_array_update( unsigned int wid, char* str ){
       /* Remove the word " License".  It's redundant and makes the text overflow
          into another text box */
       license_text = ship->license;
-      if (license_text ){
+      if (license_text ) {
          len = strlen( ship->license );
-         if ( strcmp( " License", ship->license + len - 8 ) == 0 ){
+         if ( strcmp( " License", ship->license + len - 8 ) == 0 ) {
             license_text = malloc( len - 7 );
             assert( license_text );
             memcpy( license_text, ship->license, len - 8 );
@@ -695,7 +695,7 @@ static void map_system_array_update( unsigned int wid, char* str ){
       if ( license_text != ship->license )
          free( license_text );
    
-   }else if ( !strcmp( str, MAPSYS_TRADE ) ){
+   } else if ( !strcmp( str, MAPSYS_TRADE ) ) {
       Commodity *com;
       credits_t mean;
       double std;
@@ -721,7 +721,7 @@ static void map_system_array_update( unsigned int wid, char* str ){
                  buf4,     
                  mean, std,
                  globalmean,globalstd );
-   }else{
+   } else {
       infobuf[0]='\0';
       WARN( _("Unexpected call to map_system_array_update\n") );
    }
@@ -749,14 +749,14 @@ void map_system_updateSelected( unsigned int wid )
    float g,o,s;
    nameWidth = 0; /* get the widest planet/star name */
    nshow=1;/* start at 1 for the sun*/
-   for( i=0; i<sys->nplanets; i++){
+   for( i=0; i<sys->nplanets; i++) {
       p = sys->planets[i];
-      if ( planet_isKnown( p ) && (p->real == ASSET_REAL) ){
+      if ( planet_isKnown( p ) && (p->real == ASSET_REAL) ) {
          textw = gl_printWidthRaw( &gl_smallFont, p->name );
          if ( textw > nameWidth )
             nameWidth = textw;
          last = p;
-         if ( cur_planet_sel == nshow ){
+         if ( cur_planet_sel == nshow ) {
             if ( cur_planetObj_sel != p )
                planetObjChanged = 1;
             cur_planetObj_sel = p;
@@ -775,30 +775,30 @@ void map_system_updateSelected( unsigned int wid )
    if ( pitch > w/5 )
       pitch = w/5;
 
-   if ( cur_planet_sel >= nshow ){
+   if ( cur_planet_sel >= nshow ) {
       cur_planet_sel = nshow-1;
-      if ( cur_planetObj_sel != last ){
+      if ( cur_planetObj_sel != last ) {
          cur_planetObj_sel = last;
          planetObjChanged = 1;
       }
    }
-   if ( cur_planet_sel == 0 ){
+   if ( cur_planet_sel == 0 ) {
       /* star selected */
-      if ( cur_planetObj_sel != NULL ){
+      if ( cur_planetObj_sel != NULL ) {
          cur_planetObj_sel = NULL;
          planetObjChanged = 1;
       }
    }
          
-   if ( planetObjChanged ){
+   if ( planetObjChanged ) {
       infobuf[0]='\0';
-      if ( cur_planetObj_sel == NULL ){
+      if ( cur_planetObj_sel == NULL ) {
          /*The star*/
          noutfits = 0;
          nships = 0;
          ngoods = 0;
 	 window_disableButton( wid, "btnBuyCommodPrice" );
-      }else{
+      } else {
          /* get number of each to decide how much space the lists can have */
          outfits = tech_getOutfit( cur_planetObj_sel->tech, &noutfits );
          free( outfits );
@@ -806,10 +806,10 @@ void map_system_updateSelected( unsigned int wid )
          free( ships );
          ngoods = cur_planetObj_sel->ncommodities;
 	 /* to buy commodity info, need to be landed, and the selected system must sell them! */
-	 if ( landed && planet_hasService( cur_planetObj_sel, PLANET_SERVICE_COMMODITY ) ){
+	 if ( landed && planet_hasService( cur_planetObj_sel, PLANET_SERVICE_COMMODITY ) ) {
 	   window_enableButton( wid, "btnBuyCommodPrice" );
 
-	 }else{
+	 } else {
 	   window_disableButton( wid, "btnBuyCommodPrice" );
 	 }
       }
@@ -818,13 +818,13 @@ void map_system_updateSelected( unsigned int wid )
       if ( ngoods != 0 )
          g=0.35;
 
-      if ( noutfits != 0 ){
-         if ( nships != 0 ){
+      if ( noutfits != 0 ) {
+         if ( nships != 0 ) {
             s=0.25;
             o=1-g-s;
-         }else
+         } else
             o=1-g;
-      }else if ( nships!=0 )
+      } else if ( nships!=0 )
          s=1-g;
       /* ensure total is ~1 */
       g += 1 - g - o - s;
@@ -854,25 +854,25 @@ static void map_system_genOutfitsList( unsigned int wid, float goodsSpace, float
    const char *slotname;
    static Planet *planetDone = NULL;
    window_dimWindow( wid, &w, &h );
-   if (planetDone == cur_planetObj_sel){
-      if ( widget_exists( wid, MAPSYS_OUTFITS ) ){
+   if (planetDone == cur_planetObj_sel) {
+      if ( widget_exists( wid, MAPSYS_OUTFITS ) ) {
          return;
       }
-   }else{
-      if ( widget_exists( wid, MAPSYS_OUTFITS ) ){
+   } else {
+      if ( widget_exists( wid, MAPSYS_OUTFITS ) ) {
          window_destroyWidget( wid, MAPSYS_OUTFITS );
       }
    }
    planetDone = cur_planetObj_sel;
    
    /* set up the outfits to buy/sell */
-   if ( cur_planetObj_sel == NULL ){
+   if ( cur_planetObj_sel == NULL ) {
       noutfits = 0;
       outfits = NULL;
-   }else{
+   } else {
       outfits = tech_getOutfit( cur_planetObj_sel->tech, &noutfits );
    }
-   if ( noutfits > 0 ){
+   if ( noutfits > 0 ) {
       moutfits = MAX( 1, noutfits );
       soutfits = malloc( moutfits * sizeof(char*) );
       toutfits = malloc( moutfits * sizeof(glTexture*) );
@@ -881,7 +881,7 @@ static void map_system_genOutfitsList( unsigned int wid, float goodsSpace, float
       quantity = malloc( sizeof(char*) * noutfits );
       bg       = malloc( sizeof(glColour) * noutfits );
       slottype = malloc( sizeof(char*) * noutfits );
-      for( i=0; i<noutfits; i++ ){
+      for( i=0; i<noutfits; i++ ) {
          soutfits[i] = strdup( outfits[i]->name );
          toutfits[i] = outfits[i]->gfx_store;
          /* Background colour. */
@@ -894,7 +894,7 @@ static void map_system_genOutfitsList( unsigned int wid, float goodsSpace, float
          /* Quantity. */
          owned = player_outfitOwned( outfits[i] );
          len = owned / 10 + 4;
-         if ( owned >= 1 ){
+         if ( owned >= 1 ) {
             quantity[i] = malloc( len );
             nsnprintf( quantity[i], len, "%d", owned );
          }
@@ -904,7 +904,7 @@ static void map_system_genOutfitsList( unsigned int wid, float goodsSpace, float
          
          /* Get slot name. */
          slotname = outfit_slotName( outfits[i] );
-         if ( ( strcmp( slotname,"NA") != 0 ) && ( strcmp( slotname,"NULL" ) != 0) ){
+         if ( ( strcmp( slotname,"NA") != 0 ) && ( strcmp( slotname,"NULL" ) != 0) ) {
             slottype[i]    = malloc( 2 );
             slottype[i][0] = outfit_slotName( outfits[i] )[0];
             slottype[i][1] = '\0';
@@ -943,28 +943,28 @@ static void map_system_genShipsList( unsigned int wid, float goodsSpace, float o
    window_dimWindow( wid, &w, &h );
 
    /* set up the ships that can be bought here */
-   if ( planetDone == cur_planetObj_sel ){
-      if ( widget_exists( wid, MAPSYS_SHIPS ) ){
+   if ( planetDone == cur_planetObj_sel ) {
+      if ( widget_exists( wid, MAPSYS_SHIPS ) ) {
          return;
       }
-   }else{
-      if ( widget_exists( wid, MAPSYS_SHIPS ) ){
+   } else {
+      if ( widget_exists( wid, MAPSYS_SHIPS ) ) {
          window_destroyWidget( wid, MAPSYS_SHIPS );
       }
    }
    planetDone = cur_planetObj_sel;
    
    /* set up the outfits to buy/sell */
-   if ( cur_planetObj_sel == NULL ){
+   if ( cur_planetObj_sel == NULL ) {
       nships = 0;
       ships = NULL;
-   }else{
+   } else {
       ships = tech_getShip( cur_planetObj_sel->tech, &nships );
    }
-   if ( nships > 0  ){
+   if ( nships > 0  ) {
       sships = malloc( sizeof(char*) * nships );
       tships = malloc( sizeof(glTexture*) * nships );
-      for( i=0; i<nships; i++ ){
+      for( i=0; i<nships; i++ ) {
          sships[i] = strdup( ships[i]->name );
          tships[i] = ships[i]->gfx_store;
       }
@@ -991,26 +991,26 @@ static void map_system_genTradeList( unsigned int wid, float goodsSpace, float o
    window_dimWindow( wid, &w, &h );
 
    /* set up the commodities that can be bought here */
-   if ( planetDone == cur_planetObj_sel ){
-      if ( widget_exists( wid, MAPSYS_TRADE ) ){
+   if ( planetDone == cur_planetObj_sel ) {
+      if ( widget_exists( wid, MAPSYS_TRADE ) ) {
          return;
       }
-   }else{
-      if ( widget_exists( wid, MAPSYS_TRADE ) ){
+   } else {
+      if ( widget_exists( wid, MAPSYS_TRADE ) ) {
          window_destroyWidget( wid, MAPSYS_TRADE );
       }
    }
    planetDone = cur_planetObj_sel;
    /* goods list */
-   if ( cur_planetObj_sel == NULL ){
+   if ( cur_planetObj_sel == NULL ) {
       ngoods = 0;
-   }else{
+   } else {
       ngoods = cur_planetObj_sel->ncommodities;
    }
-   if ( ngoods > 0 ){
+   if ( ngoods > 0 ) {
       goods = malloc( sizeof(char*) * ngoods );
       tgoods    = malloc( sizeof(glTexture*) * ngoods );
-      for( i=0; i<ngoods; i++ ){
+      for( i=0; i<ngoods; i++ ) {
          goods[i] = strdup( cur_planetObj_sel->commodities[i]->name);
          tgoods[i] = cur_planetObj_sel->commodities[i]->gfx_store;
       }
@@ -1037,35 +1037,37 @@ void map_system_buyCommodPrice( unsigned int wid, char *str )
    int njumps=0;
    StarSystem **syslist;
    int cost,ret;
-   ntime_t t=ntime_get();
+   ntime_t t = ntime_get();
+
    /* find number of jumps */
-   if ( !strcmp( cur_system->name, cur_sys_sel->name ) ){
+   if ( !strcmp( cur_system->name, cur_sys_sel->name ) ) {
       cost = 500;
       njumps = 0;
-   }else{
+   } else {
       syslist=map_getJumpPath( &njumps, cur_system->name, cur_sys_sel->name,
                                1, 0, NULL);
-      if ( syslist == NULL ){
+      if ( syslist == NULL ) {
          /* no route */
          cost = 0;
          dialogue_msg( _("Not available here"), _("Sorry, we don't have the commodity prices for %s available here at the moment."), cur_planetObj_sel->name );
          return;
-      }else{
+      } else {
          free ( syslist );
          cost = 500 + 300 * (njumps);
       }
    }
+
    /* get the time at which this purchase will be made (2 periods per jump ago)*/
    t-= ( njumps * 2 + 0.2 ) * NT_PERIOD_SECONDS * 1000;
-   if ( !player_hasCredits( cost ) ){
+   if ( !player_hasCredits( cost ) ) {
       dialogue_msg( _("You can't afford that"), _("Sorry, but we are selling this information for %d credits, which you don't have"), cost );
-   }else if ( cur_planetObj_sel->ncommodities == 0 ){
+   } else if ( cur_planetObj_sel->ncommodities == 0 ) {
       dialogue_msgRaw( _("No commodities sold here"),_("There are no commodities sold here, as far as we are aware!"));
-   }else if ( cur_planetObj_sel->commodityPrice[0].updateTime >= t ){
+   } else if ( cur_planetObj_sel->commodityPrice[0].updateTime >= t ) {
       dialogue_msgRaw( _("You already have newer information"), _("I've checked your computer, and you already have newer information than we can sell.") );
-   }else{
+   } else {
       ret=dialogue_YesNo( _("Purchase commodity prices?"), _("For %s, that will cost %d credits.  The latest information we have is %g periods old."), cur_planetObj_sel->name,cost,njumps*2+0.2);
-      if ( ret ){
+      if ( ret ) {
          player_modCredits( -cost );
          economy_averageSeenPricesAtTime( cur_planetObj_sel, t );
          map_system_array_update( wid,  MAPSYS_TRADE );

--- a/src/naev.c
+++ b/src/naev.c
@@ -660,7 +660,7 @@ void loadscreen_render( double done, const char *msg )
    gl_renderRect( x, y, done*w, h, &col );
 
    /* Draw text. */
-   gl_printRaw( &gl_defFont, x, y + h + 3., &cConsole, msg );
+   gl_printRaw( &gl_defFont, x, y + h + 3., &cFontGreen, msg );
 
    /* Flip buffers. */
    SDL_GL_SwapWindow( gl_screen.window );

--- a/src/news.c
+++ b/src/news.c
@@ -482,7 +482,7 @@ static void news_render( double bx, double by, double w, double h, void *data )
 
       gl_printRestore( &news_restores[i] );
       gl_printMidRaw( news_font, w-40.,
-            bx+10, by+y, &cConsole, news_lines[i] );
+            bx+10, by+y, &cFontGreen, news_lines[i] );
 
       /* Increment line and position. */
       y -= news_font->h + 5.;

--- a/src/options.c
+++ b/src/options.c
@@ -279,7 +279,7 @@ static void opt_gameplay( unsigned int wid )
    s = _("Language");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 0, "txtLanguage",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    ls = lang_list( &n );
    i = 0;
    if (conf.language != NULL) {
@@ -293,10 +293,10 @@ static void opt_gameplay( unsigned int wid )
    y -= 90;
 #endif /* defined ENABLE_NLS && ENABLE_NLS */
    window_addText( wid, x+20, y, cw, 20, 0, "txtCompile",
-         NULL, &cBlack, _("Compilation Flags") );
+         NULL, NULL, _("Compilation Flags") );
    y -= 30;
    window_addText( wid, x, y, cw, h+y-20, 0, "txtFlags",
-         NULL, &cDarkPurple,
+         NULL, &cFontPurple,
          ""
 #ifdef DEBUGGING
 #ifdef DEBUG_PARANOID
@@ -337,7 +337,7 @@ static void opt_gameplay( unsigned int wid )
    /* Autonav abort. */
    x = 20 + cw + 20;
    window_addText( wid, x+65, y, 150, 150, 0, "txtAAutonav",
-         NULL, &cBlack, _("Stop Speedup At:") );
+         NULL, NULL, _("Stop Speedup At:") );
    y -= 20;
 
    /* Autonav abort fader. */
@@ -349,7 +349,7 @@ static void opt_gameplay( unsigned int wid )
    y -= 40;
 
    window_addText( wid, x+20, y, cw, 20, 0, "txtSettings",
-         NULL, &cBlack, _("Settings") );
+         NULL, NULL, _("Settings") );
    y -= 25;
 
    window_addCheckbox( wid, x, y, cw, 20,
@@ -367,18 +367,18 @@ static void opt_gameplay( unsigned int wid )
    s = _("Visible Messages");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, -100, y, l, 20, 1, "txtSMSG",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, -50, y, 40, 20, "inpMSG", 4, 1, NULL );
    y -= 30;
    s = _("Max Time Compression Factor");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, -100, y, l, 20, 1, "txtTMax",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, -50, y, 40, 20, "inpTMax", 4, 1, NULL );
 
    /* Restart text. */
    window_addText( wid, 20, 10, 3*(BUTTON_WIDTH + 20),
-         30, 0, "txtRestart", &gl_smallFont, &cBlack, NULL );
+         30, 0, "txtRestart", &gl_smallFont, NULL, NULL );
 
    /* Update. */
    opt_gameplayUpdate( wid, NULL );
@@ -563,7 +563,7 @@ static void opt_keybinds( unsigned int wid )
 
    /* Text stuff. */
    window_addText( wid, 20+lw+20, -40, w-(20+lw+20), 30, 1, "txtName",
-         NULL, &cBlack, NULL );
+         NULL, NULL, NULL );
    window_addText( wid, 20+lw+20, -90, w-(20+lw+20), h-70-60-bh,
          0, "txtDesc", &gl_smallFont, NULL, NULL );
 
@@ -878,7 +878,7 @@ static void opt_audio( unsigned int wid )
    x = 20;
    y = -60;
    window_addText( wid, x+20, y, cw, 20, 0, "txtSGeneral",
-         NULL, &cBlack, _("General") );
+         NULL, NULL, _("General") );
    y -= 30;
    window_addCheckbox( wid, x, y, cw, 20,
          "chkNosound", _("Disable all sound/music"), NULL, conf.nosound );
@@ -908,7 +908,7 @@ static void opt_audio( unsigned int wid )
 
    /* OpenAL options. */
    window_addText( wid, x+20, y, cw, 20, 0, "txtSOpenal",
-         NULL, &cBlack, _("OpenAL") );
+         NULL, NULL, _("OpenAL") );
    y -= 30;
    window_addCheckbox( wid, x, y, cw, 20,
          "chkEFX", _("EFX (More CPU)"), NULL, conf.al_efx );
@@ -918,7 +918,7 @@ static void opt_audio( unsigned int wid )
    x = 20 + cw + 20;
    y = -60;
    window_addText( wid, x+20, y, 100, 20, 0, "txtSVolume",
-         NULL, &cBlack, _("Volume Levels") );
+         NULL, NULL, _("Volume Levels") );
    y -= 30;
 
    /* Sound fader. */
@@ -939,7 +939,7 @@ static void opt_audio( unsigned int wid )
 
    /* Restart text. */
    window_addText( wid, 20, 10, 3*(BUTTON_WIDTH + 20),
-         30, 0, "txtRestart", &gl_smallFont, &cBlack, NULL );
+         30, 0, "txtRestart", &gl_smallFont, NULL, NULL );
 
    opt_audioUpdate(wid);
 }
@@ -1174,7 +1174,7 @@ static void opt_setKey( unsigned int wid, char *str )
 
    /* Set text. */
    window_addText( new_wid, 20, -40, w-40, 60, 0, "txtInfo",
-         &gl_smallFont, &cBlack,
+         &gl_smallFont, NULL,
          _("To use a modifier key hit that key twice in a row, otherwise it "
          "will register as a modifier. To set with any modifier click the checkbox.") );
 
@@ -1244,7 +1244,7 @@ static void opt_video( unsigned int wid )
    x = 20;
    y = -60;
    window_addText( wid, x+20, y, 100, 20, 0, "txtSRes",
-         NULL, &cBlack, _("Resolution") );
+         NULL, NULL, _("Resolution") );
    y -= 40;
    window_addInput( wid, x, y, 100, 20, "inpRes", 16, 1, NULL );
    window_setInputFilter( wid, "inpRes",
@@ -1289,7 +1289,7 @@ static void opt_video( unsigned int wid )
    window_addList( wid, x, y, 140, 100, "lstRes", res, nres, -1, opt_videoRes );
    y -= 120;
    window_addText( wid, x, y-3, 110, 20, 0, "txtScale",
-         NULL, &cBlack, NULL );
+         NULL, NULL, NULL );
    window_addFader( wid, x+120, y, cw-140, 20, "fadScale", 1., 3.,
          conf.scalefactor, opt_setScalefactor );
    opt_setScalefactor( wid, "fadScale" );
@@ -1297,12 +1297,12 @@ static void opt_video( unsigned int wid )
 
    /* FPS stuff. */
    window_addText( wid, x+20, y, 100, 20, 0, "txtFPSTitle",
-         NULL, &cBlack, _("FPS Control") );
+         NULL, NULL, _("FPS Control") );
    y -= 30;
    s = _("FPS Limit");
    l = gl_printWidthRaw( NULL, s );
    window_addText( wid, x, y, l, 20, 1, "txtSFPS",
-         NULL, &cBlack, s );
+         NULL, NULL, s );
    window_addInput( wid, x+l+20, y, 40, 20, "inpFPS", 4, 1, NULL );
    toolkit_setListPos( wid, "lstRes", res_def);
    window_setInputFilter( wid, "inpFPS",
@@ -1320,7 +1320,7 @@ static void opt_video( unsigned int wid )
    x = 20+cw+20;
    y = -60;
    window_addText( wid, x+20, y, 100, 20, 0, "txtSGL",
-         NULL, &cBlack, _("OpenGL") );
+         NULL, NULL, _("OpenGL") );
    y -= 30;
    window_addCheckbox( wid, x, y, cw, 20,
          "chkVSync", _("Vertical Sync"), NULL, conf.vsync );
@@ -1335,12 +1335,12 @@ static void opt_video( unsigned int wid )
          "chkNPOT", _("NPOT Textures*"), NULL, conf.npot );
    y -= 30;
    window_addText( wid, x, y, cw, 20, 1,
-         "txtSCompat", NULL, &cBlack, _("*Disable for compatibility.") );
+         "txtSCompat", NULL, NULL, _("*Disable for compatibility.") );
    y -= 40;
 
    /* Features. */
    window_addText( wid, x+20, y, 100, 20, 0, "txtSFeatures",
-         NULL, &cBlack, _("Features") );
+         NULL, NULL, _("Features") );
    y -= 30;
    window_addCheckbox( wid, x, y, cw, 20,
          "chkEngineGlow", _("Engine Glow (More RAM)"), NULL, conf.engineglow );
@@ -1351,7 +1351,7 @@ static void opt_video( unsigned int wid )
 
    /* Restart text. */
    window_addText( wid, 20, 10, 3*(BUTTON_WIDTH + 20),
-         30, 0, "txtRestart", &gl_smallFont, &cBlack, NULL );
+         30, 0, "txtRestart", &gl_smallFont, NULL, NULL );
 }
 
 /**

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -1685,7 +1685,7 @@ if ((x) != 0.) \
 #define DESC_ADD_INT(x, s) \
 if ((x) != 0) \
    i += nsnprintf( &temp->desc_short[i], OUTFIT_SHORTDESC_MAX-i, \
-         "\n\a%c%+.d "s"\a0", ((x)>0)?'D':'r', x )
+         "\n\a%c%+.d "s"\a0", ((x)>0)?'g':'r', x )
 #define DESC_ADD0(x, s)    DESC_ADD( x, s, "0", ((x)>0)?'D':'r' )
 #define DESC_ADD1(x, s)    DESC_ADD( x, s, "1", ((x)>0)?'D':'r' )
 #define DESC_ADDI(x, s)    DESC_ADD( x, s, "1", ((x)>0)?'D':'r' )

--- a/src/pilot_outfit.c
+++ b/src/pilot_outfit.c
@@ -570,27 +570,27 @@ int pilot_reportSpaceworthy( Pilot *p, char buf[], int bufSize )
    int ret = 0;
 
    /* Core Slots */
-   SPACEWORTHY_CHECK( !pilot_slotsCheckRequired(p), _("Not All Core Slots are equipped\n") );
+   SPACEWORTHY_CHECK( !pilot_slotsCheckRequired(p), _("!! Not All Core Slots are equipped\n") );
    /* CPU. */
-   SPACEWORTHY_CHECK( p->cpu < 0, _("Insufficient CPU\n") );
+   SPACEWORTHY_CHECK( p->cpu < 0, _("!! Insufficient CPU\n") );
 
    /* Movement. */
-   SPACEWORTHY_CHECK( p->thrust < 0, _("Insufficient Thrust\n") );
-   SPACEWORTHY_CHECK( p->speed < 0,  _("Insufficient Speed\n") );
-   SPACEWORTHY_CHECK( p->turn < 0,   _("Insufficient Turn\n") );
+   SPACEWORTHY_CHECK( p->thrust < 0, _("!! Insufficient Thrust\n") );
+   SPACEWORTHY_CHECK( p->speed < 0,  _("!! Insufficient Speed\n") );
+   SPACEWORTHY_CHECK( p->turn < 0,   _("!! Insufficient Turn\n") );
 
    /* Health. */
-   SPACEWORTHY_CHECK( p->armour < 0.,       _("Insufficient Armour\n") );
-   SPACEWORTHY_CHECK( p->armour_regen < 0., _("Insufficient Armour Regeneration\n") );
-   SPACEWORTHY_CHECK( p->shield < 0.,       _("Insufficient Shield\n") );
-   SPACEWORTHY_CHECK( p->shield_regen < 0., _("Insufficient Shield Regeneration\n") );
-   SPACEWORTHY_CHECK( p->energy_max < 0.,   _("Insufficient Energy\n") );
-   SPACEWORTHY_CHECK( p->energy_regen < 0., _("Insufficient Energy Regeneration\n") );
+   SPACEWORTHY_CHECK( p->armour < 0.,       _("!! Insufficient Armour\n") );
+   SPACEWORTHY_CHECK( p->armour_regen < 0., _("!! Insufficient Armour Regeneration\n") );
+   SPACEWORTHY_CHECK( p->shield < 0.,       _("!! Insufficient Shield\n") );
+   SPACEWORTHY_CHECK( p->shield_regen < 0., _("!! Insufficient Shield Regeneration\n") );
+   SPACEWORTHY_CHECK( p->energy_max < 0.,   _("!! Insufficient Energy\n") );
+   SPACEWORTHY_CHECK( p->energy_regen < 0., _("!! Insufficient Energy Regeneration\n") );
 
    /* Misc. */
-   SPACEWORTHY_CHECK( p->fuel_max < 0,         _("Insufficient Fuel Maximum\n") );
-   SPACEWORTHY_CHECK( p->fuel_consumption < 0, _("Insufficient Fuel Consumption\n") );
-   SPACEWORTHY_CHECK( p->cargo_free < 0,        _("Insufficient Free Cargo Space\n") );
+   SPACEWORTHY_CHECK( p->fuel_max < 0,         _("!! Insufficient Fuel Maximum\n") );
+   SPACEWORTHY_CHECK( p->fuel_consumption < 0, _("!! Insufficient Fuel Consumption\n") );
+   SPACEWORTHY_CHECK( p->cargo_free < 0,        _("!! Insufficient Free Cargo Space\n") );
 
    /*buffer is full, lets write that there is more then what's copied */
    if (pos > bufSize-1) {

--- a/src/shiplog.c
+++ b/src/shiplog.c
@@ -139,8 +139,8 @@ int shiplog_create(const char *idstr, const char *logname, const char *type, con
 int shiplog_append(const char *idstr, const char *msg)
 {
    int i;
-   for ( i=0 ; i<shipLog->nlogs; i++ ){
-      if ( (idstr==NULL && shipLog->idstrList[i]==NULL) || ( idstr!=NULL && shipLog->idstrList[i]!=NULL && !strcmp(idstr, shipLog->idstrList[i])) ){
+   for ( i=0 ; i<shipLog->nlogs; i++ ) {
+      if ( (idstr==NULL && shipLog->idstrList[i]==NULL) || ( idstr!=NULL && shipLog->idstrList[i]!=NULL && !strcmp(idstr, shipLog->idstrList[i])) ) {
          break;
       }
    }

--- a/src/space.c
+++ b/src/space.c
@@ -1794,6 +1794,26 @@ char planet_getColourChar( Planet *p )
 
 
 /**
+ * @brief Gets the planet symbol.
+ */
+const char *planet_getSymbol( Planet *p )
+{
+   if (!planet_hasService( p, PLANET_SERVICE_INHABITED ))
+      return "";
+
+   if (p->can_land || p->bribed) {
+      if (areAllies(FACTION_PLAYER,p->faction))
+         return "+ ";
+      return "~ ";
+   }
+
+   if (areEnemies(FACTION_PLAYER,p->faction))
+      return "!! ";
+   return "* ";
+}
+
+
+/**
  * @brief Gets the planet colour.
  */
 const glColour* planet_getColour( Planet *p )

--- a/src/space.c
+++ b/src/space.c
@@ -3710,7 +3710,7 @@ static void space_renderAsteroid( Asteroid *a )
       com = at->material[i];
       gl_blitSprite( com->gfx_space, a->pos.x, a->pos.y-10.*i, 0, 0, NULL );
       sprintf(c, "x%i", at->quantity[i]);
-      gl_printRaw( &gl_smallFont, nx+10, ny-5-10.*i, &cFontHostile, c );
+      gl_printRaw( &gl_smallFont, nx+10, ny-5-10.*i, &cFontWhite, c );
    }
 }
 

--- a/src/space.h
+++ b/src/space.h
@@ -357,6 +357,7 @@ void planet_averageSeenPricesAtTime( const Planet *p, const ntime_t tupdate );
 int planet_setFaction( Planet *p, int faction );
 /* Land related stuff. */
 char planet_getColourChar( Planet *p );
+const char *planet_getSymbol( Planet *p );
 const glColour* planet_getColour( Planet *p );
 void planet_updateLand( Planet *p );
 int planet_setRadiusFromGFX(Planet* planet);

--- a/src/tk/widget/button.c
+++ b/src/tk/widget/button.c
@@ -259,7 +259,7 @@ static void btn_updateHotkey( Widget *btn )
    display[match] = '\0'; /* Cuts the string into two. */
 
    /* Copy both parts and insert the character in the middle. */
-   nsnprintf( buf, sizeof(buf), "%s\ab%c\a0%s", display, target, &display[match+1] );
+   nsnprintf( buf, sizeof(buf), "%s\an%c\a0%s", display, target, &display[match+1] );
 
    /* Should never be NULL. */
    free(btn->dat.btn.display);
@@ -312,10 +312,10 @@ static void btn_render( Widget* btn, double bx, double by )
       lc = &cGrey60;
       c  = &cGrey20;
       dc = &cGrey40;
-      fc = &cRed;
+      fc = &cGrey80;
    }
    else {
-      fc = &cDarkRed;
+      fc = &cFontWhite;
       switch (btn->status) {
          case WIDGET_STATUS_MOUSEOVER:
             lc = &cGrey90;

--- a/src/tk/widget/button.c
+++ b/src/tk/widget/button.c
@@ -301,56 +301,39 @@ static int btn_key( Widget* btn, SDL_Keycode key, SDL_Keymod mod )
  */
 static void btn_render( Widget* btn, double bx, double by )
 {
-   const glColour *c, *dc, *lc, *fc;
+   const glColour *c, *fc;
    double x, y;
 
    x = bx + btn->x;
    y = by + btn->y;
 
    /* set the colours */
-   if (btn->dat.btn.disabled==1) {
-      lc = &cGrey60;
-      c  = &cGrey20;
-      dc = &cGrey40;
+   if (btn->dat.btn.disabled) {
+      c  = toolkit_colDark;
       fc = &cGrey80;
    }
    else {
       fc = &cFontWhite;
       switch (btn->status) {
          case WIDGET_STATUS_MOUSEOVER:
-            lc = &cGrey90;
-            c  = &cGrey70;
-            dc = &cGrey50;
+            c  = toolkit_colLight;
             break;
          case WIDGET_STATUS_MOUSEDOWN:
-            lc = &cGrey90;
-            c  = &cGrey50;
-            dc = &cGrey70;
+            c  = &cGrey30;
             break;
          case WIDGET_STATUS_NORMAL:
          default:
-            lc = &cGrey80;
-            c  = &cGrey60;
-            dc = &cGrey40;
-            break;
+            c  = &cGrey50;
       }
    }
 
 
-   /* shaded base */
-   if (btn->dat.btn.disabled==1) {
-      toolkit_drawRect( x, y,            btn->w, 0.4*btn->h, dc, NULL );
-      toolkit_drawRect( x, y+0.4*btn->h, btn->w, 0.6*btn->h, dc, c );
-   }
-   else {
-      toolkit_drawRect( x, y,            btn->w, 0.6*btn->h, dc, c );
-      toolkit_drawRect( x, y+0.6*btn->h, btn->w, 0.4*btn->h, c, NULL );
-   }
+   toolkit_drawRect( x, y, btn->w, btn->h, c, NULL );
 
    /* inner outline */
-   toolkit_drawOutline( x, y, btn->w, btn->h, 0., lc, c );
+   toolkit_drawOutline( x, y, btn->w, btn->h, 0., toolkit_colLight, NULL );
    /* outer outline */
-   toolkit_drawOutline( x, y, btn->w, btn->h, 1., &cBlack, NULL );
+   toolkit_drawOutline( x, y, btn->w, btn->h, 1., toolkit_colDark, NULL );
 
    gl_printMidRaw( NULL, (int)btn->w,
          bx + btn->x,

--- a/src/tk/widget/button.c
+++ b/src/tk/widget/button.c
@@ -333,7 +333,7 @@ static void btn_render( Widget* btn, double bx, double by )
    /* inner outline */
    toolkit_drawOutline( x, y, btn->w, btn->h, 0., toolkit_colLight, NULL );
    /* outer outline */
-   toolkit_drawOutline( x, y, btn->w, btn->h, 1., toolkit_colDark, NULL );
+   toolkit_drawOutline( x, y, btn->w, btn->h, 1., &cBlack, NULL );
 
    gl_printMidRaw( NULL, (int)btn->w,
          bx + btn->x,

--- a/src/tk/widget/checkbox.c
+++ b/src/tk/widget/checkbox.c
@@ -247,7 +247,7 @@ static void chk_render( Widget* chk, double bx, double by )
    gl_printMaxRaw( NULL, chk->w - 20,
          bx + chk->x + 15,
          by + chk->y + (chk->h - gl_defFont.h)/2.,
-         &cBlack, chk->dat.chk.display );
+         &cFontWhite, chk->dat.chk.display );
 }
 
 

--- a/src/tk/widget/checkbox.c
+++ b/src/tk/widget/checkbox.c
@@ -212,17 +212,14 @@ static void chk_render( Widget* chk, double bx, double by )
    switch (chk->status) {
       case WIDGET_STATUS_NORMAL:
          lc = &cGrey80;
-         /*c = &cGrey60;*/
          dc = &cGrey40;
          break;
       case WIDGET_STATUS_MOUSEOVER:
          lc = &cWhite;
-         /*c = &cGrey80;*/
          dc = &cGrey60;
          break;
       case WIDGET_STATUS_MOUSEDOWN:
          lc = &cGreen;
-         /*c = &cGreen;*/
          dc = &cGrey40;
          break;
       default:
@@ -231,10 +228,10 @@ static void chk_render( Widget* chk, double bx, double by )
 #endif
 
    /* Draw rect. */
-   toolkit_drawRect( x-1, y-1 + (chk->h-10.)/2., 12., 12., &cGrey40, NULL );
-   toolkit_drawRect( x, y + (chk->h-10.)/2., 10., 10., &cGrey90, NULL );
+   toolkit_drawRect( x-1, y-1 + (chk->h-10.)/2., 12., 12., toolkit_colDark, NULL );
+   toolkit_drawRect( x, y + (chk->h-10.)/2., 10., 10., toolkit_colLight, NULL );
    if (chk->dat.chk.state)
-      toolkit_drawRect( x+1., y+1. + (chk->h-10.)/2., 8., 8., &cGrey20, NULL );
+      toolkit_drawRect( x+1., y+1. + (chk->h-10.)/2., 8., 8., toolkit_colDark, NULL );
 
 #if 0
    /* Inner outline */

--- a/src/tk/widget/cust.c
+++ b/src/tk/widget/cust.c
@@ -90,7 +90,7 @@ static void cst_render( Widget* cst, double bx, double by )
    if (cst->dat.cst.border) {
       /* inner outline */
       toolkit_drawOutline( x, y+1, cst->w+1, cst->h+1, 0.,
-            toolkit_colLight, toolkit_col );
+            toolkit_colLight, NULL );
       /* outer outline */
       toolkit_drawOutline( x, y, cst->w+1, cst->h+1, 1.,
             toolkit_colDark, NULL );

--- a/src/tk/widget/fader.c
+++ b/src/tk/widget/fader.c
@@ -101,7 +101,7 @@ static void fad_render( Widget* fad, double bx, double by )
    ty = by + fad->y + (h < w ? (h - 5.) / 2 : 0);
    tw = (h < w ? w : 5.);
    th = (h > w ? h : 5.);
-   toolkit_drawRect(tx, ty, tw , th, toolkit_colDark, toolkit_colDark);
+   toolkit_drawRect(tx, ty, tw , th, toolkit_colLight, NULL);
 
    /* Knob. */
    kx = bx + fad->x + (h < w ? w * pos - 5. : 0);
@@ -110,8 +110,8 @@ static void fad_render( Widget* fad, double bx, double by )
    kh = (h > w ? 15. : h);
 
    /* Draw. */
-   toolkit_drawRect(kx, ky, kw , kh, toolkit_colDark, toolkit_colLight);
-   toolkit_drawOutline(kx, ky, kw , kh, 1., &cBlack, toolkit_colDark);
+   toolkit_drawRect(kx, ky, kw , kh, toolkit_col, NULL);
+   toolkit_drawOutline(kx, ky, kw , kh, 1., toolkit_colDark, NULL);
 }
 
 

--- a/src/tk/widget/image.c
+++ b/src/tk/widget/image.c
@@ -83,7 +83,7 @@ static void img_render( Widget* img, double bx, double by )
    if (img->dat.img.border) {
       /* inner outline (outwards) */
       toolkit_drawOutline( x, y+1, w-1,
-         h-1, 1., toolkit_colLight, toolkit_col );
+         h-1, 1., toolkit_colLight, NULL );
       /* outer outline */
       toolkit_drawOutline( x, y+1, w-1,
             h-1, 2., toolkit_colDark, NULL );

--- a/src/tk/widget/imagearray.c
+++ b/src/tk/widget/imagearray.c
@@ -194,7 +194,7 @@ static void iar_render( Widget* iar, double bx, double by )
 
          is_selected = (iar->dat.iar.selected == pos) ? 1 : 0;
 
-         fontcolour = cWhite;
+         fontcolour = cFontWhite;
          /* Draw background. */
          if (iar->dat.iar.background != NULL) {
             if (is_selected) {

--- a/src/tk/widget/imagearray.c
+++ b/src/tk/widget/imagearray.c
@@ -139,7 +139,6 @@ static void iar_render( Widget* iar, double bx, double by )
    const glColour *c, *dc, *lc;
    glColour tc, fontcolour;
    int is_selected;
-   int tw;
    double d;
 
    /*
@@ -197,19 +196,27 @@ static void iar_render( Widget* iar, double bx, double by )
 
          fontcolour = cWhite;
          /* Draw background. */
-         if (is_selected)
+         if (iar->dat.iar.background != NULL) {
+            if (is_selected) {
+               toolkit_drawRect( xcurs + 2.,
+                     ycurs + 2.,
+                     w - 5., h - 5., &cDarkBlue, NULL );
+               fontcolour = cWhite;
+            } else {
+               toolkit_drawRect( xcurs + 2.,
+                     ycurs + 2.,
+                     w - 5., h - 5., &iar->dat.iar.background[pos], NULL );
+
+               tc = iar->dat.iar.background[pos];
+
+               if (((tc.r + tc.g + tc.b) / 3) > 0.5)
+                  fontcolour = cBlack;
+            }
+         } else if (is_selected) {
             toolkit_drawRect( xcurs + 2.,
                   ycurs + 2.,
-                  w - 5., h - 5., &cDConsole, NULL );
-         else if (iar->dat.iar.background != NULL) {
-            toolkit_drawRect( xcurs + 2.,
-                  ycurs + 2.,
-                  w - 5., h - 5., &iar->dat.iar.background[pos], NULL );
-
-            tc = iar->dat.iar.background[pos];
-
-            if (((tc.r + tc.g + tc.b) / 3) > 0.5)
-               fontcolour = cBlack;
+                  w - 5., h - 5., &cGreen, NULL );
+            fontcolour = cBlack;
          }
 
          /* image */
@@ -221,27 +228,11 @@ static void iar_render( Widget* iar, double bx, double by )
          /* caption */
          if (iar->dat.iar.captions[pos] != NULL)
             gl_printMidRaw( &gl_smallFont, iar->dat.iar.iw, xcurs + 5., ycurs + 5.,
-                     (is_selected) ? &cBlack : &fontcolour,
-                     iar->dat.iar.captions[pos] );
+                     &fontcolour, iar->dat.iar.captions[pos] );
 
          /* quantity. */
          if (iar->dat.iar.quantity != NULL) {
             if (iar->dat.iar.quantity[pos] != NULL) {
-               /* Rectangle to highlight better. */
-               tw = gl_printWidthRaw( &gl_smallFont,
-                     iar->dat.iar.quantity[pos] );
-
-               if (is_selected)
-                  tc = cDConsole;
-               else if (iar->dat.iar.background != NULL)
-                  tc = iar->dat.iar.background[pos];
-               else
-                  tc = cBlack;
-
-               tc.a = 0.75;
-               toolkit_drawRect( xcurs + 2.,
-                     ycurs + 5. + iar->dat.iar.ih,
-                     tw + 4., gl_smallFont.h + 4., &tc, NULL );
                /* Quantity number. */
                gl_printMaxRaw( &gl_smallFont, iar->dat.iar.iw,
                      xcurs + 5., ycurs + iar->dat.iar.ih + 7.,
@@ -252,20 +243,6 @@ static void iar_render( Widget* iar, double bx, double by )
          /* Slot type. */
          if (iar->dat.iar.slottype != NULL) {
             if (iar->dat.iar.slottype[pos] != NULL) {
-               /* Rectangle to highlight better. Width is a hack due to lack of monospace font. */
-               tw = gl_printWidthRaw( &gl_smallFont, "M" );
-
-               if (is_selected)
-                  tc = cDConsole;
-               else if (iar->dat.iar.background != NULL)
-                  tc = iar->dat.iar.background[pos];
-               else
-                  tc = cBlack;
-
-               tc.a = 0.75;
-               toolkit_drawRect( xcurs + iar->dat.iar.iw - 6.,
-                     ycurs + 5. + iar->dat.iar.ih,
-                     tw + 2., gl_smallFont.h + 4., &tc, NULL );
                /* Slot size letter. */
                gl_printMaxRaw( &gl_smallFont, iar->dat.iar.iw,
                      xcurs + iar->dat.iar.iw - 4., ycurs + iar->dat.iar.ih + 7.,

--- a/src/tk/widget/imagearray.c
+++ b/src/tk/widget/imagearray.c
@@ -136,7 +136,7 @@ static void iar_render( Widget* iar, double bx, double by )
    double scroll_pos;
    int xelem, yelem;
    double xspace;
-   const glColour *c, *dc, *lc;
+   const glColour *dc, *lc;
    glColour fontcolour;
    int is_selected;
    double d;
@@ -246,17 +246,15 @@ static void iar_render( Widget* iar, double bx, double by )
          /* outline */
          if (is_selected) {
             lc = &cWhite;
-            c = &cGrey80;
             dc = &cGrey60;
          }
          else {
             lc = toolkit_colLight;
-            c = toolkit_col;
-            dc = toolkit_colDark;
+            dc = toolkit_col;
          }
          toolkit_drawOutline( xcurs + 2.,
                ycurs + 2.,
-               w - 4., h - 4., 1., lc, c );
+               w - 4., h - 4., 1., lc, NULL );
          toolkit_drawOutline( xcurs + 2.,
                ycurs + 2.,
                w - 4., h - 4., 2., dc, NULL );
@@ -269,7 +267,7 @@ static void iar_render( Widget* iar, double bx, double by )
    /*
     * Final outline.
     */
-   toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 1., toolkit_colLight, toolkit_col );
+   toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 1., toolkit_colLight, NULL );
    toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 2., toolkit_colDark, NULL );
 }
 

--- a/src/tk/widget/imagearray.c
+++ b/src/tk/widget/imagearray.c
@@ -137,7 +137,7 @@ static void iar_render( Widget* iar, double bx, double by )
    int xelem, yelem;
    double xspace;
    const glColour *c, *dc, *lc;
-   glColour tc, fontcolour;
+   glColour fontcolour;
    int is_selected;
    double d;
 
@@ -201,22 +201,15 @@ static void iar_render( Widget* iar, double bx, double by )
                toolkit_drawRect( xcurs + 2.,
                      ycurs + 2.,
                      w - 5., h - 5., &cDarkBlue, NULL );
-               fontcolour = cWhite;
             } else {
                toolkit_drawRect( xcurs + 2.,
                      ycurs + 2.,
                      w - 5., h - 5., &iar->dat.iar.background[pos], NULL );
-
-               tc = iar->dat.iar.background[pos];
-
-               if (((tc.r + tc.g + tc.b) / 3) > 0.5)
-                  fontcolour = cBlack;
             }
          } else if (is_selected) {
             toolkit_drawRect( xcurs + 2.,
                   ycurs + 2.,
                   w - 5., h - 5., &cGreen, NULL );
-            fontcolour = cBlack;
          }
 
          /* image */

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -114,7 +114,7 @@ static void inp_render( Widget* inp, double bx, double by )
 
    /* Draw text. */
    gl_printTextRaw( inp->dat.inp.font, inp->w-10., inp->h,
-         x+5., ty, &cBlack, &inp->dat.inp.input[ inp->dat.inp.view ] );
+         x+5., ty, &cFontWhite, &inp->dat.inp.input[ inp->dat.inp.view ] );
 
    /* Draw cursor. */
    if (wgt_isFlag( inp, WGT_FLAG_FOCUSED )) {

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -159,7 +159,7 @@ static void inp_render( Widget* inp, double bx, double by )
 
    /* inner outline */
    toolkit_drawOutline( x, y, inp->w, inp->h, 0.,
-         toolkit_colLight, toolkit_col );
+         toolkit_colLight, NULL );
    /* outer outline */
    toolkit_drawOutline( x, y, inp->w, inp->h, 1.,
          toolkit_colDark, NULL );

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -110,7 +110,7 @@ static void lst_render( Widget* lst, double bx, double by )
    y = by + lst->y;
 
    /* lst bg */
-   toolkit_drawRect( x, y, lst->w, lst->h, &cGrey90, NULL );
+   toolkit_drawRect( x, y, lst->w, lst->h, &cBlack, NULL );
 
    /* inner outline */
    toolkit_drawOutline( x, y, lst->w, lst->h, 0.,
@@ -130,19 +130,19 @@ static void lst_render( Widget* lst, double bx, double by )
    }
 
    /* draw selected */
-   toolkit_drawRect( x, y - 1. + lst->h -
-         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_defFont.h+2.),
-         w-1, gl_defFont.h + 2., &cHilight, NULL );
+   toolkit_drawRect( x, y - 3. + lst->h -
+         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_defFont.h+5.),
+         w-1, gl_defFont.h + 6., &cHilight, NULL );
 
    /* draw content */
    tx = x + 2.;
-   ty = y + lst->h - 2. - gl_defFont.h;
-   miny = ty - lst->h + 2 + gl_defFont.h;
+   ty = y + lst->h - 5. - gl_defFont.h;
+   miny = ty - lst->h + 5 + gl_defFont.h;
    w -= 4;
    for (i=lst->dat.lst.pos; i<lst->dat.lst.noptions; i++) {
       gl_printMaxRaw( &gl_defFont, (int)w,
-            tx, ty, &cBlack, lst->dat.lst.options[i] );
-      ty -= 2 + gl_defFont.h;
+            tx, ty, &cFontWhite, lst->dat.lst.options[i] );
+      ty -= 5 + gl_defFont.h;
 
       /* Check if out of bounds. */
       if (ty < miny)
@@ -238,7 +238,7 @@ static int lst_focus( Widget* lst, double bx, double by )
       w -= 10.;
 
    if (bx < w) {
-      i = lst->dat.lst.pos + (lst->h - by) / (gl_defFont.h + 2.);
+      i = lst->dat.lst.pos + (lst->h - by) / (gl_defFont.h + 5.);
       if (i < lst->dat.lst.noptions) { /* shouldn't be out of boundaries */
          lst->dat.lst.selected = i;
          lst_scroll( lst, 0 ); /* checks boundaries and triggers callback */
@@ -246,7 +246,7 @@ static int lst_focus( Widget* lst, double bx, double by )
    }
    else {
       /* Get bar position (center). */
-      scroll_pos  = (double)(lst->dat.lst.pos * (2 + gl_defFont.h));
+      scroll_pos  = (double)(lst->dat.lst.pos * (5 + gl_defFont.h));
       scroll_pos /= (double)lst->dat.lst.height - lst->h;
       y = (lst->h - 30.) * (1.-scroll_pos) + 15.;
 

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -114,7 +114,7 @@ static void lst_render( Widget* lst, double bx, double by )
 
    /* inner outline */
    toolkit_drawOutline( x, y, lst->w, lst->h, 0.,
-         toolkit_colLight, toolkit_col );
+         toolkit_colLight, NULL );
    /* outer outline */
    toolkit_drawOutline( x, y, lst->w, lst->h, 1., toolkit_colDark, NULL );
 

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -75,12 +75,12 @@ void window_addList( const unsigned int wid,
 
    /* position/size */
    wgt->w = (double) w;
-   wgt->h = (double) h - ((h % (gl_defFont.h+2)) - 2);
+   wgt->h = (double) h - ((h % (gl_defFont.h+6)) - 6);
    toolkit_setPos( wdw, wgt, x, y );
 
    /* check if needs scrollbar. */
    if (2 + (nitems * (gl_defFont.h + 2)) > (int)wgt->h)
-      wgt->dat.lst.height = (2 + gl_defFont.h) * nitems + 2;
+      wgt->dat.lst.height = (6 + gl_defFont.h) * nitems + 6;
    else
       wgt->dat.lst.height = 0;
 
@@ -123,7 +123,7 @@ static void lst_render( Widget* lst, double bx, double by )
       /* We need to make room for list. */
       w -= 11.;
 
-      scroll_pos  = (double)(lst->dat.lst.pos * (2 + gl_defFont.h));
+      scroll_pos  = (double)(lst->dat.lst.pos * (6 + gl_defFont.h));
       scroll_pos /= (double)lst->dat.lst.height - lst->h;
       /* XXX lst->h is off by one */
       toolkit_drawScrollbar( x + lst->w - 12. + 1, y -1, 12., lst->h + 2, scroll_pos );
@@ -131,18 +131,18 @@ static void lst_render( Widget* lst, double bx, double by )
 
    /* draw selected */
    toolkit_drawRect( x, y - 3. + lst->h -
-         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_defFont.h+5.),
+         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_defFont.h+6.),
          w-1, gl_defFont.h + 6., &cHilight, NULL );
 
    /* draw content */
    tx = x + 2.;
-   ty = y + lst->h - 5. - gl_defFont.h;
-   miny = ty - lst->h + 5 + gl_defFont.h;
+   ty = y + lst->h - 6. - gl_defFont.h;
+   miny = ty - lst->h + 6 + gl_defFont.h;
    w -= 4;
    for (i=lst->dat.lst.pos; i<lst->dat.lst.noptions; i++) {
       gl_printMaxRaw( &gl_defFont, (int)w,
             tx, ty, &cFontWhite, lst->dat.lst.options[i] );
-      ty -= 5 + gl_defFont.h;
+      ty -= 6 + gl_defFont.h;
 
       /* Check if out of bounds. */
       if (ty < miny)
@@ -238,7 +238,7 @@ static int lst_focus( Widget* lst, double bx, double by )
       w -= 10.;
 
    if (bx < w) {
-      i = lst->dat.lst.pos + (lst->h - by) / (gl_defFont.h + 5.);
+      i = lst->dat.lst.pos + (lst->h - by) / (gl_defFont.h + 6.);
       if (i < lst->dat.lst.noptions) { /* shouldn't be out of boundaries */
          lst->dat.lst.selected = i;
          lst_scroll( lst, 0 ); /* checks boundaries and triggers callback */
@@ -246,7 +246,7 @@ static int lst_focus( Widget* lst, double bx, double by )
    }
    else {
       /* Get bar position (center). */
-      scroll_pos  = (double)(lst->dat.lst.pos * (5 + gl_defFont.h));
+      scroll_pos  = (double)(lst->dat.lst.pos * (6 + gl_defFont.h));
       scroll_pos /= (double)lst->dat.lst.height - lst->h;
       y = (lst->h - 30.) * (1.-scroll_pos) + 15.;
 
@@ -286,14 +286,14 @@ static int lst_mmove( Widget* lst, int x, int y, int rx, int ry )
       /* Make sure Y inbounds. */
       y = CLAMP( 15., lst->h-15., lst->h - y );
 
-      h = lst->h / (2 + gl_defFont.h) - 1;
+      h = lst->h / (6 + gl_defFont.h) - 1;
 
       /* Save previous position. */
       psel = lst->dat.lst.pos;
 
       /* Find absolute position. */
       p  = (y - 15. ) / (lst->h - 30.) * (lst->dat.lst.height - lst->h);
-      p /= (2 + gl_defFont.h);
+      p /= (6 + gl_defFont.h);
       lst->dat.lst.pos = CLAMP( 0, lst->dat.lst.noptions, (int)ceil(p) );
 
       /* Does boundary checks. */
@@ -356,8 +356,8 @@ static void lst_scroll( Widget* lst, int direction )
       if (lst->dat.lst.pos < 0)
          lst->dat.lst.pos = 0;
    }
-   else if (2 + (pos+1) * (gl_defFont.h + 2) > lst->h)
-      lst->dat.lst.pos += (2 + (pos+1) * (gl_defFont.h + 2) - lst->h) / (gl_defFont.h + 2);
+   else if (6 + (pos+1) * (gl_defFont.h + 6) > lst->h)
+      lst->dat.lst.pos += (6 + (pos+1) * (gl_defFont.h + 6) - lst->h) / (gl_defFont.h + 6);
 
    if (lst->dat.lst.fptr)
       lst->dat.lst.fptr( lst->wdw, lst->name );

--- a/src/tk/widget/rect.c
+++ b/src/tk/widget/rect.c
@@ -80,7 +80,7 @@ static void rct_render( Widget* rct, double bx, double by )
    if (rct->dat.rct.border) {
       /* inner outline */
       toolkit_drawOutline( x, y, rct->w, rct->h, 0.,
-            toolkit_colLight, toolkit_col );
+            toolkit_colLight, NULL );
       /* outer outline */
       toolkit_drawOutline( x, y, rct->w, rct->h, 1.,
             toolkit_colDark, NULL );

--- a/src/tk/widget/tabwin.c
+++ b/src/tk/widget/tabwin.c
@@ -366,7 +366,6 @@ static void tab_render( Widget* tab, double bx, double by )
 {
    int i, x, y;
    Window *wdw;
-   const glColour *c, *lc;
 
    /** Get window. */
    wdw = window_wget( tab->dat.tab.windows[ tab->dat.tab.active ] );
@@ -385,22 +384,19 @@ static void tab_render( Widget* tab, double bx, double by )
       y += tab->h-TAB_HEIGHT;
    for (i=0; i<tab->dat.tab.ntabs; i++) {
       if (i!=tab->dat.tab.active) {
-         lc = toolkit_col;
-         c  = toolkit_colDark;
-
          /* Draw border. */
          toolkit_drawRect( x, y, tab->dat.tab.namelen[i] + 10,
-               TAB_HEIGHT, lc, c );
+               TAB_HEIGHT, toolkit_colDark, NULL );
          toolkit_drawOutline( x+1, y+1, tab->dat.tab.namelen[i] + 8,
-               TAB_HEIGHT-1, 1., c, &cBlack );
+               TAB_HEIGHT-1, 1., toolkit_colDark, NULL );
       }
       else {
          if (i==0)
             toolkit_drawRect( x-1, y+0,
-                  1, TAB_HEIGHT+1, toolkit_colDark, &cGrey20 );
+                  1, TAB_HEIGHT+1, toolkit_col, NULL );
          else if (i==tab->dat.tab.ntabs-1)
             toolkit_drawRect( x+tab->dat.tab.namelen[i]+9, y+0,
-                  1, TAB_HEIGHT+1, toolkit_colDark, &cGrey20 );
+                  1, TAB_HEIGHT+1, toolkit_col, NULL );
       }
       /* Draw text. */
       gl_printRaw( tab->dat.tab.font, x + 5,

--- a/src/tk/widget/tabwin.c
+++ b/src/tk/widget/tabwin.c
@@ -379,16 +379,16 @@ static void tab_render( Widget* tab, double bx, double by )
 
    /* Render tabs ontop. */
    x = bx+tab->x+20;
-   y = by+tab->y;
+   y = by+tab->y+2;
    if (tab->dat.tab.tabpos == 1)
       y += tab->h-TAB_HEIGHT;
    for (i=0; i<tab->dat.tab.ntabs; i++) {
       if (i!=tab->dat.tab.active) {
          /* Draw border. */
+         toolkit_drawOutline( x+1, y+1, tab->dat.tab.namelen[i] + 8,
+               TAB_HEIGHT-2, 1., toolkit_col, NULL );
          toolkit_drawRect( x, y, tab->dat.tab.namelen[i] + 10,
                TAB_HEIGHT, toolkit_colDark, NULL );
-         toolkit_drawOutline( x+1, y+1, tab->dat.tab.namelen[i] + 8,
-               TAB_HEIGHT-1, 1., toolkit_colDark, NULL );
       }
       else {
          if (i==0)

--- a/src/tk/widget/tabwin.c
+++ b/src/tk/widget/tabwin.c
@@ -404,7 +404,7 @@ static void tab_render( Widget* tab, double bx, double by )
       }
       /* Draw text. */
       gl_printRaw( tab->dat.tab.font, x + 5,
-            y + (TAB_HEIGHT-tab->dat.tab.font->h)/2, &cBlack,
+            y + (TAB_HEIGHT-tab->dat.tab.font->h)/2, &cFontWhite,
             tab->dat.tab.tabnames[i] );
 
       /* Go to next line. */

--- a/src/tk/widget/text.c
+++ b/src/tk/widget/text.c
@@ -54,7 +54,7 @@ void window_addText( const unsigned int wid,
    wgt->render             = txt_render;
    wgt->cleanup            = txt_cleanup;
    wgt->dat.txt.font       = (font==NULL) ? &gl_defFont : font;
-   wgt->dat.txt.colour     = (colour==NULL) ? cBlack : *colour;
+   wgt->dat.txt.colour     = (colour==NULL) ? cFontWhite : *colour;
    wgt->dat.txt.centered   = centered;
    wgt->dat.txt.text       = (string==NULL) ? NULL : strdup(string);
 

--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -59,9 +59,9 @@ static char input_text              = 0; /**< Current character. */
 /*
  * default outline colours
  */
-const glColour* toolkit_colLight = &cGrey90; /**< Light outline colour. */
-const glColour* toolkit_col      = &cGrey70; /**< Normal outline colour. */
-const glColour* toolkit_colDark  = &cGrey30; /**< Dark outline colour. */
+const glColour* toolkit_colLight = &cGrey60; /**< Light outline colour. */
+const glColour* toolkit_col      = &cGrey40; /**< Normal outline colour. */
+const glColour* toolkit_colDark  = &cGrey20; /**< Dark outline colour. */
 
 
 /*
@@ -1222,18 +1222,17 @@ static void window_renderBorder( Window* w )
    y = w->y;
 
    /* colours */
-   lc = &cGrey90;
-   c = &cGrey70;
-   dc = &cGrey50;
-   oc = &cGrey30;
+   lc = toolkit_col;
+   c = toolkit_col;
+   dc = toolkit_col;
+   oc = toolkit_colLight;
 
    /*
     * Case fullscreen.
     */
    if (window_isFlag( w, WINDOW_FULLSCREEN )) {
       /* Background. */
-      toolkit_drawRect( x, y,          w->w, 0.6*w->h, dc, c );
-      toolkit_drawRect( x, y+0.6*w->h, w->w, 0.4*w->h, c, NULL );
+      toolkit_drawRect( x, y, w->w, w->h, c, NULL );
       /* Name. */
       gl_printMidRaw( &gl_defFont, w->w,
             x,
@@ -1359,13 +1358,11 @@ void toolkit_drawScrollbar( int x, int y, int w, int h, double pos )
    double sy;
 
    /* scrollbar background */
-   toolkit_drawRect( x, y, w, h, toolkit_colDark, toolkit_col );
-   /* toolkit_drawOutline( x, y, w, h,  0., toolkit_colDark, NULL ); */
-   /* toolkit_drawOutline( x, y, w, h, 0., toolkit_colLight, toolkit_col ); */
+   toolkit_drawRect( x, y, w, h, toolkit_colDark, NULL );
 
    /* Bar itself. */
    sy = y + (h - 30.) * (1.-pos);
-   toolkit_drawRect( x, sy, w, 30., toolkit_colLight, toolkit_col );
+   toolkit_drawRect( x, sy, w, 30., toolkit_colLight, NULL );
    toolkit_drawOutline( x + 1, sy, w - 1, 30., 0., toolkit_colDark, NULL );
 }
 

--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -1202,7 +1202,7 @@ void toolkit_drawAltText( int bx, int by, const char *alt )
    c2.a = 0.7;
    toolkit_drawRect( x-1, y-5, w+6, h+6, &c2, NULL );
    toolkit_drawRect( x-3, y-3, w+6, h+6, &c, NULL );
-   gl_printTextRaw( &gl_smallFont, w, h, x, y, &cBlack, alt );
+   gl_printTextRaw( &gl_smallFont, w, h, x, y, &cFontWhite, alt );
 }
 
 
@@ -1238,7 +1238,7 @@ static void window_renderBorder( Window* w )
       gl_printMidRaw( &gl_defFont, w->w,
             x,
             y + w->h - 20.,
-            &cBlack, w->name );
+            &cFontWhite, w->name );
       return;
    }
 
@@ -1269,7 +1269,7 @@ static void window_renderBorder( Window* w )
    gl_printMidRaw( &gl_defFont, w->w,
          x,
          y + w->h - 20.,
-         &cBlack, w->name );
+         &cFontWhite, w->name );
 }
 
 

--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -1214,25 +1214,17 @@ void toolkit_drawAltText( int bx, int by, const char *alt )
 static void window_renderBorder( Window* w )
 {
    double x, y;
-   const glColour *lc, *c, *dc, *oc;
-   gl_Matrix4 projection;
 
    /* position */
    x = w->x;
    y = w->y;
-
-   /* colours */
-   lc = toolkit_col;
-   c = toolkit_col;
-   dc = toolkit_col;
-   oc = toolkit_colLight;
 
    /*
     * Case fullscreen.
     */
    if (window_isFlag( w, WINDOW_FULLSCREEN )) {
       /* Background. */
-      toolkit_drawRect( x, y, w->w, w->h, c, NULL );
+      toolkit_drawRect( x, y, w->w, w->h, toolkit_col, NULL );
       /* Name. */
       gl_printMidRaw( &gl_defFont, w->w,
             x,
@@ -1241,26 +1233,9 @@ static void window_renderBorder( Window* w )
       return;
    }
 
-   projection = gl_view_matrix;
-   projection = gl_Matrix4_Translate(projection, w->x, w->y, 0);
-   projection = gl_Matrix4_Scale(projection, w->w, w->h, 1);
-
-   glUseProgram(shaders.tk.program);
-   glEnableVertexAttribArray(shaders.tk.vertex);
-   gl_uniformColor(shaders.tk.dc, dc);
-   gl_uniformColor(shaders.tk.c, c);
-   gl_uniformColor(shaders.tk.oc, oc);
-   gl_uniformColor(shaders.tk.lc, lc);
-   gl_Matrix4_Uniform(shaders.tk.projection, projection);
-   glUniform2f(shaders.tk.wh, w->w, w->h);
-   glUniform1f(shaders.tk.corner_radius, 10. / gl_screen.scale);
-
-   gl_vboActivateAttribOffset( gl_squareVBO, shaders.tk.vertex, 0, 2, GL_FLOAT, 0 );
-   glDrawArrays( GL_TRIANGLE_STRIP, 0, 4 );
-
-   glDisableVertexAttribArray(shaders.tk.vertex);
-   glUseProgram(0);
-   gl_checkErr();
+   toolkit_drawRect( x, y, w->w, w->h, toolkit_col, NULL );
+   toolkit_drawOutlineThick( x, y, w->w, w->h, 1, 2, toolkit_colDark, NULL );
+   toolkit_drawOutline( x + 3, y + 2, w->w - 5, w->h - 5, 1, toolkit_colLight, NULL );
 
    /*
     * render window name


### PR DESCRIPTION
This has been a long time coming, and we've finally managed to do it! I think I've achieved something that looks fantastic and finally, completely solves the issue of text contrast forever.

The first thing we did was Emmy added text outlines in an admittedly crude fashion; the method is borrowed from Project: Starfighter.

Then we changed the text colors from black to white (and dark to light).

And then we noticed something: tk having a bright background was creating some eye strain, so we set out to change that and thought, you know, since we've gotten our hands dirty with the toolkit, we might as well do something we've wanted to do for months: flatten the colors and make it look much nicer!

![Screenshot at 2020-08-01 20-52-48](https://user-images.githubusercontent.com/2217995/89113080-26101000-d43a-11ea-9459-364f448c8c9a.png)
![Screenshot at 2020-08-01 20-56-28](https://user-images.githubusercontent.com/2217995/89113081-290b0080-d43a-11ea-80b8-3c2d0fea3eec.png)

Behold, the new look of Naev! It's nice and simple, so it doesn't look like a product of the early 2000s, and it's dark, so it's easy on the eyes. We also made it so that it would be easy to change the colors in the future, as well, removing most custom cGrey color usages and replacing them with the three standard colors.

I believe everything looks good and this should be merged ASAP. However, I'd like to make sure we agree that this is an improvement first since I've changed the entire look of Naev. 🙂

🕷️