### PR TITLE
Rarity Adjustment

### DIFF
--- a/dat/outfits/activated/emergency_shield_booster.xml
+++ b/dat/outfits/activated/emergency_shield_booster.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Emergency Shield Booster">
  <general>
-  <rarity>2</rarity>
   <slot>utility</slot>
   <size>small</size>
   <mass>2</mass>

--- a/dat/outfits/activated/generic_afterburner.xml
+++ b/dat/outfits/activated/generic_afterburner.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Generic Afterburner">
  <general>
-  <rarity>1</rarity>
   <slot>utility</slot>
   <size>small</size>
   <mass>6</mass>

--- a/dat/outfits/activated/hellburner.xml
+++ b/dat/outfits/activated/hellburner.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Hellburner">
  <general>
-  <rarity>3</rarity>
   <slot>utility</slot>
   <size>small</size>
   <mass>10</mass>

--- a/dat/outfits/activated/hidden_jump_scanner.xml
+++ b/dat/outfits/activated/hidden_jump_scanner.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Hidden Jump Scanner">
  <general>
-  <rarity>1</rarity>
+  <rarity>6</rarity>
   <slot>utility</slot>
   <size>small</size>
   <mass>2</mass>

--- a/dat/outfits/activated/milspec_jammer.xml
+++ b/dat/outfits/activated/milspec_jammer.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Milspec Jammer">
  <general>
-  <rarity>3</rarity>
   <slot>utility</slot>
   <size>small</size>
   <mass>3</mass>

--- a/dat/outfits/activated/unicorp_jammer.xml
+++ b/dat/outfits/activated/unicorp_jammer.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Unicorp Jammer">
  <general>
-  <rarity>2</rarity>
   <slot>utility</slot>
   <size>small</size>
   <mass>2</mass>

--- a/dat/outfits/bio_weapons/bioplasma_organ_stage_1.xml
+++ b/dat/outfits/bio_weapons/bioplasma_organ_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="BioPlasma Organ Stage 1">
  <general>
-  <rarity>2</rarity>
   <slot prop="bio_weapon">weapon</slot>
   <size>small</size>
   <license>Medium Weapon License</license>

--- a/dat/outfits/bio_weapons/bioplasma_organ_stage_2.xml
+++ b/dat/outfits/bio_weapons/bioplasma_organ_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="BioPlasma Organ Stage 2">
  <general>
-  <rarity>3</rarity>
   <slot prop="bio_weapon">weapon</slot>
   <size>small</size>
   <license>Medium Weapon License</license>

--- a/dat/outfits/bio_weapons/bioplasma_organ_stage_3.xml
+++ b/dat/outfits/bio_weapons/bioplasma_organ_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="BioPlasma Organ Stage 3">
  <general>
-  <rarity>4</rarity>
   <slot prop="bio_weapon">weapon</slot>
   <size>small</size>
   <license>Medium Weapon License</license>

--- a/dat/outfits/bio_weapons/bioplasma_organ_stage_x.xml
+++ b/dat/outfits/bio_weapons/bioplasma_organ_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="BioPlasma Organ Stage X">
  <general>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <slot prop="bio_weapon">weapon</slot>
   <size>small</size>
   <license>Medium Weapon License</license>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage 1">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage 2">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage 3">
  <general>
-  <rarity>4</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_4.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage 4">
  <general>
-  <rarity>4</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_5.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_5.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage 5">
  <general>
-  <rarity>5</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_6.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_6.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage 6">
  <general>
-  <rarity>5</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/heavy_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/heavy_bioship_brain_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Brain Stage X">
  <general>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Light Bioship Brain Stage 1">
  <general>
-  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Light Bioship Brain Stage 2">
  <general>
-  <rarity>2</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Light Bioship Brain Stage 3">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_brain/light_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/light_bioship_brain_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Light Bioship Brain Stage X">
  <general>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium Bioship Brain Stage 1">
  <general>
-  <rarity>2</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium Bioship Brain Stage 2">
  <general>
-  <rarity>2</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium Bioship Brain Stage 3">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_4.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium Bioship Brain Stage 4">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/medium_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/medium_bioship_brain_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium Bioship Brain Stage X">
  <general>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Brain Stage 1">
  <general>
-  <rarity>2</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Brain Stage 2">
  <general>
-  <rarity>2</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Brain Stage 3">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_4.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Brain Stage 4">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_5.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_5.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Brain Stage 5">
  <general>
-  <rarity>4</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/mediumheavy_bioship_brain_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Brain Stage X">
  <general>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>medium</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 1">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 2">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_3.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 3">
  <general>
-  <rarity>4</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_4.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_4.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 4">
  <general>
-  <rarity>4</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_5.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_5.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 5">
  <general>
-  <rarity>5</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_6.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_6.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 6">
  <general>
-  <rarity>5</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_7.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_7.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage 7">
  <general>
-  <rarity>5</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/superheavy_bioship_brain_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Brain Stage X">
  <general>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>large</size>

--- a/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_1.xml
+++ b/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Ultralight Bioship Brain Stage 1">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_2.xml
+++ b/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Ultralight Bioship Brain Stage 2">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_x.xml
+++ b/dat/outfits/biocore_brain/ultralight_bioship_brain_stage_x.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Ultralight Bioship Brain Stage X">
  <general>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <typename>Bioship Brain</typename>
   <slot prop="bio_systems">utility</slot>
   <size>small</size>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_1.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Fast Fin Stage 1">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_2.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Fast Fin Stage 2">
  <general>
-  <rarity>3</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_3.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Bioship Fast Fin Stage 3">
  <general>
-  <rarity>4</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_4.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
   <mass>60</mass>
   <price>1350000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_5.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_5.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
   <mass>60</mass>
   <price>1350000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_6.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_6.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
   <mass>60</mass>
   <price>1350000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_fast_fin_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>60</mass>
   <price>1350000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_3.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_4.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_5.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_5.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_6.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_6.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/heavy_bioship_strong_fin_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>75</mass>
   <price>550000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>

--- a/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_1.xml
@@ -9,7 +9,6 @@
   <price>110000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_s2</gfx_store>
-  <rarity>1</rarity>
  </general>
  <specific type="modification">
   <thrust>120</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_2.xml
@@ -9,7 +9,6 @@
   <price>110000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_s2</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>130</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_3.xml
@@ -9,7 +9,6 @@
   <price>110000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_s2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>145</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/light_bioship_fast_fin_stage_x.xml
@@ -4,12 +4,12 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>12</mass>
   <price>110000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>
   <gfx_store>organic_engine_fast_s2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>160</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_1.xml
@@ -9,7 +9,6 @@
   <price>45000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_s2</gfx_store>
-  <rarity>1</rarity>
  </general>
  <specific type="modification">
   <thrust>86</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_2.xml
@@ -9,7 +9,6 @@
   <price>45000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_s2</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>95</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_3.xml
@@ -9,7 +9,6 @@
   <price>45000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_s2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>105</thrust>

--- a/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/light_bioship_strong_fin_stage_x.xml
@@ -4,12 +4,12 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>15</mass>
   <price>45000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>
   <gfx_store>organic_engine_strong_s2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>115</thrust>

--- a/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>20</mass>
   <price>180000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>20</mass>
   <price>180000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_3.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>20</mass>
   <price>180000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_4.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>20</mass>
   <price>180000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_fast_fin_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>20</mass>
   <price>180000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>24</mass>
   <price>75000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>24</mass>
   <price>75000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_3.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>24</mass>
   <price>75000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_4.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>24</mass>
   <price>75000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/medium_bioship_strong_fin_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>24</mass>
   <price>75000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_1.xml
@@ -9,7 +9,6 @@
   <price>325000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_m2</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>75</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_2.xml
@@ -9,7 +9,6 @@
   <price>325000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_m2</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>80</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_3.xml
@@ -9,7 +9,6 @@
   <price>325000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_m2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>85</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_4.xml
@@ -9,7 +9,6 @@
   <price>325000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_m2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>90</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_5.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_5.xml
@@ -9,7 +9,6 @@
   <price>325000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_m2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>95</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_fast_fin_stage_x.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Fast Fin Stage X">
  <general>
+  <rarity>1</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
@@ -9,7 +10,6 @@
   <price>325000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>
   <gfx_store>organic_engine_fast_m2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>100</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_1.xml
@@ -9,7 +9,6 @@
   <price>140000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_m2</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>52</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_2.xml
@@ -9,7 +9,6 @@
   <price>140000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_m2</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>55</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_3.xml
@@ -9,7 +9,6 @@
   <price>140000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_m2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>58</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_4.xml
@@ -9,7 +9,6 @@
   <price>140000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_m2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>62</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_5.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_5.xml
@@ -9,7 +9,6 @@
   <price>140000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_m2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>66</thrust>

--- a/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/mediumheavy_bioship_strong_fin_stage_x.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Medium-Heavy Bioship Strong Fin Stage X">
  <general>
+  <rarity>1</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>medium</size>
@@ -9,7 +10,6 @@
   <price>140000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>
   <gfx_store>organic_engine_strong_m2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>70</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_1.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>37</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_2.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>38</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_3.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>40</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_4.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>42</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_5.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_5.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>44</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_6.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_6.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>46</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_7.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_7.xml
@@ -9,7 +9,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>48</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_fast_fin_stage_x.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Fast Fin Stage X">
  <general>
+  <rarity>1</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
@@ -9,7 +10,6 @@
   <price>1800000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>
   <gfx_store>organic_engine_fast_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>50</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_1.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>26</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_2.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>27</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_3.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_3.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>28</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_4.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_4.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>29</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_5.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_5.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>30</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_6.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_6.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>31</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_7.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_7.xml
@@ -9,7 +9,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>33</thrust>

--- a/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/superheavy_bioship_strong_fin_stage_x.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Superheavy Bioship Strong Fin Stage X">
  <general>
+  <rarity>1</rarity>
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>large</size>
@@ -9,7 +10,6 @@
   <price>750000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>
   <gfx_store>organic_engine_strong_l2</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>35</thrust>

--- a/dat/outfits/biocore_fin/ultralight_bioship_fast_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/ultralight_bioship_fast_fin_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
   <mass>8</mass>
   <price>70000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/ultralight_bioship_fast_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/ultralight_bioship_fast_fin_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
   <mass>8</mass>
   <price>70000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/ultralight_bioship_fast_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/ultralight_bioship_fast_fin_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>8</mass>
   <price>70000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>

--- a/dat/outfits/biocore_fin/ultralight_bioship_strong_fin_stage_1.xml
+++ b/dat/outfits/biocore_fin/ultralight_bioship_strong_fin_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
   <mass>10</mass>
   <price>25000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/ultralight_bioship_strong_fin_stage_2.xml
+++ b/dat/outfits/biocore_fin/ultralight_bioship_strong_fin_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
   <mass>10</mass>
   <price>25000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). All fins start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_fin/ultralight_bioship_strong_fin_stage_x.xml
+++ b/dat/outfits/biocore_fin/ultralight_bioship_strong_fin_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Fin</typename>
   <slot prop="bio_engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>10</mass>
   <price>25000</price>
   <description>The fin is a Soromid bioship's equivalent to engines in synthetic ships. It is charged with moving the organism through space and comes in either a strong form (for heavy loads) or a fast form (for greater speed and agility). This fin has reached Stage X, its full potential.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_3.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_4.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_5.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_5.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_6.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_6.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/heavy_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/heavy_bioship_shell_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>1150</mass>
   <price>1100000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_1.xml
@@ -9,7 +9,6 @@
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_s</gfx_store>
-  <rarity>1</rarity>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_2.xml
@@ -9,7 +9,6 @@
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_s</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_3.xml
@@ -9,7 +9,6 @@
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_s</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/light_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/light_bioship_shell_stage_x.xml
@@ -4,12 +4,12 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>60</mass>
   <price>120000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
   <gfx_store>organic_hull_s</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <cargo>9</cargo>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_3.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_4.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/medium_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/medium_bioship_shell_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>medium</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>110</mass>
   <price>180000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_1.xml
@@ -9,7 +9,6 @@
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_l</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_2.xml
@@ -9,7 +9,6 @@
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_l</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_3.xml
@@ -9,7 +9,6 @@
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_l</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_4.xml
@@ -9,7 +9,6 @@
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_l</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_5.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_5.xml
@@ -9,7 +9,6 @@
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_l</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/mediumheavy_bioship_shell_stage_x.xml
@@ -4,12 +4,12 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>310</mass>
   <price>320000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
   <gfx_store>organic_hull_l</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <cargo>36</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_1.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_2.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_3.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_3.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_4.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_4.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_5.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_5.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_6.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_6.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_7.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_7.xml
@@ -9,7 +9,6 @@
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/superheavy_bioship_shell_stage_x.xml
@@ -4,12 +4,12 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>1950</mass>
   <price>1450000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>
   <gfx_store>organic_hull_x</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <cargo>90</cargo>

--- a/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_1.xml
+++ b/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_1.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
   <mass>30</mass>
   <price>65000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_2.xml
+++ b/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_2.xml
@@ -4,7 +4,6 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
   <mass>30</mass>
   <price>65000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. All shells start off undeveloped, but over time, just like the ships themselves, they grow and improve.</description>

--- a/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_x.xml
+++ b/dat/outfits/biocore_shell/ultralight_bioship_shell_stage_x.xml
@@ -4,7 +4,7 @@
   <typename>Bioship Shell</typename>
   <slot prop="bio_hull">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>30</mass>
   <price>65000</price>
   <description>The shell is a Soromid bioship's natural protection, equivalent to hulls of synthetic ships. The shell is responsible both for protecting the organism's internal organs and for creating camoflauge to reduce the risk of being detected by hostiles. This shell has reached stage X, its full potential.</description>

--- a/dat/outfits/core_engine/beat_up_large_engine.xml
+++ b/dat/outfits/core_engine/beat_up_large_engine.xml
@@ -8,7 +8,6 @@
   <price>0</price>
   <description>Clogged, corroded and cracked in every way possible while still remaining in functional condition, this engine really belongs on the scrap heap.</description>
   <gfx_store>engine02</gfx_store>
-  <rarity>1</rarity>
  </general>
  <specific type="modification">
   <thrust>30</thrust>

--- a/dat/outfits/core_engine/beat_up_medium_engine.xml
+++ b/dat/outfits/core_engine/beat_up_medium_engine.xml
@@ -8,7 +8,6 @@
   <price>0</price>
   <description>Clogged, corroded and cracked in every way possible while still remaining in functional condition, this engine really belongs on the scrap heap.</description>
   <gfx_store>engine03</gfx_store>
-  <rarity>1</rarity>
  </general>
  <specific type="modification">
   <thrust>60</thrust>

--- a/dat/outfits/core_engine/beat_up_small_engine.xml
+++ b/dat/outfits/core_engine/beat_up_small_engine.xml
@@ -8,7 +8,6 @@
   <price>0</price>
   <description>Clogged, corroded and cracked in every way possible while still remaining in functional condition, this engine really belongs on the scrap heap.</description>
   <gfx_store>engine04</gfx_store>
-  <rarity>1</rarity>
  </general>
  <specific type="modification">
   <thrust>100</thrust>

--- a/dat/outfits/core_engine/krain_remige_engine.xml
+++ b/dat/outfits/core_engine/krain_remige_engine.xml
@@ -4,7 +4,7 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>40</mass>
   <price>2400000</price>
   <description>The Remige was developed by Krain Industries exclusively for their flagship cruiser, the Kestrel. Optimized for the Kestrel's needs, the Remige delivers performance exceeding most other cruiser engines in every respect, though its tuning renders it ill-suited to heavier vessels.</description>

--- a/dat/outfits/core_engine/melendez_buffalo_engine.xml
+++ b/dat/outfits/core_engine/melendez_buffalo_engine.xml
@@ -4,7 +4,7 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
+  <rarity>1</rarity>
   <mass>24</mass>
   <price>150000</price>
   <description>The Buffalo is a mid-sized engine intended for light freighters, though it's occasionally seen on particularly well-armed corvettes. As a typical freight-oriented engine, the Buffalo posseses decent top speed, poor handling, and excellent fuel capacity.</description>

--- a/dat/outfits/core_engine/melendez_buffalo_xl_engine.xml
+++ b/dat/outfits/core_engine/melendez_buffalo_xl_engine.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>30</mass>
   <price>280000</price>
   <description>The Buffalo XL is a staple among mid-sized freighters, particularly those carrying dense cargo. Its considerable power leaves it with few competitors in its size class, and more than a few combat vessels rely on it to move them and their arsenals into battle.</description>
   <gfx_store>engine06</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>70</thrust>

--- a/dat/outfits/core_engine/melendez_mammoth_engine.xml
+++ b/dat/outfits/core_engine/melendez_mammoth_engine.xml
@@ -4,7 +4,7 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>75</mass>
   <price>1100000</price>
   <description>Melendez's Mammoth can pull incredible amounts of mass. Requiring specialized grav tethers to keep it attached to the ship's hull, it significantly impacts manoeuvrability, though a reasonable top speed can still be maintained. Many bulk freight corporations only turn a profit thanks to the Mammoth line of engines.</description>

--- a/dat/outfits/core_engine/melendez_mammoth_xl_engine.xml
+++ b/dat/outfits/core_engine/melendez_mammoth_xl_engine.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>100</mass>
   <price>1500000</price>
   <description>The very largest engine that Melendez produces, the Mammoth XL has precious little competition when it comes to moving massive amounts of mass around the galaxy, whether in the form of bulk freight or as the primary engine of a fully-equipped battlecruiser.</description>
   <gfx_store>engine12</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>35</thrust>

--- a/dat/outfits/core_engine/melendez_ox_xl_engine.xml
+++ b/dat/outfits/core_engine/melendez_ox_xl_engine.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>15</mass>
   <price>95000</price>
   <description>Among the most powerful engines available for small vessels, the Ox XL excels at enabling merchants to haul moderate amounts of cargo from system to system with minimal refuelling stops.</description>
   <gfx_store>engine15</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>115</thrust>

--- a/dat/outfits/core_engine/nexus_arrow_1200_engine.xml
+++ b/dat/outfits/core_engine/nexus_arrow_1200_engine.xml
@@ -9,7 +9,6 @@
   <price>225000</price>
   <description>Derived from the smaller Arrow 550, the Arrow 1200 is intended for use on destroyers and mid-sized freighters. With moderate power consumption and solid performance, it's found on many seasoned captains' ships.</description>
   <gfx_store>engine14</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>87</thrust>

--- a/dat/outfits/core_engine/nexus_arrow_550_engine.xml
+++ b/dat/outfits/core_engine/nexus_arrow_550_engine.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>20</mass>
   <price>120000</price>
   <description>The Arrow 550 is a respectable engine for a respectable price, giving the serious captain the means to pilot his ship to effect.</description>

--- a/dat/outfits/core_engine/nexus_bolt_4500_engine.xml
+++ b/dat/outfits/core_engine/nexus_bolt_4500_engine.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>60</mass>
   <price>900000</price>
   <description>The Bolt 4500 is a mid-range engine designed for light cruisers. Like most Nexus engines, it doesn't excel in any particular aspect, but its lack of over-specialization allows it to be flexible, whether it's propelling a cruiser into combat or moving a freighter through a system.</description>

--- a/dat/outfits/core_engine/nexus_bolt_6500_engine.xml
+++ b/dat/outfits/core_engine/nexus_bolt_6500_engine.xml
@@ -9,7 +9,6 @@
   <price>1200000</price>
   <description>Though lacking the glamour of flagship models from the likes of Tricon, the Nexus Bolt 6500 is nonetheless a respectable engine used by many captains. As a general-purpose engine, it lacks the sheer power of a Melendez engine, can't quite keep up with Tricon offerings, yet costs less than either, and manages to maintain a balance between all of its attributes.</description>
   <gfx_store>engine11</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>45</thrust>

--- a/dat/outfits/core_engine/nexus_dart_150_engine.xml
+++ b/dat/outfits/core_engine/nexus_dart_150_engine.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>small</size>
-  <rarity>2</rarity>
   <mass>8</mass>
   <price>45000</price>
   <description>The Dart 150 is a well-rounded engine for light vessels. While it doesn't excel in any particular respect, it offers good handling and power efficiency for a reasonable price. A very popular engine among civilian and military users alike.</description>

--- a/dat/outfits/core_engine/nexus_dart_300_engine.xml
+++ b/dat/outfits/core_engine/nexus_dart_300_engine.xml
@@ -9,7 +9,6 @@
   <price>75000</price>
   <description>The Dart 300 is a larger variant of Nexus's popular Dart 150, aimed at heavy fighters and light-duty cargo vessels. Its modest energy consumption allows it to be equipped on most vessels without requiring reactor upgrades.</description>
   <gfx_store>engine09</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>140</thrust>

--- a/dat/outfits/core_engine/tricon_cyclone_engine.xml
+++ b/dat/outfits/core_engine/tricon_cyclone_engine.xml
@@ -4,7 +4,7 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>20</mass>
   <price>360000</price>
   <description>Tricon's Cyclone engine upholds the corporation's reputation for premium engines with superb performance. Many large navies and wealthier mercenaries employ the Cyclone in their corvettes.</description>

--- a/dat/outfits/core_engine/tricon_cyclone_ii_engine.xml
+++ b/dat/outfits/core_engine/tricon_cyclone_ii_engine.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>25</mass>
   <price>675000</price>
   <description>A preferred engine of destroyer and time-focused freighter captains, the Cyclone II retains most of the original Cyclone's performance while more than doubling the engine's mass capacity. Its high power consumption is typically gladly written off given its exemplary performance.</description>
   <gfx_store>engine07</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>100</thrust>

--- a/dat/outfits/core_engine/tricon_typhoon_engine.xml
+++ b/dat/outfits/core_engine/tricon_typhoon_engine.xml
@@ -4,7 +4,7 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>60</mass>
   <price>2700000</price>
   <description>Development of the Typhoon engine was something of a prestige project for Tricon. Providing light cruisers with superb handling and speed, it's a favourite of many captains, though its high power consumption limits it to ships with powerful reactors.</description>

--- a/dat/outfits/core_engine/tricon_typhoon_ii_engine.xml
+++ b/dat/outfits/core_engine/tricon_typhoon_ii_engine.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>80</mass>
   <price>3600000</price>
   <description>The largest Tricon engine in production, the Typhoon II boasts surprisingly high performance for a capital ship engine. Its power consumption is markedly higher than anything in its class, but most captains are willing to make the trade for superior manoeuvrability</description>
   <gfx_store>engine05</gfx_store>
-  <rarity>5</rarity>
  </general>
  <specific type="modification">
   <thrust>50</thrust>

--- a/dat/outfits/core_engine/tricon_zephyr_engine.xml
+++ b/dat/outfits/core_engine/tricon_zephyr_engine.xml
@@ -4,7 +4,7 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>8</mass>
   <price>135000</price>
   <description>For light vessel pilots who demand unparalleled performance, Tricon's Zephyr is the engine of choice. Its best-in-class handling does come with the caveat of markedly increased power consumption, but those flying with Tricon engines can usually afford the requisite reactor upgrades.</description>

--- a/dat/outfits/core_engine/tricon_zephyr_ii_engine.xml
+++ b/dat/outfits/core_engine/tricon_zephyr_ii_engine.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>12</mass>
   <price>225000</price>
   <description>A larger version of Tricon's original Zephyr intended for heavy fighters, the Zephyr II affords heavier fighters and bombers to move like scout ships. Its performance has not gone unnoticed by merchants either, resulting in its use for lightweight, time-critical shipping.</description>
   <gfx_store>engine10</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>160</thrust>

--- a/dat/outfits/core_engine/unicorp_eagle_4500_engine.xml
+++ b/dat/outfits/core_engine/unicorp_eagle_4500_engine.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>50</mass>
   <price>300000</price>
   <description>Inexpensive by capital ship standards, the Eagle 4500 is seldom selected by captains who can afford better. While spaceworthy, the engine's performance renders it a liability in combat and uneconomical for freight hauling.</description>

--- a/dat/outfits/core_engine/unicorp_eagle_6500_engine.xml
+++ b/dat/outfits/core_engine/unicorp_eagle_6500_engine.xml
@@ -9,7 +9,6 @@
   <price>400000</price>
   <description>The Eagle 6500 is Unicorp's largest and highest-capacity engine, though perhaps not a flagship model. Its relatively low price makes it attractive to captains on a tight budget, if their performance demands aren't too great.</description>
   <gfx_store>engine02</gfx_store>
-  <rarity>4</rarity>
  </general>
  <specific type="modification">
   <thrust>37</thrust>

--- a/dat/outfits/core_engine/unicorp_falcon_1200_engine.xml
+++ b/dat/outfits/core_engine/unicorp_falcon_1200_engine.xml
@@ -9,7 +9,6 @@
   <price>75000</price>
   <description>The Falcon 1200 is the larger brother to the Falcon 550. Commonly found on mid-sized short-haul freighters, its relatively low performance and fuel capacity makes it a poor choice for longer routes.</description>
   <gfx_store>engine03</gfx_store>
-  <rarity>3</rarity>
  </general>
  <specific type="modification">
   <thrust>75</thrust>

--- a/dat/outfits/core_engine/unicorp_falcon_550_engine.xml
+++ b/dat/outfits/core_engine/unicorp_falcon_550_engine.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>16</mass>
   <price>40000</price>
   <description>The Falcon 550 is a low-budget engine for use on corvettes and similarly-sized vessels. Its middling performance relegates it primarily to use on civilians vessels, as few captains are comfortable relying on bargain-priced propulsion systems when engaged in battle.</description>

--- a/dat/outfits/core_engine/unicorp_hawk_150_engine.xml
+++ b/dat/outfits/core_engine/unicorp_hawk_150_engine.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Engine)</typename>
   <slot prop="engines">structure</slot>
   <size>small</size>
-  <rarity>1</rarity>
   <mass>6</mass>
   <price>15000</price>
   <description>The Hawk 150 is a low-budget, general-purpose engine many civilians use to propel their ships. It's not particularly effective, but it's a lightweight engine with low energy demands, making it a solid choice for small vessels.</description>

--- a/dat/outfits/core_engine/unicorp_hawk_300_engine.xml
+++ b/dat/outfits/core_engine/unicorp_hawk_300_engine.xml
@@ -9,7 +9,6 @@
   <price>25000</price>
   <description>The Hawk 300 is an enlarged version of the Hawk 150 engine, optimized for heavier loads. Like its smaller counterpart, it offers modest performance for a low price.</description>
   <gfx_store>engine04</gfx_store>
-  <rarity>2</rarity>
  </general>
  <specific type="modification">
   <thrust>120</thrust>

--- a/dat/outfits/core_hull/dummy_plating.xml
+++ b/dat/outfits/core_hull/dummy_plating.xml
@@ -9,7 +9,7 @@
   <price>0</price>
   <description>This is a dummy  hull for use in missions only, which does nothing. DO NOT BUY.</description>
   <gfx_store>plating_patchwork</gfx_store>
- <priority>3</priority></general>
+ </general>
  <specific type="modification">
   <cargo>0</cargo>
   <absorb>0</absorb>

--- a/dat/outfits/core_hull/patchwork_heavy_plating.xml
+++ b/dat/outfits/core_hull/patchwork_heavy_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
+  <priority>3</priority>
   <mass>720</mass>
   <price>0</price>
   <description>On the plus side, it keeps air from venting into space. But that's about it. This kind of hull maintenance is simply unacceptable.</description>
   <gfx_store>plating_patchwork</gfx_store>
- <priority>3</priority></general>
+ </general>
  <specific type="modification">
   <cargo>50</cargo>
   <absorb>24</absorb>

--- a/dat/outfits/core_hull/patchwork_light_plating.xml
+++ b/dat/outfits/core_hull/patchwork_light_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <priority>3</priority>
   <mass>24</mass>
   <price>0</price>
   <description>On the plus side, it keeps air from venting into space. But that's about it. This kind of hull maintenance is simply unacceptable.</description>
   <gfx_store>plating_patchwork</gfx_store>
- <priority>3</priority></general>
+ </general>
  <specific type="modification">
   <cargo>3</cargo>
   <absorb>4</absorb>

--- a/dat/outfits/core_hull/patchwork_medium_plating.xml
+++ b/dat/outfits/core_hull/patchwork_medium_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
+  <priority>3</priority>
   <mass>90</mass>
   <price>0</price>
   <description>On the plus side, it keeps air from venting into space. But that's about it. This kind of hull maintenance is simply unacceptable.</description>
   <gfx_store>plating_patchwork</gfx_store>
- <priority>3</priority></general>
+ </general>
  <specific type="modification">
   <cargo>12</cargo>
   <absorb>11</absorb>

--- a/dat/outfits/core_hull/sk_heavy_combat_plating.xml
+++ b/dat/outfits/core_hull/sk_heavy_combat_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>1150</mass>
   <price>2200000</price>
   <description>This heavy plating developed by Schafer &amp; Kane Industries can endure prolonged battle. Quite a few captains and their crews owe their lives to this armour configuration.</description>
   <gfx_store>combat_hull_l</gfx_store>
- <priority>3</priority></general>
+ </general>
  <specific type="modification">
   <cargo>65</cargo>
   <absorb>34</absorb>

--- a/dat/outfits/core_hull/sk_large_cargo_hull.xml
+++ b/dat/outfits/core_hull/sk_large_cargo_hull.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>1150</mass>
   <price>1100000</price>
   <description>This cargo hull from Schafer &amp; Kane Industries makes use of state-of-the-art defensive alloys, which allows it to free up even more space for cargo without sacrificing too much durability.</description>
   <gfx_store>large_cargo_hull</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>300</cargo>
   <absorb>27</absorb>

--- a/dat/outfits/core_hull/sk_light_combat_plating.xml
+++ b/dat/outfits/core_hull/sk_light_combat_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>80</mass>
   <price>240000</price>
   <description>Schafer &amp; Kane Industries mostly develop for larger ships, but the Light Combat Plating configuration is a product made for fighters and bombers, providing optimum protection.</description>
   <gfx_store>combat_hull_s</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>8</cargo>
   <absorb>8</absorb>

--- a/dat/outfits/core_hull/sk_light_stealth_plating.xml
+++ b/dat/outfits/core_hull/sk_light_stealth_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>60</mass>
   <price>180000</price>
   <description>Designed for military scouting and patrol vessels, Schafer &amp; Kane's Light Stealth Plating configuration features the latest in sensor-absorbing materials and geometry.</description>
   <gfx_store>stealth_hull_s</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>6</cargo>
   <absorb>7</absorb>

--- a/dat/outfits/core_hull/sk_medium_cargo_hull.xml
+++ b/dat/outfits/core_hull/sk_medium_cargo_hull.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>140</mass>
   <price>320000</price>
   <description>Schafer &amp; Kane Industries have developed a hull modification that provides both ample cargo space and protection.</description>
   <gfx_store>medium_cargo_hull</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>120</cargo>
   <absorb>12</absorb>

--- a/dat/outfits/core_hull/sk_medium_combat_plating.xml
+++ b/dat/outfits/core_hull/sk_medium_combat_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>140</mass>
   <price>360000</price>
   <description>Designed for corvettes and similarly-sized vessels, Schafer &amp; Kane's medium combat plating provides ample protection utilizing the latest in defensive materials.</description>
   <gfx_store>combat_hull_m</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>16</cargo>
   <absorb>16</absorb>

--- a/dat/outfits/core_hull/sk_medium_stealth_plating.xml
+++ b/dat/outfits/core_hull/sk_medium_stealth_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>110</mass>
   <price>270000</price>
   <description>Medium-sized ships are usually not in the business of remaining undetected, but Schafer &amp; Kane Industries have nevertheless developed a hull modification that helps in this area</description>
   <gfx_store>stealth_hull_m</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>12</cargo>
   <absorb>15</absorb>

--- a/dat/outfits/core_hull/sk_mediumheavy_combat_plating.xml
+++ b/dat/outfits/core_hull/sk_mediumheavy_combat_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>310</mass>
   <price>640000</price>
   <description>Designed for destroyers and similarly-sized vessels, Schafer &amp; Kane's medium-heavy combat plating provides excellent protection from everything save capital-class threats.</description>
   <gfx_store>combat_hull_h</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>32</cargo>
   <absorb>23</absorb>

--- a/dat/outfits/core_hull/sk_mediumheavy_stealth_plating.xml
+++ b/dat/outfits/core_hull/sk_mediumheavy_stealth_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>240</mass>
   <price>480000</price>
   <description>Though vessels weighing in at nearly a thousand tonnes can seldom be called stealthy, Schafer &amp; Kane's medium-heavy stealth plating does what it can to reduce sensor signatures, without sacrificing protection.</description>
   <gfx_store>stealth_hull_h</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>25</cargo>
   <absorb>21</absorb>

--- a/dat/outfits/core_hull/sk_small_cargo_hull.xml
+++ b/dat/outfits/core_hull/sk_small_cargo_hull.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>40</mass>
   <price>120000</price>
   <description>Though a pricey investment for small couriers, this hull modification from Schafer &amp; Kane Industries provides an impressive amount of cargo space without compromising the hull's integrity.</description>
   <gfx_store>small_cargo_hull</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>30</cargo>
   <absorb>4</absorb>

--- a/dat/outfits/core_hull/sk_superheavy_combat_plating.xml
+++ b/dat/outfits/core_hull/sk_superheavy_combat_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>1950</mass>
   <price>2900000</price>
   <description>Considered the best standard plating configuration on the market, this hull modification from Schafer &amp; Kane Industries is generally found only on important capital ships.</description>
   <gfx_store>combat_hull_x</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>80</cargo>
   <absorb>40</absorb>

--- a/dat/outfits/core_hull/sk_ultralight_combat_plating.xml
+++ b/dat/outfits/core_hull/sk_ultralight_combat_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>40</mass>
   <price>130000</price>
   <description>Schafer &amp; Kane Industries mostly develop for larger ships, but the Ultralight Combat Plating configuration is a product made for light fighters and in-system patrol craft, providing optimum protection.</description>
   <gfx_store>combat_hull_t</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>4</cargo>
   <absorb>6</absorb>

--- a/dat/outfits/core_hull/sk_ultralight_stealth_plating.xml
+++ b/dat/outfits/core_hull/sk_ultralight_stealth_plating.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>30</mass>
   <price>95000</price>
   <description>Designed for military scouting vessels, Schafer &amp; Kane's Ultralight Stealth Plating configuration features the latest in sensor-absorbing materials and geometry.</description>
   <gfx_store>stealth_hull_t</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>3</cargo>
   <absorb>5</absorb>

--- a/dat/outfits/core_hull/unicorp_b12_medium_plating.xml
+++ b/dat/outfits/core_hull/unicorp_b12_medium_plating.xml
@@ -9,7 +9,7 @@
   <price>200000</price>
   <description>Unicorp's B-12 plating is based on their D-12 design, substituting denser materials to increase armour effectiveness.</description>
   <gfx_store>refined_hull_h</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>40</cargo>
   <absorb>20</absorb>

--- a/dat/outfits/core_hull/unicorp_b16_heavy_plating.xml
+++ b/dat/outfits/core_hull/unicorp_b16_heavy_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>
-  <rarity>4</rarity>
   <mass>900</mass>
   <price>700000</price>
   <description>B-16 plating improves on Unicorp's D-16 plating, offering increased protection and cargo capacity, for only slightly increased mass.</description>
   <gfx_store>refined_hull_l</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>80</cargo>
   <absorb>30</absorb>

--- a/dat/outfits/core_hull/unicorp_b20_heavy_plating.xml
+++ b/dat/outfits/core_hull/unicorp_b20_heavy_plating.xml
@@ -9,7 +9,7 @@
   <price>900000</price>
   <description>Derived from the venerable D-20 plating, the B-20 utilizes high-density composites to provide additional protection while also leaving more room for cargo, at the cost of slightly increased mass.</description>
   <gfx_store>refined_hull_x</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>100</cargo>
   <absorb>35</absorb>

--- a/dat/outfits/core_hull/unicorp_b2_light_plating.xml
+++ b/dat/outfits/core_hull/unicorp_b2_light_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
-  <rarity>2</rarity>
   <mass>30</mass>
   <price>40000</price>
   <description>Built with more sophisticated materials but fundamentally similar to the D-2 plating, the B-2 is a notable improvement over its predecessor in many respects, though it comes at a significantly increased price.</description>
   <gfx_store>refined_hull_t</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>5</cargo>
   <absorb>5</absorb>

--- a/dat/outfits/core_hull/unicorp_b4_light_plating.xml
+++ b/dat/outfits/core_hull/unicorp_b4_light_plating.xml
@@ -9,7 +9,7 @@
   <price>75000</price>
   <description>Built with more sophisticated materials but fundamentally similar to the D-4 plating, the B-4 is a notable improvement over its predecessor in many respects, though it comes at a significantly increased price.</description>
   <gfx_store>refined_hull_s</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>10</cargo>
   <absorb>7</absorb>

--- a/dat/outfits/core_hull/unicorp_b8_medium_plating.xml
+++ b/dat/outfits/core_hull/unicorp_b8_medium_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>110</mass>
   <price>110000</price>
   <description>Unicorp's B-8 plating is a marked improvement over the more common D-8 offering, bringing significantly improved protection and additional cargo space.</description>
   <gfx_store>refined_hull_m</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>20</cargo>
   <absorb>14</absorb>

--- a/dat/outfits/core_hull/unicorp_d12_medium_plating.xml
+++ b/dat/outfits/core_hull/unicorp_d12_medium_plating.xml
@@ -9,7 +9,7 @@
   <price>80000</price>
   <description>Unicorp's D-12 plating is similar to D-8 plating, but the armour plates are thicker and built atop an enlarged superstructure, increasing mass, armour, and cargo capacity.</description>
   <gfx_store>base_hull_h</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>36</cargo>
   <absorb>18</absorb>

--- a/dat/outfits/core_hull/unicorp_d16_heavy_plating.xml
+++ b/dat/outfits/core_hull/unicorp_d16_heavy_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>800</mass>
   <price>280000</price>
   <description>Though a respectable design, the D-16 plating is outclassed by modern heavy weapons, with most seasoned captains opting for a heavier, more advanced plating.</description>
   <gfx_store>base_hull_l</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>70</cargo>
   <absorb>27</absorb>

--- a/dat/outfits/core_hull/unicorp_d20_heavy_plating.xml
+++ b/dat/outfits/core_hull/unicorp_d20_heavy_plating.xml
@@ -9,7 +9,7 @@
   <price>360000</price>
   <description>Though a respectable design, the D-20 plating is outclassed by modern heavy weapons, with most seasoned captains opting for a heavier, more advanced plating.</description>
   <gfx_store>base_hull_x</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>90</cargo>
   <absorb>31</absorb>

--- a/dat/outfits/core_hull/unicorp_d2_light_plating.xml
+++ b/dat/outfits/core_hull/unicorp_d2_light_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>
-  <rarity>1</rarity>
   <mass>27</mass>
   <price>16000</price>
   <description>Commonly found on civilian vessels, the D-2 plating is popular with ship manufacturers due to its low cost and adequate, if uninspiring performance.</description>
   <gfx_store>base_hull_t</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>4</cargo>
   <absorb>4</absorb>

--- a/dat/outfits/core_hull/unicorp_d4_light_plating.xml
+++ b/dat/outfits/core_hull/unicorp_d4_light_plating.xml
@@ -9,7 +9,7 @@
   <price>30000</price>
   <description>Commonly found on civilian vessels, the D-4 plating is popular with ship manufacturers due to its low cost and adequate, if uninspiring performance.</description>
   <gfx_store>base_hull_s</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>9</cargo>
   <absorb>6</absorb>

--- a/dat/outfits/core_hull/unicorp_d8_medium_plating.xml
+++ b/dat/outfits/core_hull/unicorp_d8_medium_plating.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>
-  <rarity>2</rarity>
   <mass>100</mass>
   <price>45000</price>
   <description>D-8 plating provides a serviceable layer of armour to medium ships, and doesn't weigh too much.</description>
   <gfx_store>base_hull_m</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cargo>18</cargo>
   <absorb>12</absorb>

--- a/dat/outfits/core_system/milspec_aegis_2201_core_system.xml
+++ b/dat/outfits/core_system/milspec_aegis_2201_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>12</mass>
   <price>80000</price>
   <description>Milspec cares about your personal safety. Your protection is our concern. The Aegis 2201 grants your ship excellent shield strength while preserving a high level of subsystem control and energy capacity. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_shield_s1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>36</cpu_max>
   <shield>250</shield>

--- a/dat/outfits/core_system/milspec_aegis_3601_core_system.xml
+++ b/dat/outfits/core_system/milspec_aegis_3601_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>45</mass>
   <price>140000</price>
   <description>Milspec cares about your personal safety. Your protection is our concern. The Aegis 3601 grants your ship excellent shield strength while preserving a high level of subsystem control and energy capacity. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_shield_s2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>50</cpu_max>
   <shield>310</shield>

--- a/dat/outfits/core_system/milspec_aegis_4701_core_system.xml
+++ b/dat/outfits/core_system/milspec_aegis_4701_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>80</mass>
   <price>220000</price>
   <description>Milspec cares about your personal safety. Your protection is our concern. The Aegis 4701 grants your ship excellent shield strength while preserving a high level of subsystem control and energy capacity. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_shield_m1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>68</cpu_max>
   <shield>550</shield>

--- a/dat/outfits/core_system/milspec_aegis_5401_core_system.xml
+++ b/dat/outfits/core_system/milspec_aegis_5401_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>180</mass>
   <price>400000</price>
   <description>Milspec cares about your personal safety. Your protection is our concern. The Aegis 5401 grants your ship excellent shield strength while preserving a high level of subsystem control and energy capacity. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_shield_m2</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>100</cpu_max>
   <shield>700</shield>

--- a/dat/outfits/core_system/milspec_aegis_8501_core_system.xml
+++ b/dat/outfits/core_system/milspec_aegis_8501_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>600</mass>
   <price>2000000</price>
   <description>Milspec cares about your personal safety. Your protection is our concern. The Aegis 8501 grants your ship excellent shield strength while preserving a high level of subsystem control and energy capacity. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_shield_l1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>180</cpu_max>
   <shield>1050</shield>

--- a/dat/outfits/core_system/milspec_aegis_9801_core_system.xml
+++ b/dat/outfits/core_system/milspec_aegis_9801_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>975</mass>
   <price>2600000</price>
   <description>Milspec cares about your personal safety. Your protection is our concern. The Aegis 9801 grants your ship excellent shield strength while preserving a high level of subsystem control and energy capacity. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_shield_l2</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>235</cpu_max>
   <shield>1200</shield>

--- a/dat/outfits/core_system/milspec_hermes_2202_core_system.xml
+++ b/dat/outfits/core_system/milspec_hermes_2202_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>12</mass>
   <price>80000</price>
   <description>Milspec knows that a ship is merely the sum of its parts, and that means that the more parts, the better the ship. The Hermes 2202 provides serious subsystem control whilst retaining the high standard in energy and shielding that Milspec prides itself on. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_cpu_s1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>50</cpu_max>
   <shield>180</shield>

--- a/dat/outfits/core_system/milspec_hermes_3602_core_system.xml
+++ b/dat/outfits/core_system/milspec_hermes_3602_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>45</mass>
   <price>140000</price>
   <description>Milspec knows that a ship is merely the sum of its parts, and that means that the more parts, the better the ship. The Hermes 3602 provides serious subsystem control whilst retaining the high standard in energy and shielding that Milspec prides itself on. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_cpu_s2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>70</cpu_max>
   <shield>225</shield>

--- a/dat/outfits/core_system/milspec_hermes_4702_core_system.xml
+++ b/dat/outfits/core_system/milspec_hermes_4702_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>80</mass>
   <price>220000</price>
   <description>Milspec knows that a ship is merely the sum of its parts, and that means that the more parts, the better the ship. The Hermes 4702 provides serious subsystem control whilst retaining the high standard in energy and shielding that Milspec prides itself on. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_cpu_m1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>95</cpu_max>
   <shield>400</shield>

--- a/dat/outfits/core_system/milspec_hermes_5402_core_system.xml
+++ b/dat/outfits/core_system/milspec_hermes_5402_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>180</mass>
   <price>400000</price>
   <description>Milspec knows that a ship is merely the sum of its parts, and that means that the more parts, the better the ship. The Hermes 5402 provides serious subsystem control whilst retaining the high standard in energy and shielding that Milspec prides itself on. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_cpu_m2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>135</cpu_max>
   <shield>500</shield>

--- a/dat/outfits/core_system/milspec_hermes_8502_core_system.xml
+++ b/dat/outfits/core_system/milspec_hermes_8502_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>600</mass>
   <price>2000000</price>
   <description>Milspec knows that a ship is merely the sum of its parts, and that means that the more parts, the better the ship. The Hermes 8502 provides serious subsystem control whilst retaining the high standard in energy and shielding that Milspec prides itself on. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_cpu_l1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>250</cpu_max>
   <shield>800</shield>

--- a/dat/outfits/core_system/milspec_hermes_9802_core_system.xml
+++ b/dat/outfits/core_system/milspec_hermes_9802_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>975</mass>
   <price>2600000</price>
   <description>Milspec knows that a ship is merely the sum of its parts, and that means that the more parts, the better the ship. The Hermes 9802 provides serious subsystem control whilst retaining the high standard in energy and shielding that Milspec prides itself on. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_cpu_l2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>325</cpu_max>
   <shield>900</shield>

--- a/dat/outfits/core_system/milspec_orion_2301_core_system.xml
+++ b/dat/outfits/core_system/milspec_orion_2301_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>14</mass>
   <price>120000</price>
   <description>Milspec develops high performance hardware for your ship, to make sure you are always optimally prepared for the dangers the universe might throw at you on your travels. The Orion 2301 core system is affordable yet capable, recommended for the beginning captain. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_refined_s1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>
   <shield>200</shield>

--- a/dat/outfits/core_system/milspec_orion_3701_core_system.xml
+++ b/dat/outfits/core_system/milspec_orion_3701_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>50</mass>
   <price>210000</price>
   <description>Milspec develops high performance hardware for your ship, to make sure you are always optimally prepared for the dangers the universe might throw at you on your travels. The Orion 3701 core system is a high-end solution for small ships, providing superior performance in every field. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_refined_s2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>55</cpu_max>
   <shield>250</shield>

--- a/dat/outfits/core_system/milspec_orion_4801_core_system.xml
+++ b/dat/outfits/core_system/milspec_orion_4801_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>90</mass>
   <price>330000</price>
   <description>Milspec develops high performance hardware for your ship, to make sure you are always optimally prepared for the dangers the universe might throw at you on your travels. The Orion 4801 core system is affordable yet capable, recommended for the discerning captain. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_refined_m1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>75</cpu_max>
   <shield>450</shield>

--- a/dat/outfits/core_system/milspec_orion_5501_core_system.xml
+++ b/dat/outfits/core_system/milspec_orion_5501_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>200</mass>
   <price>600000</price>
   <description>Milspec develops high performance hardware for your ship, to make sure you are always optimally prepared for the dangers the universe might throw at you on your travels. The Orion 5501 core system is a high-end solution for medium ships, providing superior performance in every field. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_refined_m2</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>110</cpu_max>
   <shield>550</shield>

--- a/dat/outfits/core_system/milspec_orion_8601_core_system.xml
+++ b/dat/outfits/core_system/milspec_orion_8601_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>660</mass>
   <price>3000000</price>
   <description>Milspec develops high performance hardware for your ship, to make sure you are always optimally prepared for the dangers the universe might throw at you on your travels. The Orion 8601 core system is a high-end solution for capital ships, providing superior performance in every field. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_refined_l1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>200</cpu_max>
   <shield>850</shield>

--- a/dat/outfits/core_system/milspec_orion_9901_core_system.xml
+++ b/dat/outfits/core_system/milspec_orion_9901_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>1075</mass>
   <price>4000000</price>
   <description>Milspec develops high performance hardware for your ship, to make sure you are always optimally prepared for the dangers the universe might throw at you on your travels. The Orion 9901 core system is a high-end solution for capital ships, providing superior performance in every field. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_refined_l2</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>260</cpu_max>
   <shield>1000</shield>

--- a/dat/outfits/core_system/milspec_prometheus_2203_core_system.xml
+++ b/dat/outfits/core_system/milspec_prometheus_2203_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
-  <rarity>3</rarity>
+  <rarity>1</rarity>
   <mass>12</mass>
   <price>80000</price>
   <description>Milspec offers solutions for pilots who believe the best defense is a good offense. The Prometheus 2203 boasts a heavy duty power generator as well as considerable shielding and subsystem control.</description>
   <gfx_store>core_system_power_s1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>36</cpu_max>
   <shield>180</shield>

--- a/dat/outfits/core_system/milspec_prometheus_3603_core_system.xml
+++ b/dat/outfits/core_system/milspec_prometheus_3603_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>45</mass>
   <price>140000</price>
   <description>Milspec offers solutions for pilots who believe the best defense is a good offense. The Prometheus 3603 boasts a heavy duty power generator as well as considerable shielding and subsystem control.</description>
   <gfx_store>core_system_power_s2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>50</cpu_max>
   <shield>225</shield>

--- a/dat/outfits/core_system/milspec_prometheus_4703_core_system.xml
+++ b/dat/outfits/core_system/milspec_prometheus_4703_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
-  <rarity>5</rarity>
+  <rarity>1</rarity>
   <mass>80</mass>
   <price>220000</price>
   <description>Milspec offers solutions for pilots who believe the best defense is a good offense. The Prometheus 4703 boasts a heavy duty power generator as well as considerable shielding and subsystem control. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_power_m1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>68</cpu_max>
   <shield>400</shield>

--- a/dat/outfits/core_system/milspec_prometheus_5403_core_system.xml
+++ b/dat/outfits/core_system/milspec_prometheus_5403_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>180</mass>
   <price>400000</price>
   <description>Milspec offers solutions for pilots who believe the best defense is a good offense. The Prometheus 5403 boasts a heavy duty power generator as well as considerable shielding and subsystem control. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_power_m2</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>100</cpu_max>
   <shield>500</shield>

--- a/dat/outfits/core_system/milspec_prometheus_8503_core_system.xml
+++ b/dat/outfits/core_system/milspec_prometheus_8503_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
-  <rarity>4</rarity>
+  <rarity>1</rarity>
   <mass>600</mass>
   <price>2000000</price>
   <description>Milspec offers solutions for pilots who believe the best defense is a good offense. The 8503 boasts a heavy duty power generator as well as considerable shielding and subsystem control. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_power_l1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>180</cpu_max>
   <shield>800</shield>

--- a/dat/outfits/core_system/milspec_prometheus_9803_core_system.xml
+++ b/dat/outfits/core_system/milspec_prometheus_9803_core_system.xml
@@ -4,12 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
+  <rarity>1</rarity>
   <priority>7</priority>
   <mass>975</mass>
   <price>2600000</price>
   <description>Milspec offers solutions for pilots who believe the best defense is a good offense. The 9803 boasts a heavy duty power generator as well as considerable shielding and subsystem control. Fly safe, fly Milspec.</description>
   <gfx_store>core_system_power_l2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>235</cpu_max>
   <shield>900</shield>

--- a/dat/outfits/core_system/previous_generation_large_systems.xml
+++ b/dat/outfits/core_system/previous_generation_large_systems.xml
@@ -8,7 +8,7 @@
   <price>0</price>
   <description>A jury-rigged mess of processors and generators that most captains wouldn't be seen dead having installed on their ship.</description>
   <gfx_store>core_system_basic_l1</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>145</cpu_max>
   <shield>500</shield>

--- a/dat/outfits/core_system/previous_generation_medium_systems.xml
+++ b/dat/outfits/core_system/previous_generation_medium_systems.xml
@@ -8,7 +8,7 @@
   <price>0</price>
   <description>A jury-rigged mess of processors and generators that most captains wouldn't be seen dead having installed on their ship.</description>
   <gfx_store>core_system_basic_m1</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>40</cpu_max>
   <shield>250</shield>

--- a/dat/outfits/core_system/previous_generation_small_systems.xml
+++ b/dat/outfits/core_system/previous_generation_small_systems.xml
@@ -8,7 +8,7 @@
   <price>0</price>
   <description>A jury-rigged mess of processors and generators that most captains wouldn't be seen dead having installed on their ship.</description>
   <gfx_store>core_system_basic_s1</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>22</cpu_max>
   <shield>110</shield>

--- a/dat/outfits/core_system/unicorp_pt1000_core_system.xml
+++ b/dat/outfits/core_system/unicorp_pt1000_core_system.xml
@@ -9,7 +9,7 @@
   <price>650000</price>
   <description>Criticized by some as nothing more than a cluster of PT-600 systems, the PT-1000 nevertheless offers acceptable performance for capital ships at a fraction of its competitors' prices.</description>
   <gfx_store>core_system_basic_l2</gfx_store>
- <rarity>4</rarity></general>
+  </general>
  <specific type="modification">
   <cpu_max>180</cpu_max>
   <shield>700</shield>

--- a/dat/outfits/core_system/unicorp_pt100_core_system.xml
+++ b/dat/outfits/core_system/unicorp_pt100_core_system.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>small</size>
-  <rarity>2</rarity>
   <mass>10</mass>
   <price>20000</price>
   <description>The PT-100 is a modest but to-spec core system offering reasonable, all-round performance for small vessels.</description>
   <gfx_store>core_system_basic_s1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>28</cpu_max>
   <shield>140</shield>

--- a/dat/outfits/core_system/unicorp_pt200_core_system.xml
+++ b/dat/outfits/core_system/unicorp_pt200_core_system.xml
@@ -9,7 +9,7 @@
   <price>35000</price>
   <description>The PT-200 is an economical core system providing decent performance to small-to-medium vessels.</description>
   <gfx_store>core_system_basic_s2</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>38</cpu_max>
   <shield>175</shield>

--- a/dat/outfits/core_system/unicorp_pt500_core_system.xml
+++ b/dat/outfits/core_system/unicorp_pt500_core_system.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>medium</size>
-  <rarity>3</rarity>
   <mass>70</mass>
   <price>55000</price>
   <description>Continuing Unicorp's PT series of core systems in the medium ship category, the PT-500 gives acceptable performance for an acceptable price.</description>
   <gfx_store>core_system_basic_m1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>53</cpu_max>
   <shield>300</shield>

--- a/dat/outfits/core_system/unicorp_pt600_core_system.xml
+++ b/dat/outfits/core_system/unicorp_pt600_core_system.xml
@@ -9,7 +9,7 @@
   <price>100000</price>
   <description>A heavy-duty variant of the PT-500, the PT-600 exceeds its predecessor in all respects. Its considerably higher mass restricts its use to larger medium vessels such as destroyers.</description>
   <gfx_store>core_system_basic_m2</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <cpu_max>77</cpu_max>
   <shield>400</shield>

--- a/dat/outfits/core_system/unicorp_pt900_core_system.xml
+++ b/dat/outfits/core_system/unicorp_pt900_core_system.xml
@@ -4,12 +4,12 @@
   <typename>Core Systems (System)</typename>
   <slot prop="systems">utility</slot>
   <size>large</size>
-  <rarity>3</rarity>
   <mass>540</mass>
   <price>500000</price>
   <description>Criticized by some as nothing more than a cluster of PT-600 systems, the PT-900 nevertheless offers acceptable performance for capital ships at a fraction of its competitors' prices.</description>
   <gfx_store>core_system_basic_l1</gfx_store>
- <priority>3</priority></general>
+  <priority>3</priority>
+ </general>
  <specific type="modification">
   <cpu_max>140</cpu_max>
   <shield>600</shield>

--- a/dat/outfits/launchers/convulsion_launcher.xml
+++ b/dat/outfits/launchers/convulsion_launcher.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>medium</size>
   <license>Medium Weapon License</license>
+  <rarity>2</rarity>
   <mass>16</mass>
   <price>60000</price>
   <description>The Thurion interceptor class missile focus on high agility rather than destructive power. While it does little damage to physical objects it is quite effective at disrupting shields.</description>
   <gfx_store>convulsion_launcher</gfx_store>
   <cpu>-12</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Convulsion Missile</ammo>
   <delay>3</delay>

--- a/dat/outfits/launchers/drone_fighter_bay.xml
+++ b/dat/outfits/launchers/drone_fighter_bay.xml
@@ -9,7 +9,7 @@
   <gfx_store>drone_fighter</gfx_store>
   <description>The Drone Fighter bay uses the advanced Collective technologies to sustain a group of three Drone Fighters. Drone Fighters require no pilot making them a safer approach in dangerous situations. They do however need some careful maintenance. All the tools needed to take care of them are provided with the bay.</description>
   <cpu>-30</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Drone Fighter</ammo>
   <delay>3</delay>

--- a/dat/outfits/launchers/electron_burst_cannon.xml
+++ b/dat/outfits/launchers/electron_burst_cannon.xml
@@ -9,7 +9,7 @@
   <description>This powerful energy weapon is built to bombard a target from great range with ion bursts, causing debilitating damage to a target's shields and electrical systems, which can leave a ship effectively crippled. It is unclear who originally designed this weapon: Robosys or the Za'lek. Either way, the drones that use this weapon are rightly feared and respected.</description>
   <gfx_store>weapon01</gfx_store>
   <cpu>-10</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Electron Energy Cell</ammo>
   <delay>0.3</delay>

--- a/dat/outfits/launchers/emp_grenade_launcher.xml
+++ b/dat/outfits/launchers/emp_grenade_launcher.xml
@@ -8,7 +8,7 @@
   <gfx_store>empgrenadelauncher_blue</gfx_store>
   <description>This launcher can fire EMP grenades in any direction using a unique internal guidance system. The grenades unleash an electromagnetic pulse, rapidly disabling the electronics of enemy ships. Useful for taking ships alive; the EM pulses rarely destroy the ship, leaving it floating disabled in space. These are favoured by traders for keeping pirates at bay.</description>
   <cpu>-8</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="turret launcher" secondary="1">
   <ammo>EMP Grenade</ammo>
   <delay>2</delay>

--- a/dat/outfits/launchers/empire_lancelot_fighter_bay.xml
+++ b/dat/outfits/launchers/empire_lancelot_fighter_bay.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Light Combat Vessel License</license>
+  <rarity>1</rarity>
   <mass>280</mass>
   <price>930000</price>
   <gfx_store>lancelot_empire_fighter_bay</gfx_store>
   <description>This fighter bay allows your ship to carry a pair of Empire Lancelot class fighters. It comes with all the devices required for the maintenance and flight of the fighters.</description>
   <cpu>-40</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Empire Lancelot Fighter</ammo>
   <delay>6</delay>

--- a/dat/outfits/launchers/energy_torpedo_mk1.xml
+++ b/dat/outfits/launchers/energy_torpedo_mk1.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>small</size>
   <license>Medium Weapon License</license>
+  <rarity>2</rarity>
   <mass>5</mass>
   <price>50000</price>
   <description>One of the greatest advancements the Thurion have made was in the field of non-corporeal computation. While it wasn't the original intention, the self-contained energy cascades that are capable of doing simple calculations are used as weapons. While such weapons have very high computational requirements, the homing energy projectiles have a high chance of hitting an evasive target.</description>
   <gfx_store>energy_dart</gfx_store>
   <cpu>-14</cpu>
-  <rarity>2</rarity></general>
+  </general>
  <specific type="launcher" secondary="1">
   <ammo>Thurion Energy Cell I</ammo>
   <delay>1.0</delay>

--- a/dat/outfits/launchers/energy_torpedo_mk2.xml
+++ b/dat/outfits/launchers/energy_torpedo_mk2.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>medium</size>
   <license>Medium Weapon License</license>
+  <rarity>2</rarity>
   <mass>14</mass>
   <price>75000</price>
   <description>One of the greatest advancements the Thurion have made was in the field of non-corporeal computation. While it wasn't the original intention, the self-contained energy cascades that are capable of doing simple calculations are used as weapons. While such weapons have very high computational requirements, the homing energy projectiles have a high chance of hitting an evasive target.</description>
   <gfx_store>energy_missile</gfx_store>
   <cpu>-26</cpu>
-  <rarity>3</rarity></general>
+  </general>
  <specific type="launcher" secondary="1">
   <ammo>Thurion Energy Cell II</ammo>
   <delay>1.0</delay>

--- a/dat/outfits/launchers/energy_torpedo_mk3.xml
+++ b/dat/outfits/launchers/energy_torpedo_mk3.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Heavy Weapon License</license>
+  <rarity>2</rarity>
   <mass>37</mass>
   <price>100000</price>
   <description>One of the greatest advancements the Thurion have made was in the field of non-corporeal computation. While it wasn't the original intention, the self-contained energy cascades that are capable of doing simple calculations are used as weapons. While such weapons have very high computational requirements, the homing energy projectiles have a high chance of hitting an evasive target.</description>
   <gfx_store>energy_torpedo</gfx_store>
   <cpu>-42</cpu>
-  <rarity>4</rarity></general>
+  </general>
  <specific type="launcher" secondary="1">
   <ammo>Thurion Energy Cell III</ammo>
   <delay>1.0</delay>

--- a/dat/outfits/launchers/enygma_systems_spearhead_launcher.xml
+++ b/dat/outfits/launchers/enygma_systems_spearhead_launcher.xml
@@ -9,7 +9,7 @@
   <description>The Spearhead class shieldbreaker missile is one of Enygma Systems' more specialised pieces of hardware. Its sole function is to do massive damage to shielding. It uses a special energy discharge warhead that is quite effective at disrupting shields, but has little effect on physical objects. The Spearhead's limited agility make it primarily suited to fighting corvette class ships or heavier.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-7</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Spearhead Missile</ammo>
   <delay>4</delay>

--- a/dat/outfits/launchers/enygma_systems_turreted_fury_launcher.xml
+++ b/dat/outfits/launchers/enygma_systems_turreted_fury_launcher.xml
@@ -9,7 +9,7 @@
   <description>Enygma Systems has developed a turret mounted Fury launcher. It comes at a steep price, but Fury missiles can be a powerful means of discouraging pirate fighters and an effective means of defending against hostile bombers.</description>
   <gfx_store>turreted_fury_launcher</gfx_store>
   <cpu>-9</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="turret launcher" secondary="1">
   <ammo>Fury Missile</ammo>
   <delay>1.5</delay>

--- a/dat/outfits/launchers/enygma_systems_turreted_headhunter_launcher.xml
+++ b/dat/outfits/launchers/enygma_systems_turreted_headhunter_launcher.xml
@@ -9,7 +9,7 @@
   <description>These turreted launchers are sometimes employed by cruiser captains whose ships aren't manoeuvrable enough to effectively combat enemy fighters and bombers. The punch of the Headhunter missile combined with Enygma Systems' swivel mounted launcher can effectively compensate for any blind spots.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-14</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret launcher" secondary="1">
   <ammo>Headhunter Missile</ammo>
   <delay>2.5</delay>

--- a/dat/outfits/launchers/enygma_systems_turreted_vengeance_launcher.xml
+++ b/dat/outfits/launchers/enygma_systems_turreted_vengeance_launcher.xml
@@ -11,7 +11,7 @@
 Turreted Vengeance launchers aren't commonly seen in interplanetary combat. Only heavy cruisers can afford to mount these weapons, and they usually have other means of taking out corvette class enemies.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-14</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret launcher" secondary="1">
   <ammo>Vengeance Missile</ammo>
   <delay>5.5</delay>

--- a/dat/outfits/launchers/fidelity_fighter_bay.xml
+++ b/dat/outfits/launchers/fidelity_fighter_bay.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Light Combat Vessel License</license>
+  <rarity>1</rarity>
   <mass>260</mass>
   <price>830000</price>
   <gfx_store>fidelity_fighter</gfx_store>
   <description>This bay launches three Sirius Fidelity fighters. Weak individually, they are stronger when working together in groups. Quite apropos, given Sirian society.</description>
   <cpu>-40</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Fidelity Fighter</ammo>
   <delay>4</delay>

--- a/dat/outfits/launchers/lancelot_fighter_bay.xml
+++ b/dat/outfits/launchers/lancelot_fighter_bay.xml
@@ -9,7 +9,7 @@
   <gfx_store>lancelot_fighter_bay</gfx_store>
   <description>This fighter bay allows your ship to carry a pair of Lancelot class fighters. It comes with all the devices required for the maintenance and flight of the fighters.</description>
   <cpu>-35</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Lancelot Fighter</ammo>
   <delay>6</delay>

--- a/dat/outfits/launchers/teracom_banshee_launcher.xml
+++ b/dat/outfits/launchers/teracom_banshee_launcher.xml
@@ -9,7 +9,7 @@
   <gfx_store>bansheelauncher</gfx_store>
   <description>TeraCom has equipped its Banshee launcher model with high grade reload and tube cooling systems, giving a significant boost to rate of fire. These dumbfire rockets, while slow, can do quite respectable damage even to capital ships.</description>
   <cpu>-8</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Banshee Rocket</ammo>
   <delay>3</delay>

--- a/dat/outfits/launchers/teracom_fury_launcher.xml
+++ b/dat/outfits/launchers/teracom_fury_launcher.xml
@@ -11,7 +11,7 @@
 TeraCom's Fury Launcher is a high-performance missile launcher equipped with patented target tracking and missile arming technology, allowing pilots to get a lock on their target faster and more easily than with launchers made by competing brands.</description>
   <gfx_store>teracom_fury_launcher</gfx_store>
   <cpu>-6</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Fury Missile</ammo>
   <delay>2</delay>

--- a/dat/outfits/launchers/teracom_headhunter_launcher.xml
+++ b/dat/outfits/launchers/teracom_headhunter_launcher.xml
@@ -11,7 +11,7 @@
 This is TeraCom's model Headhunter launcher. Though somewhat pricey and demanding on the ship's resources, the patented tracking and missile arming technology allows pilots to fire their missiles before the competition does.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-8</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Headhunter Missile</ammo>
   <delay>3.5</delay>

--- a/dat/outfits/launchers/teracom_imperator_launcher.xml
+++ b/dat/outfits/launchers/teracom_imperator_launcher.xml
@@ -9,7 +9,7 @@
   <description>TeraCom decided not to develop a launcher for the Caesar IV, because it fell short of the company's performance requirements. Instead, the company released a completely new torpedo specification. At present, the Imperator class heavy torpedo provides devastating destructive power, though it will take a while for it to reach its target. Faster cruisers may be able to outrun it completely.</description>
   <gfx_store>caesarlauncher</gfx_store>
   <cpu>-20</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Imperator Torpedo</ammo>
   <delay>11</delay>

--- a/dat/outfits/launchers/teracom_mace_launcher.xml
+++ b/dat/outfits/launchers/teracom_mace_launcher.xml
@@ -11,7 +11,7 @@
 TeraCom's Mace launcher uses an advanced reload mechanism that allows the launcher to fire more rockets in less time.</description>
   <gfx_store>macelauncher</gfx_store>
   <cpu>-5</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Mace Rocket</ammo>
   <delay>0.3</delay>

--- a/dat/outfits/launchers/teracom_medusa_launcher.xml
+++ b/dat/outfits/launchers/teracom_medusa_launcher.xml
@@ -11,7 +11,7 @@
 TeraCom has built a highly efficient Medusa launcher, capable of locking on and firing faster than the standard specification, and holding a greater amount in the magazine as well.</description>
   <gfx_store>seekerlauncher</gfx_store>
   <cpu>-6</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Medusa Missile</ammo>
   <delay>3.5</delay>

--- a/dat/outfits/launchers/teracom_vengeance_launcher.xml
+++ b/dat/outfits/launchers/teracom_vengeance_launcher.xml
@@ -11,7 +11,7 @@
 TeraCom's patented launcher hardware considerably reduces the time it takes to achieve a lock. Sometimes, those few seconds can make all the difference.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-10</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Vengeance Missile</ammo>
   <delay>6</delay>

--- a/dat/outfits/launchers/turreted_convulsion_launcher.xml
+++ b/dat/outfits/launchers/turreted_convulsion_launcher.xml
@@ -11,7 +11,7 @@
 This launcher is mounted on a turret and has more ammo capacity than the standard launcher.</description>
   <gfx_store>turreted_convulsion_launcher</gfx_store>
   <cpu>-18</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="turret launcher" secondary="1">
   <ammo>Convulsion Missile</ammo>
   <delay>2.5</delay>

--- a/dat/outfits/launchers/unicorp_banshee_launcher.xml
+++ b/dat/outfits/launchers/unicorp_banshee_launcher.xml
@@ -9,7 +9,7 @@
   <gfx_store>bansheelauncher</gfx_store>
   <description>The Banshee class heavy dumbfire rocket is sometimes labeled the "poor man's torpedo". It has a relatively weak engine, but packs a powerful punch that can do respectable damage even to capital ships. The launcher is small and light enough to be usable by even small fighters, which makes it a great choice for bombers.</description>
   <cpu>-5</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Banshee Rocket</ammo>
   <delay>4</delay>

--- a/dat/outfits/launchers/unicorp_caesar_iv_launcher.xml
+++ b/dat/outfits/launchers/unicorp_caesar_iv_launcher.xml
@@ -9,7 +9,7 @@
   <description>Caesar IV class torpedoes are among the most common torpedo weapons available. Though much slower than missiles and useless against mobile targets, they remain manoeuvrable enough to chase down light cruisers.</description>
   <gfx_store>caesarlauncher</gfx_store>
   <cpu>-13</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Caesar IV Torpedo</ammo>
   <delay>10</delay>

--- a/dat/outfits/launchers/unicorp_fury_launcher.xml
+++ b/dat/outfits/launchers/unicorp_fury_launcher.xml
@@ -9,7 +9,7 @@
   <description>The Fury class interceptor missile is a lightweight missile propelled by a powerful engine, delivering its payload to its target quickly and efficiently. Its high agility comes at the cost of destructive power, however, limiting its effectiveness to light, nimble fighters.</description>
   <gfx_store>unicorp_fury_launcher</gfx_store>
   <cpu>-4</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Fury Missile</ammo>
   <delay>2</delay>

--- a/dat/outfits/launchers/unicorp_headhunter_launcher.xml
+++ b/dat/outfits/launchers/unicorp_headhunter_launcher.xml
@@ -9,7 +9,7 @@
   <description>The Headhunter class interceptor missile is a medium calibre missile that can deal devastating damage to small and medium sized targets, while remaining reasonably fast and agile. Most effective when launched at distant enemies.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-5</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Headhunter Missile</ammo>
   <delay>3.5</delay>

--- a/dat/outfits/launchers/unicorp_mace_launcher.xml
+++ b/dat/outfits/launchers/unicorp_mace_launcher.xml
@@ -9,7 +9,7 @@
   <description>The Mace class unguided rocket is a cheap, expendable weapon used to boost peak firepower in tight situations. It is far better at dealing damage to light targets than most fighter sized energy cannons, but comes with the disadvantage of running out of ammunition after only a short time of fire.</description>
   <gfx_store>macelauncher</gfx_store>
   <cpu>-3</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Mace Rocket</ammo>
   <delay>0.36</delay>

--- a/dat/outfits/launchers/unicorp_medusa_launcher.xml
+++ b/dat/outfits/launchers/unicorp_medusa_launcher.xml
@@ -9,7 +9,7 @@
   <description>The Medusa class EMP cruise missile is a nonlethal weapon designed to knock out a ship's internal systems, rendering it harmless and ready for boarding. The warhead does only limited damage, so even lightly armoured targets can effectively be disabled with this weapon. However, the Medusa is not the most agile missile on the market.</description>
   <gfx_store>seekerlauncher</gfx_store>
   <cpu>-4</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Medusa Missile</ammo>
   <delay>4</delay>

--- a/dat/outfits/launchers/unicorp_vengeance_launcher.xml
+++ b/dat/outfits/launchers/unicorp_vengeance_launcher.xml
@@ -9,7 +9,7 @@
   <description>Vengeance class interceptor missiles are the heaviest interceptor missiles currently in production. Almost half the missile hull is used for payload, which decreases its ability to catch fast targets. It's designed to excel at killing armoured targets at the expense of making it poor against shields. Best paired with anti-shield weapons.</description>
   <gfx_store>headhunterlauncher</gfx_store>
   <cpu>-6</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Vengeance Missile</ammo>
   <delay>6</delay>

--- a/dat/outfits/launchers/zalek_bomber_drone_fighter_bay.xml
+++ b/dat/outfits/launchers/zalek_bomber_drone_fighter_bay.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Light Combat Vessel License</license>
+  <rarity>1</rarity>
   <mass>200</mass>
   <price>1200000</price>
   <gfx_store>zalek_drone_bomber_fighter</gfx_store>
   <description>This relatively bulky drone is built to crack open large ships from afar. It accomplishes this task admirably. Drone Fighters require no pilot making them a safer approach in dangerous situations. They do however need some careful maintenance. All the tools needed to take care of them are provided with the bay.</description>
   <cpu>-25</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Za'lek Bomber Drone Fighter</ammo>
   <delay>4</delay>

--- a/dat/outfits/launchers/zalek_heavy_drone_fighter_bay.xml
+++ b/dat/outfits/launchers/zalek_heavy_drone_fighter_bay.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Light Combat Vessel License</license>
+  <rarity>1</rarity>
   <mass>320</mass>
   <price>1200000</price>
   <gfx_store>zalek_drone_heavy_fighter</gfx_store>
   <description>The Za'lek Heavy Drone is a fearsome craft using very advanced AI techniques to be able to pilot itself. Three heavy drones can be operated from this bay, giving the mothership a good deal of punch.</description>
   <cpu>-35</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Za'lek Heavy Drone Fighter</ammo>
   <delay>5</delay>

--- a/dat/outfits/launchers/zalek_hunter_launcher.xml
+++ b/dat/outfits/launchers/zalek_hunter_launcher.xml
@@ -4,6 +4,7 @@
   <slot>weapon</slot>
   <size>medium</size>
   <license>Heavy Weapon License</license>
+  <rarity>1</rarity>
   <mass>28</mass>
   <price>250000</price>
   <description>The Za'lek began to find conventional missiles and torpedoes to be woefully primitive compared to their miniaturized drone technology. Thus, they began work on kamikaze drone fabricators to replace them. The results have born deadly fruit with the hunter-killer drone. It accelerates towards its target and unleashes its ferromagnetohydraulic payload to deadly effect.
@@ -11,7 +12,7 @@
 The Za'lek do not share the secrets of their 'missile' drones lightly. Only trusted allies of the Za'lek are trusted with these weapons.</description>
   <gfx_store>empgrenadelauncher</gfx_store>
   <cpu>-19</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="turret launcher" secondary="1">
   <ammo>Za'lek Hunter-Killer</ammo>
   <delay>1.5</delay>

--- a/dat/outfits/launchers/zalek_light_drone_fighter_bay.xml
+++ b/dat/outfits/launchers/zalek_light_drone_fighter_bay.xml
@@ -4,12 +4,13 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Light Combat Vessel License</license>
+  <rarity>1</rarity>
   <mass>240</mass>
   <price>1200000</price>
   <gfx_store>zalek_drone_light_fighter</gfx_store>
   <description>A quartet of light drones are maintained and launched from this bay. The Drones themselves are frail, but very cheap.</description>
   <cpu>-30</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="fighter bay" secondary="1">
   <ammo>Za'lek Light Drone Fighter</ammo>
   <delay>3</delay>

--- a/dat/outfits/launchers/zalek_reaper_launcher.xml
+++ b/dat/outfits/launchers/zalek_reaper_launcher.xml
@@ -4,6 +4,7 @@
   <slot>weapon</slot>
   <size>large</size>
   <license>Heavy Weapon License</license>
+  <rarity>1</rarity>
   <mass>80</mass>
   <price>420000</price>
   <description>This weapon stretches the term 'miniturized drone' nearly to its breaking point. It is effectivly a slimmed-down standard drone platform with almost everything replaced in favor of a huge ferromegetohydraulic bomb. It is the Za'lek's answer to torpedoes from less advanced nations, and an eloquent answer it certainly is.
@@ -11,7 +12,7 @@
 The Za'lek do not share the secrets of their 'missile' drones lightly. Only trusted allies of the Za'lek are trusted with these weapons.</description>
   <gfx_store>zalek_reaper_launcher</gfx_store>
   <cpu>-34</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="launcher" secondary="1">
   <ammo>Za'lek Reaper Drone</ammo>
   <delay>2</delay>

--- a/dat/outfits/maps/localmap.xml
+++ b/dat/outfits/maps/localmap.xml
@@ -5,7 +5,7 @@
   <price>5000</price>
   <description>This map contains information about the local system.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="localmap">
   <jump_detect>1.25</jump_detect>
   <asset_detect>0.75</asset_detect>

--- a/dat/outfits/maps/map_collective_space.xml
+++ b/dat/outfits/maps/map_collective_space.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: Collective Space">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>25000</price>
   <description>This map charts the known jumps that connect the systems occupied by the Collective. Sadly, the Empire has no accurate intel about Collective assets in the area.</description>
   <gfx_store>map</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Hades">
    <jump>C-43</jump>

--- a/dat/outfits/maps/map_dvaered_core.xml
+++ b/dat/outfits/maps/map_dvaered_core.xml
@@ -5,7 +5,7 @@
   <price>25000</price>
   <description>This map lists the locations of all Dvaered worlds and stations close to the Dvaered capital.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Dvaer">
    <jump>Beeklo</jump>

--- a/dat/outfits/maps/map_dvaeredsoromid_trade_route.xml
+++ b/dat/outfits/maps/map_dvaeredsoromid_trade_route.xml
@@ -5,7 +5,7 @@
   <price>30000</price>
   <description>This map contains the main route between Dvaered and Soromid controlled space.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Draygar">
    <jump>Tau Prime</jump>

--- a/dat/outfits/maps/map_empire_core.xml
+++ b/dat/outfits/maps/map_empire_core.xml
@@ -5,7 +5,7 @@
   <price>25000</price>
   <description>This map lists the locations of all Imperial worlds and stations close to the Imperial capital.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Gamma Polaris">
    <jump>Apez</jump>

--- a/dat/outfits/maps/map_flf.xml
+++ b/dat/outfits/maps/map_flf.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: FLF Hidden Jumps">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>100000</price>
   <description>This map contains the location of hidden jump points between the FLF base and Frontier space.</description>
   <gfx_store>map</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Sigur">
    <jump>Arcanis</jump>

--- a/dat/outfits/maps/map_flf_pirate_route.xml
+++ b/dat/outfits/maps/map_flf_pirate_route.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: FLF-Pirate Route">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>10000000</price>
   <description>This map contains the location of the two-way hidden jump point between the FLF base and the nearest Pirate stronghold.</description>
   <gfx_store>map</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Tormulex">
    <jump>Anger</jump>

--- a/dat/outfits/maps/map_inner_nebula_secret_jump.xml
+++ b/dat/outfits/maps/map_inner_nebula_secret_jump.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: Inner Nebula Secret Jump">
  <general>
+  <rarity>6</rarity>
   <mass>0</mass>
   <price>10000000</price>
   <description>This map contains the location of a hidden jump point leading to the inner nebula.</description>
   <gfx_store>map</gfx_store>
- <rarity>5</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Iris">
    <jump>Oriantis</jump>

--- a/dat/outfits/maps/map_kretogg_hidden_jumps.xml
+++ b/dat/outfits/maps/map_kretogg_hidden_jumps.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: Kretogg's hidden jump points">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>200000</price>
   <description>This map contains the position of hidden jump points leading straight into Za'lek space.</description>
   <gfx_store>map</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Unicorn">
    <jump>Nunavut</jump>

--- a/dat/outfits/maps/map_nebula_edge.xml
+++ b/dat/outfits/maps/map_nebula_edge.xml
@@ -5,7 +5,7 @@
   <price>25000</price>
   <description>This map contains the route leading from Dvaered/Imperial space to the edge of the Nebula. It also lists the two Imperial stations along the route.</description>
   <gfx_store>map</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Zacron">
    <jump>Raelid</jump>

--- a/dat/outfits/maps/map_new_haven_hidden_jumps.xml
+++ b/dat/outfits/maps/map_new_haven_hidden_jumps.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: New Haven's hidden jump points">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>250000</price>
   <description>This map contains the position of a set of hidden jump points in and around the New Haven system. Only a minority of pirates have access to this map.</description>
   <gfx_store>map</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Andres">
    <jump>Gamel</jump>

--- a/dat/outfits/maps/map_pirate_strongholds.xml
+++ b/dat/outfits/maps/map_pirate_strongholds.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: Pirate strongholds">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>100000</price>
   <description>This map contains the locations of the pirate clan worlds, and a few stations that are known to offer opportunities for pirates in the vicinity.</description>
   <gfx_store>map</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="map">
   <sys name="New Haven">
    <jump>Titus</jump>

--- a/dat/outfits/maps/map_qorel.xml
+++ b/dat/outfits/maps/map_qorel.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: Qorel Expanse">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>500000</price>
   <description>This map contains the location of the jump points in and out of the Qorel expanse, a set of systems not accessible through standard jump points. Getting the location of these very special jump points is usually very costly to reduce the number of people having access to it.</description>
   <gfx_store>map</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Acheron">
    <jump>Terminus</jump>

--- a/dat/outfits/maps/map_sirian_border_systems.xml
+++ b/dat/outfits/maps/map_sirian_border_systems.xml
@@ -5,7 +5,7 @@
   <price>15000</price>
   <description>This map contains the systems that lead to Sirius controlled space.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Esker">
    <jump>Nougat</jump>

--- a/dat/outfits/maps/map_sirius_core.xml
+++ b/dat/outfits/maps/map_sirius_core.xml
@@ -5,7 +5,7 @@
   <price>25000</price>
   <description>This map contains the location of Mutris, home of Sirichana and capital to the Sirians, as well as the surrounding systems.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Aesir">
    <jump>Vanir</jump>

--- a/dat/outfits/maps/map_sol.xml
+++ b/dat/outfits/maps/map_sol.xml
@@ -5,7 +5,7 @@
   <price>100000</price>
   <description>This map contains the location of the Sol system, the origin of mankind. Rendered dead by the Incident, it is now covered by a highly unstable nebula which no known ship in the galaxy can safely pass through. What lies beyond Sol, if anything, is unknown.</description>
   <gfx_store>map</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Sol">
   </sys>

--- a/dat/outfits/maps/map_the_frontier.xml
+++ b/dat/outfits/maps/map_the_frontier.xml
@@ -5,7 +5,7 @@
   <price>50000</price>
   <description>This map contains an east-west route through Frontier space, as well as the location of the Frontier Council.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Theras">
    <jump>Haleb</jump>

--- a/dat/outfits/maps/map_thurion.xml
+++ b/dat/outfits/maps/map_thurion.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Map: Thurion Core">
  <general>
+  <rarity>1</rarity>
   <mass>0</mass>
   <price>500000</price>
   <description>This map provides the hidden route to the Thurion core systems outside of the nebula.</description>
   <gfx_store>map</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Metsys">
    <jump>Booster</jump>

--- a/dat/outfits/maps/map_zalek_core.xml
+++ b/dat/outfits/maps/map_zalek_core.xml
@@ -5,7 +5,7 @@
   <price>25000</price>
   <description>This map contains the heart of Za'lek space, including its capital Ruadan and central hub, Za'lek.</description>
   <gfx_store>map</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="map">
   <sys name="Ruadan">
    <jump>Damien</jump>

--- a/dat/outfits/maps/ultra_map.xml
+++ b/dat/outfits/maps/ultra_map.xml
@@ -5,7 +5,8 @@
   <price>1</price>
   <description>For cheating.</description>
   <gfx_store>map</gfx_store>
- <rarity>6</rarity></general>
+  <rarity>6</rarity>
+ </general>
  <specific type="map">
   <all />
  </specific>

--- a/dat/outfits/misc/heavy_combat_vessel_license.xml
+++ b/dat/outfits/misc/heavy_combat_vessel_license.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Combat Vessel License">
  <general>
+  <rarity>1</rarity>
   <license>Medium Combat Vessel License</license>
   <mass>0</mass>
   <price>900000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to buy cruiser and carrier-class ships.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/misc/heavy_weapon_license.xml
+++ b/dat/outfits/misc/heavy_weapon_license.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <outfit name="Heavy Weapon License">
  <general>
+  <rarity>1</rarity>
   <license>Medium Weapon License</license>
   <mass>0</mass>
   <price>125000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to buy and use heavy weapons like the heavy ion turret.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/misc/large_civilian_vessel_license.xml
+++ b/dat/outfits/misc/large_civilian_vessel_license.xml
@@ -5,6 +5,6 @@
   <price>75000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to buy freighter-class ships.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/misc/light_combat_vessel_license.xml
+++ b/dat/outfits/misc/light_combat_vessel_license.xml
@@ -5,6 +5,6 @@
   <price>175000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to buy fighter and bomber class ships.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/misc/medium_combat_vessel_license.xml
+++ b/dat/outfits/misc/medium_combat_vessel_license.xml
@@ -6,6 +6,6 @@
   <price>350000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to buy destroyer and corvette-class ships.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/misc/medium_weapon_license.xml
+++ b/dat/outfits/misc/medium_weapon_license.xml
@@ -5,6 +5,6 @@
   <price>50000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to buy and use medium weapons like the ion cannon.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/misc/mercenary_license.xml
+++ b/dat/outfits/misc/mercenary_license.xml
@@ -5,6 +5,6 @@
   <price>250000</price>
   <gfx_store>license</gfx_store>
   <description>This license will authorize you to do mercenary missions and collect bounties.</description>
- <rarity>6</rarity></general>
+ </general>
  <specific type="license" />
 </outfit>

--- a/dat/outfits/modifiers/active_plating.xml
+++ b/dat/outfits/modifiers/active_plating.xml
@@ -4,12 +4,13 @@
   <typename>Armour Modifier</typename>
   <slot>structure</slot>
   <size>medium</size>
+  <rarity>2</rarity>
   <mass />
   <price>200000</price>
   <gfx_store>active_plating</gfx_store>
   <description>As the Thurion favour defense over offensive capabilities they developed this light-weight yet strong armour plating, at the expense of CPU usage.</description>
   <cpu>-10</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <absorb>4</absorb>
   <armour_mod>10</armour_mod>

--- a/dat/outfits/modifiers/adaptive_stealth_plating.xml
+++ b/dat/outfits/modifiers/adaptive_stealth_plating.xml
@@ -4,12 +4,13 @@
   <typename>Armour Modifier</typename>
   <slot>structure</slot>
   <size>small</size>
+  <rarity>2</rarity>
   <mass />
   <price>150000</price>
   <gfx_store>stealth_plating</gfx_store>
   <description>This armour plating does not provide any protection, instead it makes the ship harder to detect. It has integrated sensors that measure the ambient radiation around the ship and is able to emit space-resolved the right ammount of radiation to appear invisible for passive sensors.</description>
   <cpu>-8</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <ew_hide>20</ew_hide>
   <mass_mod>3</mass_mod>

--- a/dat/outfits/modifiers/asteroid_scanner.xml
+++ b/dat/outfits/modifiers/asteroid_scanner.xml
@@ -9,7 +9,7 @@
   <gfx_store>misc04</gfx_store>
   <limit>reverse_thruster</limit>
   <cpu>-4</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <energy_usage>5</energy_usage>
   <misc_asteroid_scan>1</misc_asteroid_scan>

--- a/dat/outfits/modifiers/battery.xml
+++ b/dat/outfits/modifiers/battery.xml
@@ -8,7 +8,7 @@
   <price>40000</price>
   <description>A large battery unit designed to hold 200 MJ of energy. Small enough to mount on many light vessels.</description>
   <gfx_store>capacitor-g</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <energy>200</energy>
  </specific>

--- a/dat/outfits/modifiers/battery_ii.xml
+++ b/dat/outfits/modifiers/battery_ii.xml
@@ -8,7 +8,7 @@
   <price>120000</price>
   <description>A large battery unit designed to hold 400 MJ of energy. Ideally mounted on medium-to-large vessels.</description>
   <gfx_store>capacitor2-g</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <energy>400</energy>
  </specific>

--- a/dat/outfits/modifiers/battery_iii.xml
+++ b/dat/outfits/modifiers/battery_iii.xml
@@ -8,7 +8,7 @@
   <price>360000</price>
   <description>A massive battery unit designed to hold 800 MJ of energy. Given the mass of this battery, it's advisable to only mount it on capital ships.</description>
   <gfx_store>capacitor4-g</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <energy>800</energy>
  </specific>

--- a/dat/outfits/modifiers/biometal_armour.xml
+++ b/dat/outfits/modifiers/biometal_armour.xml
@@ -8,7 +8,7 @@
   <price>1120000</price>
   <gfx_store>biometal</gfx_store>
   <description>Biometal is an armour that regenerates itself due to genetically-engineered bacteria throughout it. Due to the compartmentalization to permit bacterial life, and the difficulty of cultivating the bacteria, Biometal has greater mass than alternatives, and is the most expensive hull plating.</description>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <armour_mod>20</armour_mod>
   <armour_regen>1.0</armour_regen>

--- a/dat/outfits/modifiers/boarding_androids_mki.xml
+++ b/dat/outfits/modifiers/boarding_androids_mki.xml
@@ -8,7 +8,7 @@
   <price>20000</price>
   <description>The Asimov Destructicorp Boarding Android is the latest in robotic hostile takeover technology. Equipped with a multifunction plasma blaster/cutting torch/can opener/spatula, the Boarding Android is ready for any situation, be it tactical or culinary.</description>
   <gfx_store>cargo_pod</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <crew_mod>20</crew_mod>
  </specific>

--- a/dat/outfits/modifiers/boarding_androids_mkii.xml
+++ b/dat/outfits/modifiers/boarding_androids_mkii.xml
@@ -8,7 +8,7 @@
   <price>50000</price>
   <description>The Boarding Android Mark II improves upon the wide variety of implements sported by its predecessor, additionally including scissor-hands and a rape whistle. </description>
   <gfx_store>cargo_pod</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <crew_mod>35</crew_mod>
  </specific>

--- a/dat/outfits/modifiers/cargo_pod.xml
+++ b/dat/outfits/modifiers/cargo_pod.xml
@@ -8,7 +8,7 @@
   <price>35000</price>
   <description>Cargo pods are large containers that increase a ship's cargo capacity.</description>
   <gfx_store>cargo_pod</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>15</cargo>
  </specific>

--- a/dat/outfits/modifiers/droid_repair_crew.xml
+++ b/dat/outfits/modifiers/droid_repair_crew.xml
@@ -9,7 +9,7 @@
   <gfx_store>droid</gfx_store>
   <description>This low maintenance droid crew will scour your ship to repair any damages caused by space hazards. They are very small and able to work both on the interior or exterior of the ship. Power is drawn from the ship to feed the robots, although the load is generally very low compared to the benefits of having a robotic repair crew.</description>
   <cpu>-4</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <armour_regen>1.7</armour_regen>
   <energy_usage>5</energy_usage>

--- a/dat/outfits/modifiers/engine_reroute.xml
+++ b/dat/outfits/modifiers/engine_reroute.xml
@@ -9,7 +9,7 @@
   <description>This enhancement routes energy from the ship's energy supplies to the engine, giving the ship an increased thrust. It does not increase the ship's max speed nor turning abilities.</description>
   <gfx_store>reroute</gfx_store>
   <cpu>-1</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <thrust>3</thrust>
   <thrust_mod>10</thrust_mod>

--- a/dat/outfits/modifiers/forward_shock_absorbers.xml
+++ b/dat/outfits/modifiers/forward_shock_absorbers.xml
@@ -8,7 +8,7 @@
   <price>35000</price>
   <description>These shock absorbers are attached to the forward mounts, isolating them from the hull and providing increased accuracy.</description>
   <gfx_store>accuracy_forward</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <fwd_heat>-15</fwd_heat>
  </specific>

--- a/dat/outfits/modifiers/fuel_pod.xml
+++ b/dat/outfits/modifiers/fuel_pod.xml
@@ -8,7 +8,7 @@
   <price>25000</price>
   <description>The fuel pod allows a ship to store more fuel for hyperspace jumps.</description>
   <gfx_store>fuel_pod</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <fuel>200</fuel>
  </specific>

--- a/dat/outfits/modifiers/improved_power_regulator.xml
+++ b/dat/outfits/modifiers/improved_power_regulator.xml
@@ -9,7 +9,7 @@
   <gfx_store>efficiency_turret</gfx_store>
   <description>Improved power regulation allows your turrets to waste less power when firing, though feeding turrets the bare minimum wattage results in a slightly decreased rate of fire.</description>
   <cpu>-2</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <tur_firerate>-5</tur_firerate>
   <tur_energy>-10</tur_energy>

--- a/dat/outfits/modifiers/improved_refrigeration_cycle.xml
+++ b/dat/outfits/modifiers/improved_refrigeration_cycle.xml
@@ -9,7 +9,7 @@
   <description>By adding an auxiliary coolant reservoir, the ship can keep is able to dissipate heat more quickly, allowing it to exceed standard firing rates. The side effect of having everything cool faster is minor instabilities that end up affecting both accuracy and damage. Only the turrets are affected by this modification.</description>
   <gfx_store>firerate_turret</gfx_store>
   <cpu>-2</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <tur_heat>-10</tur_heat>
   <tur_damage>-5</tur_damage>

--- a/dat/outfits/modifiers/improved_stabilizer.xml
+++ b/dat/outfits/modifiers/improved_stabilizer.xml
@@ -9,7 +9,7 @@
   <description>By improving your ship's stabilization systems drastically, this modification will allow you to reach higher speeds while still keeping the ship stable.</description>
   <gfx_store>stabilizer</gfx_store>
   <cpu>-2</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <speed_mod>10</speed_mod>
   <engine_limit_rel>-5</engine_limit_rel>

--- a/dat/outfits/modifiers/jump_scanner.xml
+++ b/dat/outfits/modifiers/jump_scanner.xml
@@ -8,7 +8,7 @@
   <description>This device installs a secondary scanning array on the ship. The array is programmed with the known characteristics of the spatial anomalies associated with hyperspace jumps. Because the scanner detects a very specific kind of signature, its range can be easily boosted without sacrificing accuracy. In effect, this means that a ship with one or more of these scanners installed can detect jump points at a greater range. The scanner will not detect jump points whose signature differs from the standard type.</description>
   <gfx_store>jammer0</gfx_store>
   <cpu>-1</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <energy_usage>10</energy_usage>
   <ew_jump_detect>60</ew_jump_detect>

--- a/dat/outfits/modifiers/large_cargo_pod.xml
+++ b/dat/outfits/modifiers/large_cargo_pod.xml
@@ -8,7 +8,7 @@
   <price>135000</price>
   <description>Cargo pods are large containers that increase a ship's cargo capacity.</description>
   <gfx_store>cargo_pod</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>60</cargo>
  </specific>

--- a/dat/outfits/modifiers/large_fuel_pod.xml
+++ b/dat/outfits/modifiers/large_fuel_pod.xml
@@ -8,7 +8,7 @@
   <price>125000</price>
   <description>The fuel pod allows a ship to store more fuel for hyperspace jumps.</description>
   <gfx_store>large_fuel_pod</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <fuel>800</fuel>
  </specific>

--- a/dat/outfits/modifiers/large_shield_booster.xml
+++ b/dat/outfits/modifiers/large_shield_booster.xml
@@ -9,7 +9,7 @@
   <description>A shield generator that feeds off the ship's main energy line. It will allow you to regenerate your shield faster and give you a small shield capacity boost, at the expense of draining some of the ship's energy.</description>
   <gfx_store>shield</gfx_store>
   <cpu>-12</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <shield>60</shield>
   <shield_regen>2.0</shield_regen>

--- a/dat/outfits/modifiers/medium_cargo_pod.xml
+++ b/dat/outfits/modifiers/medium_cargo_pod.xml
@@ -8,7 +8,7 @@
   <price>85000</price>
   <description>Cargo pods are large containers that increase a ship's cargo capacity.</description>
   <gfx_store>cargo_pod</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <cargo>30</cargo>
  </specific>

--- a/dat/outfits/modifiers/medium_fuel_pod.xml
+++ b/dat/outfits/modifiers/medium_fuel_pod.xml
@@ -8,7 +8,7 @@
   <price>75000</price>
   <description>The fuel pod allows a ship to store more fuel for hyperspace jumps.</description>
   <gfx_store>medium_fuel_pod</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <fuel>400</fuel>
  </specific>

--- a/dat/outfits/modifiers/medium_shield_booster.xml
+++ b/dat/outfits/modifiers/medium_shield_booster.xml
@@ -9,7 +9,7 @@
   <description>A shield generator that feeds off the ship's main energy line. It will allow you to regenerate your shield faster and give you a small shield capacity boost, at the expense of draining some of the ship's energy.</description>
   <gfx_store>shield</gfx_store>
   <cpu>-8</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <shield>30</shield>
   <shield_regen>1.5</shield_regen>

--- a/dat/outfits/modifiers/milspec_scrambler.xml
+++ b/dat/outfits/modifiers/milspec_scrambler.xml
@@ -8,7 +8,7 @@
   <description>Milspec knows what's important out there. It's that you don't get shot! And the best way not to get shot is not to get targeted in the first place. The Milspec RX 500-C scrambler will put the wool over your enemies' sensors, at a minimal cost to you or your ship's reactor! Fly safe, fly Milspec.</description>
   <gfx_store>jammer1</gfx_store>
   <cpu>-3</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <energy_usage>6</energy_usage>
   <ew_hide>20</ew_hide>

--- a/dat/outfits/modifiers/nanobond_plating.xml
+++ b/dat/outfits/modifiers/nanobond_plating.xml
@@ -8,7 +8,7 @@
   <price>365000</price>
   <gfx_store>nanobond</gfx_store>
   <description>Nanobond is the successor to Plasteel. It follows the same approach but has a greatly refined manufacturing process, providing greater particle density. The result is a much more robust material, although it is substantially more expensive.</description>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <armour_mod>25</armour_mod>
   <mass_mod>15</mass_mod>

--- a/dat/outfits/modifiers/nebula_shielding0.xml
+++ b/dat/outfits/modifiers/nebula_shielding0.xml
@@ -4,11 +4,12 @@
   <typename>Shield Power Modifier</typename>
   <slot>structure</slot>
   <size>small</size>
+  <rarity>2</rarity>
   <mass>15</mass>
   <price>10000</price>
   <description>A modification to the ship's shields that allows them to resist nebular volatility.</description>
   <gfx_store>capacitor</gfx_store>
- <rarity>6</rarity></general>
+ </general>
  <specific type="modification">
   <nebu_absorb_shield>40</nebu_absorb_shield>
   <energy_usage>20</energy_usage>

--- a/dat/outfits/modifiers/plasteel_plating.xml
+++ b/dat/outfits/modifiers/plasteel_plating.xml
@@ -8,7 +8,7 @@
   <price>65000</price>
   <gfx_store>plasteel</gfx_store>
   <description>Plasteel was one of man's greatest improvements on materials. It's a cheap, strong armour that seems to take the best from both plastic and steel, bending easily yet keeping its incredible strength. The Second Growth was only possible with this material. Although it is no longer cutting-edge, its low price point attracts many buyers.</description>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <armour_mod>5</armour_mod>
   <mass_mod>5</mass_mod>

--- a/dat/outfits/modifiers/power_regulation_override.xml
+++ b/dat/outfits/modifiers/power_regulation_override.xml
@@ -8,7 +8,7 @@
   <price>55000</price>
   <description>This outfit allows your forward mounts to dump more power into the weapons, providing greatly enhanced destructive potential. Unfortunately, exceeding design specifications results in increased heat production.</description>
   <gfx_store>damage_forward</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <fwd_damage>15</fwd_damage>
   <fwd_heat>5</fwd_heat>

--- a/dat/outfits/modifiers/reactor_class_i.xml
+++ b/dat/outfits/modifiers/reactor_class_i.xml
@@ -9,7 +9,7 @@
   <gfx_store>reactor_i</gfx_store>
   <description>Adding a complementary reactor to your ship is a great way to get that extra energy boost you need. This does not replace the existing reactor but works alongside it and hooks up directly to the energy flux.</description>
   <cpu>-5</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <energy>20</energy>
   <energy_regen>5</energy_regen>

--- a/dat/outfits/modifiers/reactor_class_ii.xml
+++ b/dat/outfits/modifiers/reactor_class_ii.xml
@@ -9,7 +9,7 @@
   <gfx_store>reactor_ii</gfx_store>
   <description>The class II reactor uses a newer fusion technology than the class I, permitting it to have greater energy density. The result is a mid-sized reactor that is best used on ships with moderate energy demands.</description>
   <cpu>-10</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <energy>60</energy>
   <energy_regen>10</energy_regen>

--- a/dat/outfits/modifiers/reactor_class_iii.xml
+++ b/dat/outfits/modifiers/reactor_class_iii.xml
@@ -9,7 +9,7 @@
   <gfx_store>reactor_iii</gfx_store>
   <description>The immense class III reactor provides enough power for nearly anything. The technology used in this reactor is particularly groundbreaking, with the best energy density of the three reactor classes. The huge size of the class III results in it only fitting comfortably on large vessels, though its energy output would be excessive for anything less.</description>
   <cpu>-20</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <energy>180</energy>
   <energy_regen>20</energy_regen>

--- a/dat/outfits/modifiers/reactor_thurion_i.xml
+++ b/dat/outfits/modifiers/reactor_thurion_i.xml
@@ -4,12 +4,13 @@
   <typename>Energy Modifier</typename>
   <slot>utility</slot>
   <size>small</size>
+  <rarity>2</rarity>
   <mass>10</mass>
   <price>530000</price>
   <gfx_store>reactor_i</gfx_store>
   <description>Thurion-designed reactor that uses Positrons for a superior energy output.</description>
   <cpu>-10</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <energy>40</energy>
   <energy_regen>10</energy_regen>

--- a/dat/outfits/modifiers/reactor_thurion_ii.xml
+++ b/dat/outfits/modifiers/reactor_thurion_ii.xml
@@ -4,12 +4,13 @@
   <typename>Energy Modifier</typename>
   <slot>utility</slot>
   <size>medium</size>
+  <rarity>2</rarity>
   <mass>30</mass>
   <price>970000</price>
   <gfx_store>reactor_ii</gfx_store>
   <description>Thurion-designed reactor that uses Positrons for a superior energy output.</description>
   <cpu>-20</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <energy>120</energy>
   <energy_regen>20</energy_regen>

--- a/dat/outfits/modifiers/reactor_thurion_iii.xml
+++ b/dat/outfits/modifiers/reactor_thurion_iii.xml
@@ -4,12 +4,13 @@
   <typename>Energy Modifier</typename>
   <slot>utility</slot>
   <size>large</size>
+  <rarity>2</rarity>
   <mass>90</mass>
   <price>1550000</price>
   <gfx_store>reactor_iii</gfx_store>
   <description>Thurion-designed reactor that uses Positrons for a superior energy output.</description>
   <cpu>-40</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="modification">
   <energy>360</energy>
   <energy_regen>40</energy_regen>

--- a/dat/outfits/modifiers/reverse_thrusters.xml
+++ b/dat/outfits/modifiers/reverse_thrusters.xml
@@ -9,7 +9,7 @@
   <gfx_store>afterburner</gfx_store>
   <limit>reverse_thruster</limit>
   <cpu>-2</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <misc_reverse_thrust>1</misc_reverse_thrust>
  </specific>

--- a/dat/outfits/modifiers/sensor_array.xml
+++ b/dat/outfits/modifiers/sensor_array.xml
@@ -3,12 +3,13 @@
  <general>
   <slot>utility</slot>
   <size>small</size>
+  <rarity>2</rarity>
   <mass>2</mass>
   <price>250000</price>
   <description>To detect other ships despite heavy ambient radiation the Thurion have developed powerful sensor arrays. By installing these additional sensors, the distance at which ships can be detected is increased.</description>
   <gfx_store>jammer0</gfx_store>
   <cpu>-8</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <energy_usage>10</energy_usage>
   <ew_detect>25</ew_detect>

--- a/dat/outfits/modifiers/shield_capacitor.xml
+++ b/dat/outfits/modifiers/shield_capacitor.xml
@@ -8,7 +8,7 @@
   <price>60000</price>
   <description>An enhancement for the shield power system, giving small ships a better chance of escaping attackers.</description>
   <gfx_store>capacitor</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <shield>40</shield>
  </specific>

--- a/dat/outfits/modifiers/shield_capacitor_ii.xml
+++ b/dat/outfits/modifiers/shield_capacitor_ii.xml
@@ -8,7 +8,7 @@
   <price>110000</price>
   <description>A more powerful shield enhancer, providing better protection during skirmishes.</description>
   <gfx_store>capacitor2</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <shield>75</shield>
  </specific>

--- a/dat/outfits/modifiers/shield_capacitor_iii.xml
+++ b/dat/outfits/modifiers/shield_capacitor_iii.xml
@@ -8,7 +8,7 @@
   <price>220000</price>
   <description>A heavy duty shield enhancer for ships that face combat on a regular basis.</description>
   <gfx_store>capacitor4</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <shield>145</shield>
  </specific>

--- a/dat/outfits/modifiers/shield_capacitor_iv.xml
+++ b/dat/outfits/modifiers/shield_capacitor_iv.xml
@@ -8,7 +8,7 @@
   <price>400000</price>
   <description>The pinnacle in shield boosting technology, reinforcing the defenses of ships fighting on the front lines.</description>
   <gfx_store>capacitor8</gfx_store>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <shield>280</shield>
  </specific>

--- a/dat/outfits/modifiers/small_shield_booster.xml
+++ b/dat/outfits/modifiers/small_shield_booster.xml
@@ -9,7 +9,7 @@
   <description>A shield generator that feeds off the ship's main energy line. It will allow you to regenerate your shield faster and give you a small shield capacity boost, at the expense of draining some of the ship's energy.</description>
   <gfx_store>shield</gfx_store>
   <cpu>-5</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <shield>15</shield>
   <shield_regen>1</shield_regen>

--- a/dat/outfits/modifiers/solar_panel.xml
+++ b/dat/outfits/modifiers/solar_panel.xml
@@ -8,7 +8,7 @@
   <price>25000</price>
   <description>A large panel that generates energy by collecting light and converting it into electricity. This will allow your ship to regenerate its energy supplies more quickly.</description>
   <gfx_store>solar</gfx_store>
- <rarity>1</rarity></general>
+ </general>
  <specific type="modification">
   <energy_regen>1.0</energy_regen>
  </specific>

--- a/dat/outfits/modifiers/steering_thrusters.xml
+++ b/dat/outfits/modifiers/steering_thrusters.xml
@@ -8,7 +8,7 @@
   <price>130000</price>
   <description>With the addition of several additional steering thrusters, you can increase your ship's turning rate. A favourite among fighter pilots.</description>
   <gfx_store>thruster</gfx_store>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <turn>5</turn>
   <turn_mod>10</turn_mod>

--- a/dat/outfits/modifiers/targeting_array.xml
+++ b/dat/outfits/modifiers/targeting_array.xml
@@ -8,7 +8,7 @@
   <price>125000</price>
   <description>An improved targeting array allows your turrets to more quickly acquire targets, and minimizes accuracy losses at range. It requires a short period to compute an ideal vector, slightly slowing firing rates.</description>
   <gfx_store>accuracy_turret</gfx_store>
- <rarity>2</rarity></general>
+ </general>
  <specific type="modification">
   <tur_heat>-25</tur_heat>
   <tur_firerate>-10</tur_firerate>

--- a/dat/outfits/modifiers/thurion_engine_reroute.xml
+++ b/dat/outfits/modifiers/thurion_engine_reroute.xml
@@ -4,12 +4,13 @@
   <typename>Manoevrability Modifier</typename>
   <slot>structure</slot>
   <size>small</size>
+  <rarity>2</rarity>
   <mass>0</mass>
   <price>175000</price>
   <description>This enhancement routes energy from the ship's energy supplies to the engine, giving the ship an increased thrust. It does not increase the ship's max speed nor turning abilities.</description>
   <gfx_store>reroute</gfx_store>
   <cpu>-8</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="modification">
   <thrust>5</thrust>
   <thrust_mod>15</thrust_mod>

--- a/dat/outfits/modifiers/unicorp_scrambler.xml
+++ b/dat/outfits/modifiers/unicorp_scrambler.xml
@@ -8,7 +8,7 @@
   <description>Scramblers distort a ship's electromagnetic signature, making it harder for various sensors to pick it up. In effect, a scrambler reduces the distance at which the ship can be detected and scanned, and makes it harder for missiles to lock on. The effect is quite limited however, and multiple scramblers may be required for the desired effect. On the upside, scramblers put a minimal strain on the ship's resources, and are always active.</description>
   <gfx_store>jammer0</gfx_store>
   <cpu>-1</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="modification">
   <energy_usage>4</energy_usage>
   <ew_hide>10</ew_hide>

--- a/dat/outfits/weapons/gauss_gun.xml
+++ b/dat/outfits/weapons/gauss_gun.xml
@@ -8,7 +8,7 @@
   <description>The Gauss Gun is one of the oldest weapon designs in the galaxy today, dating back to the times of the Federation. It fires a rapid stream of high velocity projectiles at a target, dealing damage through sheer kinetic impact. Gauss Guns are popular among small time pirates for being a cheap, reliable weapon.</description>
   <gfx_store>gaussgun</gfx_store>
   <cpu>-4</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>gatling</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/grave_beam.xml
+++ b/dat/outfits/weapons/grave_beam.xml
@@ -9,7 +9,7 @@
   <description>The Grave Beam is a lighter, faster version of the Ragnarok Beam. It does not deal as much damage, but its lighter size and more forgiving CPU requirements makes it a competitive contender.</description>
   <gfx_store>ragnarok</gfx_store>
   <cpu>-32</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret beam">
   <delay>6</delay>
   <duration min="1.5">5</duration>

--- a/dat/outfits/weapons/grave_lance.xml
+++ b/dat/outfits/weapons/grave_lance.xml
@@ -9,7 +9,7 @@
   <description>The Grave Lance is one of the most powerful Lance weapons around. The technology behind it is poorly understood by everyone except the Za'lek, who use it as a standard weapon.</description>
   <gfx_store>orion</gfx_store>
   <cpu>-20</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="beam">
   <delay>5</delay>
   <duration min="3.5">4.5</duration>

--- a/dat/outfits/weapons/heavy_ion_cannon.xml
+++ b/dat/outfits/weapons/heavy_ion_cannon.xml
@@ -9,7 +9,7 @@
   <description>The Heavy Ion Cannon does a far better job at disabling ships than the standard model, but it requires a medium mount. Most militaries employ these weapons on specialized capture teams, but the design is licensed for public use as well.</description>
   <gfx_store>ioncannon</gfx_store>
   <cpu>-12</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt" secondary="1">
   <gfx>ionL</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/heavy_ion_turret.xml
+++ b/dat/outfits/weapons/heavy_ion_turret.xml
@@ -9,7 +9,7 @@
   <description>The Heavy Ion Turret is a Sirius military design, applying brute force to its target's internal systems. When coupled with Razor weaponry, it is terribly efficient at reducing enemy warships to tumbling hunks of junk.</description>
   <gfx_store>ionturret</gfx_store>
   <cpu>-24</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt" secondary="1">
   <gfx>ionL</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/heavy_laser.xml
+++ b/dat/outfits/weapons/heavy_laser.xml
@@ -9,7 +9,7 @@
   <description>The Heavy Laser is more or less an upscaled version of the Laser Cannon Turret, though some fundamental mechanisms had to be redesigned to adapt to the increased energy throughput found in this weapon.</description>
   <gfx_store>laserturret2</gfx_store>
   <cpu>-30</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser3L</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/heavy_razor_turret.xml
+++ b/dat/outfits/weapons/heavy_razor_turret.xml
@@ -9,7 +9,7 @@
   <description>House Sirius typically equips its heavier vessels with Heavy Razor Turrets. Where the standard razor turrets are ineffective, the heavy razor turret provides the necessary firepower to batter down virtually any shielding.</description>
   <gfx_store>ionturret</gfx_store>
   <cpu>-24</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>razorL</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/heavy_ripper_cannon.xml
+++ b/dat/outfits/weapons/heavy_ripper_cannon.xml
@@ -9,7 +9,7 @@
   <description>By modulating the frequency of the basic Ripper Cannon, the Empire military increased its range, accuracy and destructive power. After reworking the power conduits, their efforts culminated in the devastating Heavy Ripper Cannon. The main drawback to this model is its increased bulk, which makes it unsuitable for smaller ships.</description>
   <gfx_store>ripper</gfx_store>
   <cpu>-15</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>ripperM</gfx>
   <sound>ripper</sound>

--- a/dat/outfits/weapons/heavy_ripper_turret.xml
+++ b/dat/outfits/weapons/heavy_ripper_turret.xml
@@ -9,7 +9,7 @@
   <description>While limited in range compared to true capital-class weaponry, the heavy ripper turret's pair of heavy ripper cannons deliver exceptional firepower for dealing with lighter threats such as corvettes.</description>
   <gfx_store>ripperturret</gfx_store>
   <cpu>-26</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>ripperM</gfx>
   <sound>ripper</sound>

--- a/dat/outfits/weapons/ion_cannon.xml
+++ b/dat/outfits/weapons/ion_cannon.xml
@@ -8,7 +8,7 @@
   <description>Ion Cannons are primarily nonlethal weapons designed to short out internal ship systems and rendering it disabled without killing the crew in the process. The standard Ion Cannon is the most basic and compact design, which allows it to be mounted on small craft. This makes the Ion Cannon one of the most popular weapons for weaker pirates.</description>
   <gfx_store>ioncannon</gfx_store>
   <cpu>-6</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt" secondary="1">
   <gfx>ionM</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/laser_cannon_mk0.xml
+++ b/dat/outfits/weapons/laser_cannon_mk0.xml
@@ -8,7 +8,7 @@
   <description>A home-made laser cannon for personal use by Captain T. Practice.</description>
   <gfx_store>laser</gfx_store>
   <cpu>-5</cpu>
-  <rarity>1</rarity></general>
+  </general>
  <specific type="bolt">
   <gfx>laser1S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_cannon_mk1.xml
+++ b/dat/outfits/weapons/laser_cannon_mk1.xml
@@ -8,7 +8,7 @@
   <description>The laser cannon is a standard weapon on many vessels. It fires charged energy beams that do a decent amount of damage to both shield and armour, while remaining efficient enough to mount several even on small ships.</description>
   <gfx_store>laser</gfx_store>
   <cpu>-4</cpu>
-  <rarity>1</rarity></general>
+  </general>
  <specific type="bolt">
   <gfx>laser1S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_cannon_mk2.xml
+++ b/dat/outfits/weapons/laser_cannon_mk2.xml
@@ -9,7 +9,7 @@
   <description>The mark 2 laser cannon improves on the original in many ways. Featuring increased range and greater firepower while only moderately increasing power demands, it's become a favourite civilian armament.</description>
   <gfx_store>laser2</gfx_store>
   <cpu>-5</cpu>
-  <rarity>2</rarity></general>
+  </general>
  <specific type="bolt">
   <gfx>laser2S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_cannon_mk3.xml
+++ b/dat/outfits/weapons/laser_cannon_mk3.xml
@@ -9,7 +9,7 @@
   <description>A high-powered version of the Laser Cannon, the MK3 is usually found on Imperial law enforcement ships. Its superior firepower helps keep order among the civilian populace, though it has limited applications in full blown military engagements.</description>
   <gfx_store>laser2</gfx_store>
   <cpu>-7</cpu>
-  <rarity>2</rarity></general>
+  </general>
  <specific type="bolt">
   <gfx>laser3S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_pd_mk1.xml
+++ b/dat/outfits/weapons/laser_pd_mk1.xml
@@ -8,7 +8,7 @@
   <description>While little more than a mark 1 laser cannon mounted on a turret, the Laser Point Defense MK1 is nevertheless a decent defensive weapon for light vessels.</description>
   <gfx_store>laserturret</gfx_store>
   <cpu>-8</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser1S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_pd_mk2.xml
+++ b/dat/outfits/weapons/laser_pd_mk2.xml
@@ -9,7 +9,7 @@
   <description>Featuring the improved firepower of the mark 2 laser cannon, the Laser Point Defense MK2 is a favourite among light merchant pilots.</description>
   <gfx_store>laserturret2</gfx_store>
   <cpu>-10</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser2S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_pd_mk3.xml
+++ b/dat/outfits/weapons/laser_pd_mk3.xml
@@ -9,7 +9,7 @@
   <description>While somewhat hard to come by due to Imperial export restrictions, the Laser Point Defense MK3 represents the pinnacle of light laser weapons technology.</description>
   <gfx_store>laserturret2</gfx_store>
   <cpu>-12</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser3S</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_turret_mk1.xml
+++ b/dat/outfits/weapons/laser_turret_mk1.xml
@@ -9,7 +9,7 @@
   <description>A pair of laser cannons mounted on a rotating turret, providing excellent point-defense capabilities. With a full 360 degrees of rotation, laser turrets provide affordable, energy-efficient firepower to less manoeuvrable ships.</description>
   <gfx_store>laserturret</gfx_store>
   <cpu>-14</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser1M</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_turret_mk2.xml
+++ b/dat/outfits/weapons/laser_turret_mk2.xml
@@ -9,7 +9,7 @@
   <description>A pair of mark 2 laser cannons mounted on a rotating turret, providing excellent point-defense capabilities. This new offering has quickly won the hearts of high-value traders for its superior firepower and range, easily warding off most pirates.</description>
   <gfx_store>laserturret2</gfx_store>
   <cpu>-16</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser2M</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/laser_turret_mk3.xml
+++ b/dat/outfits/weapons/laser_turret_mk3.xml
@@ -9,7 +9,7 @@
   <description>The Laser Turret MK3 is often found on Imperial fast response fleets, for use against fleets of small to medium ships. This weapon is one of the mainstays in the Imperial space forces.</description>
   <gfx_store>laserturret2</gfx_store>
   <cpu>-18</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser3M</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/mass_driver_mk1.xml
+++ b/dat/outfits/weapons/mass_driver_mk1.xml
@@ -9,7 +9,7 @@
   <description>Mass Drivers fire massive slugs of matter at enemy ships, dealing damage through kinetic impact and knocking the target back. One of the most economical heavy weapons in the galaxy.</description>
   <gfx_store>gatling</gfx_store>
   <cpu>-12</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>autocannon</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/mass_driver_mk2.xml
+++ b/dat/outfits/weapons/mass_driver_mk2.xml
@@ -9,7 +9,7 @@
   <description>The MK2 version of the Mass Driver differs little from its weaker model in its working. Rather, the parts it's made of have a better performance curve, allowing the driver rounds to be fired with increased force.</description>
   <gfx_store>gatling</gfx_store>
   <cpu>-15</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>autocannon</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/mass_driver_mk3.xml
+++ b/dat/outfits/weapons/mass_driver_mk3.xml
@@ -9,7 +9,7 @@
   <description>If ever there was a clear example of House Dvaered's lack of subtlety, then the Mass Driver MK3 would be it. Typically mounted on medium escorts, these weapons can reduce any other ship to an inert lump of metal.</description>
   <gfx_store>gatling</gfx_store>
   <cpu>-18</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>autocannon</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/neutron_disruptor.xml
+++ b/dat/outfits/weapons/neutron_disruptor.xml
@@ -9,7 +9,7 @@
   <description>The Neutron Disruptor uses high-energy pulses that modify the base composition of molecules, causing heavy damage. This weapon was first popular with the Collective, as until recently, firing it would produce radiation lethal to humans aboard the ship.</description>
   <gfx_store>neutron</gfx_store>
   <cpu>-8</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>neutron</gfx>
   <sound>neutron</sound>

--- a/dat/outfits/weapons/neutron_disruptor_heavy.xml
+++ b/dat/outfits/weapons/neutron_disruptor_heavy.xml
@@ -9,7 +9,7 @@
   <description>The Heavy Neutron Disruptor improves upon the processes behind the smaller Neutron Disruptor, giving this weapon greater damage and range.</description>
   <gfx_store>neutronheavy</gfx_store>
   <cpu>-12</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>neutron</gfx>
   <sound>neutron</sound>

--- a/dat/outfits/weapons/orion_beam.xml
+++ b/dat/outfits/weapons/orion_beam.xml
@@ -9,7 +9,7 @@
   <description>The turret-mounted edition of the Orion design offers mid-sized ships exceptional short-duration firepower, a potent deterrent against lighter vessels.</description>
   <gfx_store>ragnarok</gfx_store>
   <cpu>-16</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret beam">
   <delay>4</delay>
   <duration>4</duration>

--- a/dat/outfits/weapons/orion_lance.xml
+++ b/dat/outfits/weapons/orion_lance.xml
@@ -9,7 +9,7 @@
   <description>The Orion Lance is a fixed-mount weapon designed to be mounted on fighters and up. Based on a heavily-modified, liquid-cooled laser, it's capable of bursts of continuous fire, resulting in a destructive beam.</description>
   <gfx_store>orion</gfx_store>
   <cpu>-8</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="beam">
   <delay>3</delay>
   <duration>4</duration>

--- a/dat/outfits/weapons/particle_beam.xml
+++ b/dat/outfits/weapons/particle_beam.xml
@@ -9,7 +9,7 @@
   <description>A turret-mounted particle beam. The smallest possible turreted beam weapon, used as a last-ditch weapon against light enemies.</description>
   <gfx_store>ragnarok</gfx_store>
   <cpu>-9</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret beam">
   <delay>2</delay>
   <duration>2</duration>

--- a/dat/outfits/weapons/particle_lance.xml
+++ b/dat/outfits/weapons/particle_lance.xml
@@ -9,7 +9,7 @@
   <description>This is the smallest direct beam weapon built, purpose-built by the Za'lek for their drones.</description>
   <gfx_store>orion</gfx_store>
   <cpu>-5</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="beam">
   <delay>1.5</delay>
   <duration>2</duration>

--- a/dat/outfits/weapons/plasma_blaster_mk1.xml
+++ b/dat/outfits/weapons/plasma_blaster_mk1.xml
@@ -8,7 +8,7 @@
   <description>Highly volatile, the plasma blaster is among the best choices for fast attacks. As a result of its volatility, it is a potent weapon against both shields and armour, though it is known for dissipating quickly after being fired.</description>
   <gfx_store>plasma</gfx_store>
   <cpu>-3</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>plasma</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_blaster_mk2.xml
+++ b/dat/outfits/weapons/plasma_blaster_mk2.xml
@@ -9,7 +9,7 @@
   <description>The mark 2 plasma blaster improves on its predecessor in many ways, maintaining good energy efficiency while augmenting range and firepower. Pirates have taken a liking to this weapon.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-5</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>plasma2</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_blaster_mk3.xml
+++ b/dat/outfits/weapons/plasma_blaster_mk3.xml
@@ -9,7 +9,7 @@
   <description>The Plasma Blaster MK3 is a Soromid refinement to what was originally an Imperial design. It is one of the few Soromid military weapons that are compatible with standard ship mount points. The Soromid use it mainly for local law enforcement purposes.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-7</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>plasma2</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_cluster_cannon_mk1.xml
+++ b/dat/outfits/weapons/plasma_cluster_cannon_mk1.xml
@@ -9,7 +9,7 @@
   <description>The mark 2 plasma blaster improves on its predecessor in many ways, maintaining good energy efficiency while augmenting range and firepower. Though intended primarily for military use, many have found their way to pirate hands.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-24</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>plasma2</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_cluster_cannon_mk2.xml
+++ b/dat/outfits/weapons/plasma_cluster_cannon_mk2.xml
@@ -9,7 +9,7 @@
   <description>The mark 2 plasma blaster improves on its predecessor in many ways, maintaining good energy efficiency while augmenting range and firepower. Though intended primarily for military use, many have found their way to pirate hands.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-28</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>plasma2</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_cluster_cannon_mk3.xml
+++ b/dat/outfits/weapons/plasma_cluster_cannon_mk3.xml
@@ -9,7 +9,7 @@
   <description>The mark 2 plasma blaster improves on its predecessor in many ways, maintaining good energy efficiency while augmenting range and firepower. Though intended primarily for military use, many have found their way to pirate hands.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-34</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>plasma2</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_turret_mk1.xml
+++ b/dat/outfits/weapons/plasma_turret_mk1.xml
@@ -9,7 +9,7 @@
   <description>The plasma turret essentially takes a plasma blaster and mounts it on a turret. Its short range makes it ill-suited for defense, so it is not especially popular with traders and merchants, but it has found a niche among inexperienced mercenaries who are not as well-practiced at aiming as the pros.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-10</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>plasma</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/plasma_turret_mk2.xml
+++ b/dat/outfits/weapons/plasma_turret_mk2.xml
@@ -9,7 +9,7 @@
   <description>The mark 2 plasma turret isn't especially impressive compared to other medium-size turrets, but it is sometimes favored by corvettes for its unusually low weight compared to its range and damage output.</description>
   <gfx_store>plasma2</gfx_store>
   <cpu>-16</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>plasma2</gfx>
   <sound>plasma</sound>

--- a/dat/outfits/weapons/pulse_beam.xml
+++ b/dat/outfits/weapons/pulse_beam.xml
@@ -9,7 +9,7 @@
   <description>The Pulse Beam is an aptly named beam weapon designed to counter fighters with a rapid-firing, short-lived pulse. It doesn't do very much damage against larger targets, but fighters who get near ships equipped with this weapon will have a bad day.</description>
   <gfx_store>ragnarok</gfx_store>
   <cpu>-14</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret beam">
   <delay>0.2</delay>
   <duration min="0.25">0.25</duration>

--- a/dat/outfits/weapons/ragnarok_beam.xml
+++ b/dat/outfits/weapons/ragnarok_beam.xml
@@ -9,7 +9,7 @@
   <description>The Ragnarok Beam is one of the most powerful beam class weapons on the market. It's designed for capital ship combat, although its extremely large payload makes it somewhat useful for clearing enemy fighters.</description>
   <gfx_store>ragnarok</gfx_store>
   <cpu>-44</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="turret beam">
   <delay>8</delay>
   <duration min="2">6</duration>

--- a/dat/outfits/weapons/railgun.xml
+++ b/dat/outfits/weapons/railgun.xml
@@ -9,7 +9,7 @@
   <description>The railgun is a cannon that uses heavy magnetic pulses to accelerate pieces of debris to extremely high velocities. The impact caused by the pieces of debris can tear apart even the strongest ship hulls.</description>
   <gfx_store>railgun</gfx_store>
   <cpu>-26</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>massL</gfx>
   <sound>mass</sound>

--- a/dat/outfits/weapons/railgun_turret.xml
+++ b/dat/outfits/weapons/railgun_turret.xml
@@ -9,7 +9,7 @@
   <description>While one 150mm railgun is a formidable weapon, the ultimate in brute-force capital ship weaponry is the 150mm railgun turret. Mounting two railguns in a specialized turret housing, it manages to mitigate the recoil normally associated with railguns, at a slight velocity cost.</description>
   <gfx_store>railgunturret</gfx_store>
   <cpu>-34</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>massL</gfx>
   <sound>mass</sound>

--- a/dat/outfits/weapons/razor_mk1.xml
+++ b/dat/outfits/weapons/razor_mk1.xml
@@ -8,7 +8,7 @@
   <description>Razors fire concentrated pockets of high energy ions that are very effective at draining shields, but have only limited effect on a ship's armour. As such, Razors are best used in the initial phase of an engagement, and swapped out for other weapons once the target's shields come down.</description>
   <gfx_store>ioncannon</gfx_store>
   <cpu>-5</cpu>
- <rarity>1</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>razorS</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/razor_mk2.xml
+++ b/dat/outfits/weapons/razor_mk2.xml
@@ -8,7 +8,7 @@
   <description>The upgraded civilian Razor model packs increased overall effectiveness compared to its predecessor, and has less difficulty in overloading capital ship grade shielding. As with the basic model, the Razor MK2 is best used to drain a target's shields, paving the way for other weapons to deliver the finishing blow.</description>
   <gfx_store>ioncannon</gfx_store>
   <cpu>-6</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>razorS</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/razor_mk3.xml
+++ b/dat/outfits/weapons/razor_mk3.xml
@@ -9,7 +9,7 @@
   <description>The heaviest version of the Razor is excellent at stripping the shields from those who would stand against House Sirius. In large engagements, Razor MK3s are often employed by support ships, whose task is to weaken a target before the heavy enforcer ships move in.</description>
   <gfx_store>ioncannon</gfx_store>
   <cpu>-8</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>razorS</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/razor_turret_mk1.xml
+++ b/dat/outfits/weapons/razor_turret_mk1.xml
@@ -9,7 +9,7 @@
   <description>Razor Turrets are popular among traders. Their high damage against shields is a great deterrent against attackers, because nothing puts a space pilot on edge like his shields rapidly coming down.</description>
   <gfx_store>ionturret</gfx_store>
   <cpu>-9</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>razorS</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/razor_turret_mk2.xml
+++ b/dat/outfits/weapons/razor_turret_mk2.xml
@@ -9,7 +9,7 @@
   <description>The MK2 turreted version of the Razor sees a lot of application on medium escort ships. They are often mounted alongside laser or gauss turrets to assist in de-shielding incoming attackers before they are ripped to shreds.</description>
   <gfx_store>ionturret</gfx_store>
   <cpu>-15</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>razorM</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/razor_turret_mk3.xml
+++ b/dat/outfits/weapons/razor_turret_mk3.xml
@@ -9,7 +9,7 @@
   <description>House Sirius typically equips its independent capital ships with Razor Turret MK3s. Where the standard Razor MK3 is impractical, the turreted version provides great de-shielding capabilities for the slower members of the Sirian fleet.</description>
   <gfx_store>ionturret</gfx_store>
   <cpu>-18</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>razorM</gfx>
   <sound>ion</sound>

--- a/dat/outfits/weapons/repeating_railgun.xml
+++ b/dat/outfits/weapons/repeating_railgun.xml
@@ -9,7 +9,7 @@
   <description>While the Railgun was devastating in its effects, it wasn't quite devastating enough for Dvaered High Command. They had their engineers enhance the weapon into a heavier, faster firing variant that isn't so much a gun as it is a miniature meteor shower generator.</description>
   <gfx_store>railgun</gfx_store>
   <cpu>-32</cpu>
- <rarity>4</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>massL</gfx>
   <sound>mass</sound>

--- a/dat/outfits/weapons/ripper_cannon.xml
+++ b/dat/outfits/weapons/ripper_cannon.xml
@@ -9,7 +9,7 @@
   <description>The Ripper Cannon is a variant on the Laser Cannon that has stronger capacitors and twin, synchronous muzzles. The result is an increase in damage per hit, though the weapon needs longer to recharge than the standard model, so rate of fire suffers. The Ripper Cannon is mostly used by experienced pilots who don't need to rely on rapid fire to hit their marks anymore.</description>
   <gfx_store>ripper</gfx_store>
   <cpu>-10</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>ripperS</gfx>
   <sound>ripper</sound>

--- a/dat/outfits/weapons/shattershield_lance.xml
+++ b/dat/outfits/weapons/shattershield_lance.xml
@@ -9,7 +9,7 @@
   <description>This ion-based beam weapon is designed to deliver a powerful stream of charged ions along with an electromagnetic pulse to a ship, short-circuiting its shields with ruthless efficiency. Fighters and ships that rely on shields for protection find this weapon to be devastating, but its weakness versus armor relegates to a secondary weapon.</description>
   <gfx_store>orion</gfx_store>
   <cpu>-12</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="beam" secondary="1">
   <delay>4</delay>
   <duration min="1">4</duration>

--- a/dat/outfits/weapons/shredder.xml
+++ b/dat/outfits/weapons/shredder.xml
@@ -9,7 +9,7 @@
   <description>The Shredder quite lives up to the name its Dvaered manufacturers gave it. The sheer damage dealing capacity of this weapon makes Dvaered fighters dangerous to engage by ships that aren't substantially larger than they are.</description>
   <gfx_store>shredder</gfx_store>
   <cpu>-8</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>gatling</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/turbolaser.xml
+++ b/dat/outfits/weapons/turbolaser.xml
@@ -9,7 +9,7 @@
   <description>The military grade model of the Heavy Laser is one of the heaviest weapons found in the galaxy. Imperial Capital ships use it to lay down devastating barrages against enemy vessels.</description>
   <gfx_store>laserturret2</gfx_store>
   <cpu>-38</cpu>
- <rarity>5</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>laser4L</gfx>
   <sound>laser</sound>

--- a/dat/outfits/weapons/turreted_gauss_gun.xml
+++ b/dat/outfits/weapons/turreted_gauss_gun.xml
@@ -9,7 +9,7 @@
   <description>One of the more common countermeasures employed by low-budget merchant ships, the turret version of the Gauss Gun provides basic defense against lone pirates. A more determined attacker is unlikely to be deterred, however.</description>
   <gfx_store>gaussturret</gfx_store>
   <cpu>-8</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>gatling</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/turreted_vulcan_gun.xml
+++ b/dat/outfits/weapons/turreted_vulcan_gun.xml
@@ -9,7 +9,7 @@
   <description>Turreted Vulcan Guns pack the same caliber ammunition as their fixed mount brethren. Ships not nimble enough to evade its relentless stream of projectiles might find themselves riddled with hull punctures before long.</description>
   <gfx_store>vulcanturret</gfx_store>
   <cpu>-16</cpu>
- <rarity>3</rarity></general>
+ </general>
  <specific type="turret bolt">
   <gfx>gatling</gfx>
   <sound>autocannon</sound>

--- a/dat/outfits/weapons/vulcan_gun.xml
+++ b/dat/outfits/weapons/vulcan_gun.xml
@@ -9,7 +9,7 @@
   <description>The Vulcan Gun improves over the Gauss Gun with increased range and damage, achieved by using a heavier calibre ammunition. A skilled pilot can wreak some serious havoc with a pair of Vulcan Guns installed in his ship.</description>
   <gfx_store>vulcangun</gfx_store>
   <cpu>-6</cpu>
- <rarity>2</rarity></general>
+ </general>
  <specific type="bolt">
   <gfx>gatling</gfx>
   <sound>autocannon</sound>

--- a/dat/ships/admonisher.xml
+++ b/dat/ships/admonisher.xml
@@ -2,7 +2,6 @@
 <ship name="Admonisher">
  <base_type>Admonisher</base_type>
  <GFX>admonisher</GFX>
- <rarity>3</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/ancestor.xml
+++ b/dat/ships/ancestor.xml
@@ -2,7 +2,6 @@
 <ship name="Ancestor">
  <base_type>Ancestor</base_type>
  <GFX>ancestor</GFX>
- <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Bomber</class>

--- a/dat/ships/drone.xml
+++ b/dat/ships/drone.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ship name="Drone">
  <base_type>Drone</base_type>
- <rarity>4</rarity>
  <GFX>drone</GFX>
  <GUI>brushed</GUI>
  <sound>engine</sound>

--- a/dat/ships/drone_heavy.xml
+++ b/dat/ships/drone_heavy.xml
@@ -2,7 +2,6 @@
 <ship name="Heavy Drone">
  <base_type>Drone</base_type>
  <GFX sx="10" sy="10">drone_heavy</GFX>
- <rarity>5</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Heavy Drone</class>

--- a/dat/ships/dvaered_ancestor.xml
+++ b/dat/ships/dvaered_ancestor.xml
@@ -2,7 +2,7 @@
 <ship name="Dvaered Ancestor">
  <base_type>Ancestor</base_type>
  <GFX>ancestor_dvaered</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Bomber</class>

--- a/dat/ships/dvaered_goddard.xml
+++ b/dat/ships/dvaered_goddard.xml
@@ -3,7 +3,7 @@
  <base_type>Goddard</base_type>
  <GFX sx="12" sy="12">goddard_dvaered</GFX>
  <GUI>brushed</GUI>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>7000000</price>

--- a/dat/ships/dvaered_phalanx.xml
+++ b/dat/ships/dvaered_phalanx.xml
@@ -3,7 +3,7 @@
  <base_type>Phalanx</base_type>
  <GFX sx="10" sy="10">phalanx_dvaered</GFX>
  <GUI>brushed</GUI>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <sound>engine</sound>
  <class>Corvette</class>
  <price>650000</price>

--- a/dat/ships/dvaered_vendetta.xml
+++ b/dat/ships/dvaered_vendetta.xml
@@ -2,7 +2,7 @@
 <ship name="Dvaered Vendetta">
  <base_type>Vendetta</base_type>
  <GFX>vendetta_dvaered</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/dvaered_vigilance.xml
+++ b/dat/ships/dvaered_vigilance.xml
@@ -2,7 +2,7 @@
 <ship name="Dvaered Vigilance">
  <base_type>Vigilance</base_type>
  <GFX sx="10" sy="10">vigilance_dvaered</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/empire_admonisher.xml
+++ b/dat/ships/empire_admonisher.xml
@@ -2,7 +2,7 @@
 <ship name="Empire Admonisher">
  <base_type>Admonisher</base_type>
  <GFX>admonisher_empire</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/empire_hawking.xml
+++ b/dat/ships/empire_hawking.xml
@@ -2,7 +2,7 @@
 <ship name="Empire Hawking">
  <base_type>Hawking</base_type>
  <GFX sx="12" sy="12">hawking_empire</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/empire_lancelot.xml
+++ b/dat/ships/empire_lancelot.xml
@@ -2,7 +2,7 @@
 <ship name="Empire Lancelot">
  <base_type>Lancelot</base_type>
  <GFX>lancelot_empire</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/empire_pacifier.xml
+++ b/dat/ships/empire_pacifier.xml
@@ -2,7 +2,7 @@
 <ship name="Empire Pacifier">
  <base_type>Pacifier</base_type>
  <GFX sx="10" sy="10">pacifier_empire</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/empire_peacemaker.xml
+++ b/dat/ships/empire_peacemaker.xml
@@ -2,7 +2,7 @@
 <ship name="Empire Peacemaker">
  <base_type>Peacemaker</base_type>
  <GFX sx="12" sy="12">peacemaker</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/empire_shark.xml
+++ b/dat/ships/empire_shark.xml
@@ -2,7 +2,7 @@
 <ship name="Empire Shark">
  <base_type>Shark</base_type>
  <GFX>shark_empire</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/gawain.xml
+++ b/dat/ships/gawain.xml
@@ -2,7 +2,6 @@
 <ship name="Gawain">
  <base_type>Gawain</base_type>
  <GFX>gawain</GFX>
- <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Luxury Yacht</class>

--- a/dat/ships/goddard.xml
+++ b/dat/ships/goddard.xml
@@ -2,7 +2,6 @@
 <ship name="Goddard">
  <base_type>Goddard</base_type>
  <GFX sx="12" sy="12">goddard</GFX>
- <rarity>5</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/hawking.xml
+++ b/dat/ships/hawking.xml
@@ -2,7 +2,6 @@
 <ship name="Hawking">
  <base_type>Hawking</base_type>
  <GFX sx="12" sy="12">hawking</GFX>
- <rarity>4</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/hyena.xml
+++ b/dat/ships/hyena.xml
@@ -2,7 +2,6 @@
 <ship name="Hyena">
  <base_type>Hyena</base_type>
  <GFX>hyena</GFX>
- <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/kestrel.xml
+++ b/dat/ships/kestrel.xml
@@ -2,7 +2,6 @@
 <ship name="Kestrel">
  <base_type>Kestrel</base_type>
  <GFX sx="10" sy="10">kestrel</GFX>
- <rarity>4</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/koala.xml
+++ b/dat/ships/koala.xml
@@ -2,7 +2,6 @@
 <ship name="Koala">
  <base_type>Koala</base_type>
  <GFX>koala</GFX>
- <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Courier</class>

--- a/dat/ships/lancelot.xml
+++ b/dat/ships/lancelot.xml
@@ -2,7 +2,6 @@
 <ship name="Lancelot">
  <base_type>Lancelot</base_type>
  <GFX>lancelot</GFX>
- <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/llama.xml
+++ b/dat/ships/llama.xml
@@ -2,7 +2,6 @@
 <ship name="Llama">
  <base_type>Llama</base_type>
  <GFX>llama</GFX>
- <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Yacht</class>

--- a/dat/ships/mule.xml
+++ b/dat/ships/mule.xml
@@ -2,7 +2,6 @@
 <ship name="Mule">
  <base_type>Mule</base_type>
  <GFX sx="10" sy="10">mule</GFX>
- <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Freighter</class>

--- a/dat/ships/pacifier.xml
+++ b/dat/ships/pacifier.xml
@@ -2,7 +2,6 @@
 <ship name="Pacifier">
  <base_type>Pacifier</base_type>
  <GFX sx="10" sy="10">pacifier</GFX>
- <rarity>3</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/phalanx.xml
+++ b/dat/ships/phalanx.xml
@@ -2,7 +2,6 @@
 <ship name="Phalanx">
  <base_type>Phalanx</base_type>
  <GFX sx="10" sy="10">phalanx</GFX>
- <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/pirate_admonisher.xml
+++ b/dat/ships/pirate_admonisher.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Admonisher">
  <base_type>Admonisher</base_type>
  <GFX>admonisher_pirate</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/pirate_ancestor.xml
+++ b/dat/ships/pirate_ancestor.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Ancestor">
  <base_type>Ancestor</base_type>
  <GFX>ancestor_pirate</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Bomber</class>

--- a/dat/ships/pirate_kestrel.xml
+++ b/dat/ships/pirate_kestrel.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Kestrel">
  <base_type>Kestrel</base_type>
  <GFX sx="10" sy="10">kestrel_pirate</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/pirate_phalanx.xml
+++ b/dat/ships/pirate_phalanx.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Phalanx">
  <base_type>Phalanx</base_type>
  <GFX sx="10" sy="10">phalanx_pirate</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/pirate_rhino.xml
+++ b/dat/ships/pirate_rhino.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Rhino">
  <base_type>Rhino</base_type>
  <GFX sx="10" sy="10">rhino_pirate</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Armoured Transport</class>

--- a/dat/ships/pirate_shark.xml
+++ b/dat/ships/pirate_shark.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Shark">
  <base_type>Shark</base_type>
  <GFX>shark_pirate</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/pirate_vendetta.xml
+++ b/dat/ships/pirate_vendetta.xml
@@ -2,7 +2,7 @@
 <ship name="Pirate Vendetta">
  <base_type>Vendetta</base_type>
  <GFX>vendetta_pirate</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/proteron_archimedes.xml
+++ b/dat/ships/proteron_archimedes.xml
@@ -2,7 +2,7 @@
 <ship name="Proteron Archimedes">
  <base_type>Archimedes</base_type>
  <GFX sx="12" sy="12">archimedes</GFX>
- <rarity>3</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/proteron_derivative.xml
+++ b/dat/ships/proteron_derivative.xml
@@ -2,7 +2,7 @@
 <ship name="Proteron Derivative">
  <base_type>Derivative</base_type>
  <GFX>derivative</GFX>
- <rarity>3</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/proteron_kahan.xml
+++ b/dat/ships/proteron_kahan.xml
@@ -2,7 +2,7 @@
 <ship name="Proteron Kahan">
  <base_type>Kahan</base_type>
  <GFX sx="10" sy="10">kahan</GFX>
- <rarity>4</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/proteron_watson.xml
+++ b/dat/ships/proteron_watson.xml
@@ -2,7 +2,7 @@
 <ship name="Proteron Watson">
  <base_type>Watson</base_type>
  <GFX sx="12" sy="12">watson</GFX>
- <rarity>5</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/quicksilver.xml
+++ b/dat/ships/quicksilver.xml
@@ -2,7 +2,6 @@
 <ship name="Quicksilver">
  <base_type>Quicksilver</base_type>
  <GFX sx="10" sy="10">quicksilver</GFX>
- <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Courier</class>

--- a/dat/ships/rhino.xml
+++ b/dat/ships/rhino.xml
@@ -2,7 +2,6 @@
 <ship name="Rhino">
  <base_type>Rhino</base_type>
  <GFX sx="10" sy="10">rhino</GFX>
- <rarity>3</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Armoured Transport</class>

--- a/dat/ships/schroedinger.xml
+++ b/dat/ships/schroedinger.xml
@@ -2,7 +2,6 @@
 <ship name="Schroedinger">
  <base_type>Schroedinger</base_type>
  <GFX>schroedinger</GFX>
- <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Scout</class>

--- a/dat/ships/shark.xml
+++ b/dat/ships/shark.xml
@@ -2,7 +2,6 @@
 <ship name="Shark">
  <base_type>Shark</base_type>
  <GFX>shark</GFX>
- <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/sirius_divinity.xml
+++ b/dat/ships/sirius_divinity.xml
@@ -2,7 +2,7 @@
 <ship name="Sirius Divinity">
  <base_type>Divinity</base_type>
  <GFX sx="12" sy="12">divinity</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/sirius_dogma.xml
+++ b/dat/ships/sirius_dogma.xml
@@ -2,7 +2,7 @@
 <ship name="Sirius Dogma">
  <base_type>Dogma</base_type>
  <GFX sx="12" sy="12">dogma</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/sirius_fidelity.xml
+++ b/dat/ships/sirius_fidelity.xml
@@ -2,7 +2,7 @@
 <ship name="Sirius Fidelity">
  <base_type>Fidelity</base_type>
  <GFX>fidelity</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/sirius_preacher.xml
+++ b/dat/ships/sirius_preacher.xml
@@ -2,7 +2,7 @@
 <ship name="Sirius Preacher">
  <base_type>Preacher</base_type>
  <GFX sx="10" sy="10">preacher</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/sirius_reverence.xml
+++ b/dat/ships/sirius_reverence.xml
@@ -2,7 +2,7 @@
 <ship name="Sirius Reverence">
  <base_type>Reverence</base_type>
  <GFX sx="10" sy="10">preacher</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/sirius_shaman.xml
+++ b/dat/ships/sirius_shaman.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ship name="Sirius Shaman">
  <base_type>Shaman</base_type>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GFX>shaman</GFX>
  <GUI>brushed</GUI>
  <sound>engine</sound>

--- a/dat/ships/soromid_arx.xml
+++ b/dat/ships/soromid_arx.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Arx">
  <base_type>Arx</base_type>
  <GFX sx="12" sy="12">arx</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/soromid_brigand.xml
+++ b/dat/ships/soromid_brigand.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Brigand">
  <base_type>Brigand</base_type>
  <GFX>brigand</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/soromid_ira.xml
+++ b/dat/ships/soromid_ira.xml
@@ -3,7 +3,7 @@
  <base_type>Ira</base_type>
  <GFX sx="12" sy="12">ira</GFX>
  <GUI>brushed</GUI>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <sound>engine</sound>
  <class>Cruiser</class>
  <price>4500000</price>

--- a/dat/ships/soromid_marauder.xml
+++ b/dat/ships/soromid_marauder.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Marauder">
  <base_type>Marauder</base_type>
  <GFX>marauder</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Bomber</class>

--- a/dat/ships/soromid_nyx.xml
+++ b/dat/ships/soromid_nyx.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Nyx">
  <base_type>Nyx</base_type>
  <GFX sx="10" sy="10">nyx</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/soromid_odium.xml
+++ b/dat/ships/soromid_odium.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Odium">
  <base_type>Odium</base_type>
  <GFX>odium</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/soromid_reaver.xml
+++ b/dat/ships/soromid_reaver.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Reaver">
  <base_type>Reaver</base_type>
  <GFX>reaver</GFX>
- <rarity>3</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/soromid_vox.xml
+++ b/dat/ships/soromid_vox.xml
@@ -2,7 +2,7 @@
 <ship name="Soromid Vox">
  <base_type>Vox</base_type>
  <GFX sx="12" sy="12">vox</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/thurion_apprehension.xml
+++ b/dat/ships/thurion_apprehension.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Apprehension">
  <base_type>Apprehension</base_type>
  <GFX sx="12" sy="12">apprehension</GFX>
- <rarity>4</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/thurion_certitude.xml
+++ b/dat/ships/thurion_certitude.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Certitude">
  <base_type>Certitude</base_type>
  <GFX sx="12" sy="12">certitude</GFX>
- <rarity>5</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/thurion_ingenuity.xml
+++ b/dat/ships/thurion_ingenuity.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Ingenuity">
  <base_type>Ingenuity</base_type>
  <GFX>ingenuity</GFX>
- <rarity>3</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/thurion_perspicacity.xml
+++ b/dat/ships/thurion_perspicacity.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Perspicacity">
  <base_type>Perspicacity</base_type>
  <GFX>perspicacity</GFX>
- <rarity>3</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/thurion_scintillation.xml
+++ b/dat/ships/thurion_scintillation.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Scintillation">
  <base_type>Scintillation</base_type>
  <GFX>scintillation</GFX>
- <rarity>3</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Bomber</class>

--- a/dat/ships/thurion_taciturnity.xml
+++ b/dat/ships/thurion_taciturnity.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Taciturnity">
  <base_type>Taciturnity</base_type>
  <GFX sx="10" sy="10">taciturnity</GFX>
- <rarity>4</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Armoured Transport</class>

--- a/dat/ships/thurion_virtuosity.xml
+++ b/dat/ships/thurion_virtuosity.xml
@@ -2,7 +2,7 @@
 <ship name="Thurion Virtuosity">
  <base_type>Virtuosity</base_type>
  <GFX>virtuosity</GFX>
- <rarity>4</rarity>
+ <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/vendetta.xml
+++ b/dat/ships/vendetta.xml
@@ -2,7 +2,6 @@
 <ship name="Vendetta">
  <base_type>Vendetta</base_type>
  <GFX>vendetta</GFX>
- <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Fighter</class>

--- a/dat/ships/vigilance.xml
+++ b/dat/ships/vigilance.xml
@@ -2,7 +2,6 @@
 <ship name="Vigilance">
  <base_type>Vigilance</base_type>
  <GFX sx="10" sy="10">vigilance</GFX>
- <rarity>4</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/zalek_demon.xml
+++ b/dat/ships/zalek_demon.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Demon">
  <base_type>Demon</base_type>
  <GFX sx="12" sy="12">demon</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Destroyer</class>

--- a/dat/ships/zalek_diablo.xml
+++ b/dat/ships/zalek_diablo.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Diablo">
  <base_type>Diablo</base_type>
  <GFX sx="12" sy="12">diablo</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/zalek_hephaestus.xml
+++ b/dat/ships/zalek_hephaestus.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Hephaestus">
  <base_type>Hephaestus</base_type>
  <GFX sx="12" sy="12">hephaestus</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Carrier</class>

--- a/dat/ships/zalek_imp.xml
+++ b/dat/ships/zalek_imp.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Imp">
  <base_type>Imp</base_type>
  <GFX sx="12" sy="12">imp</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>

--- a/dat/ships/zalek_mephisto.xml
+++ b/dat/ships/zalek_mephisto.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Mephisto">
  <base_type>Mephisto</base_type>
  <GFX sx="12" sy="12">mephisto</GFX>
- <rarity>5</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/zalek_prototype.xml
+++ b/dat/ships/zalek_prototype.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Prototype">
  <base_type>Prototype</base_type>
  <GFX sx="12" sy="12">prototype</GFX>
- <rarity>6</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Cruiser</class>

--- a/dat/ships/zalek_sting.xml
+++ b/dat/ships/zalek_sting.xml
@@ -2,7 +2,7 @@
 <ship name="Za'lek Sting">
  <base_type>Sting</base_type>
  <GFX sx="10" sy="10">sting</GFX>
- <rarity>4</rarity>
+ <rarity>1</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
  <class>Corvette</class>


### PR DESCRIPTION
This uses the "Rarity" indication of outfits differently. Rather than trying to determine what outfits are better, I changed it to only report facts. Specifically:

* Rarity 1 indicates military-grade cores and known factional equipment / ships.
* Rarity 2 indicates hidden factional equipment / ships (Thurion and Proteron).

This is a simpler, more straightforward use of rarity and avoids trying to tell the player what's better too much.