### PR TITLE
Fixed typo for Stormy description

### DIFF
--- a/dat/assets/stormy.xml
+++ b/dat/assets/stormy.xml
@@ -27,7 +27,7 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>This gas giant serves as a resource gathering and advanced atmospheric research node. With stations dotting its orbit as low as is safe (and perhaps a biut lower than that). The facilities here are frequently used in the construction of advanced beam weaponry, allowing a larger-than-usual presence of the Za'lek militiary.</description>
+  <description>This gas giant serves as a resource gathering and advanced atmospheric research node. With stations dotting its orbit as low as is safe (and perhaps a bit lower than that). The facilities here are frequently used in the construction of advanced beam weaponry, allowing a larger-than-usual presence of the Za'lek militiary.</description>
   <bar>This bar is signifigantly neater than most Za'lek spaceport bars. That is not to say it's orderly. The patrons are overwhelmingly gas miners, manufacturers and a few militia. The drinks glow suspiciously and the bartender smirks as you side-eye them.</bar>
  </general>
  <tech>


### PR DESCRIPTION
There was a typo in the description for the Planet Stormy. This pull request fixes that.