### PR TITLE
fix of gui when the speed is superior to max

### DIFF
--- a/dat/gui/brushed.lua
+++ b/dat/gui/brushed.lua
@@ -799,7 +799,7 @@ function render( dt )
    end
    if value < nlights then
       for i=value+1, nlights do
-      gfx.renderTex( speed_light_off, pl_speed_x + mod_x, pl_speed_y + (i-1)*6 + mod_y )
+         gfx.renderTex( speed_light_off, pl_speed_x + mod_x, pl_speed_y + (i-1)*6 + mod_y )
       end
    end
 
@@ -849,7 +849,7 @@ function render( dt )
                gfx.renderTex( speed_light, x_speed - 5 + mod_x, y_speed - 3 + (i-1)*6 + mod_y )
             else
                local imod = i % nlights
-               gfx.renderTex( speed_light_double, pl_speed_x - 5 + mod_x, pl_speed_y - 3 + (imod-1)*6 + mod_y )
+               gfx.renderTex( speed_light_double, x_speed - 5 + mod_x, y_speed - 3 + (imod-1)*6 + mod_y )
             end
          end
          if value < nlights then


### PR DESCRIPTION
The red bar used to be added on the player speed bar instead of the target pilot's one. (for example when targeting a pilot who is jumping out)
This should fix that.