### PR TITLE
Update naev_nightly.yml

### DIFF
--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -380,4 +380,4 @@ jobs:
           title: "Nightly Build"
           files: |
             ${{ github.workspace }}/dist/*
-      if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
+        if: ${{ github.repository == 'naev/naev' }}


### PR DESCRIPTION
Turns out that I accidentally left an extra variable in when uploading the release.

The initial reason I added an additional check is so that forks don't create their own releases automatically.

Since there is no push even when a release is created, nothing is done.