### PR TITLE
Don't allow the ship computers to access info the player doesn't have

### DIFF
--- a/src/ai.c
+++ b/src/ai.c
@@ -1784,7 +1784,7 @@ static int aiL_careful_face( lua_State *L )
       if (pilot_isDisabled(p_i) ) continue;
       if (p_i->id == cur_pilot->id) continue;
       if (p_i->id == p->id) continue; 
-      if (pilot_inRangePilot(cur_pilot, p_i) != 1) continue;
+      if (pilot_inRangePilot(cur_pilot, p_i, NULL) != 1) continue;
 
       /* If the enemy is too close, ignore it*/
       dist = vect_dist(&p_i->solid->pos, &cur_pilot->solid->pos);

--- a/src/comm.c
+++ b/src/comm.c
@@ -108,7 +108,7 @@ int comm_openPilot( unsigned int pilot )
 
    /* Make sure pilot in range. */
    if (!pilot_isFlag(p, PILOT_HAILING) &&
-         pilot_inRangePilot( player.p, comm_pilot ) <= 0) {
+         pilot_inRangePilot( player.p, comm_pilot, NULL ) <= 0) {
       player_message(_("\arTarget is out of communications range"));
       comm_pilot = NULL;
       return -1;

--- a/src/gui.c
+++ b/src/gui.c
@@ -512,7 +512,7 @@ static void gui_renderPilotTarget( double dt )
    }
 
    /* Make sure target is still in range. */
-   if (!pilot_inRangePilot( player.p, p )) {
+   if (!pilot_inRangePilot( player.p, p, NULL )) {
       pilot_setTarget( player.p, player.p->id );
       gui_setTarget();
       return;
@@ -687,7 +687,7 @@ static void gui_renderBorder( double dt )
       plt = pilot_stack[i];
 
       /* See if in sensor range. */
-      if (!pilot_inRangePilot(player.p, plt))
+      if (!pilot_inRangePilot(player.p, plt, NULL))
          continue;
 
       /* Check if out of range. */
@@ -1201,7 +1201,7 @@ void gui_renderPilot( const Pilot* p, RadarShape shape, double w, double h, doub
    glColour col;
 
    /* Make sure is in range. */
-   if (!pilot_inRangePilot( player.p, p ))
+   if (!pilot_inRangePilot( player.p, p, NULL ))
       return;
 
    /* Get position. */

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -962,7 +962,7 @@ static int pilotL_inrange( lua_State *L )
    t = luaL_validpilot(L,2);
 
    /* Check if in range. */
-   ret = pilot_inRangePilot( p, t );
+   ret = pilot_inRangePilot( p, t, NULL );
    if (ret == 1) { /* In range. */
       lua_pushboolean(L,1);
       lua_pushboolean(L,1);

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -146,7 +146,7 @@ unsigned int pilot_getNextID( const unsigned int id, int mode )
          if (((pilot_stack[p]->faction != FACTION_PLAYER) ||
                   pilot_isDisabled(pilot_stack[p])) &&
                !pilot_isFlag( pilot_stack[p], PILOT_INVISIBLE ) &&
-               pilot_inRangePilot( player.p, pilot_stack[p] ))
+               pilot_inRangePilot( player.p, pilot_stack[p], NULL ))
             return pilot_stack[p]->id;
          p++;
       }
@@ -156,7 +156,7 @@ unsigned int pilot_getNextID( const unsigned int id, int mode )
       while (p < pilot_nstack) {
          if ( ( pilot_stack[p]->faction != FACTION_PLAYER ) &&
                !pilot_isFlag( pilot_stack[p], PILOT_INVISIBLE ) &&
-               pilot_inRangePilot( player.p, pilot_stack[p] ) &&
+               pilot_inRangePilot( player.p, pilot_stack[p], NULL ) == 1 &&
                pilot_isHostile( pilot_stack[p] ) )
             return pilot_stack[p]->id;
          p++;
@@ -199,7 +199,7 @@ unsigned int pilot_getPrevID( const unsigned int id, int mode )
          if (((pilot_stack[p]->faction != FACTION_PLAYER) ||
                   (pilot_isDisabled(pilot_stack[p]))) &&
                !pilot_isFlag( pilot_stack[p], PILOT_INVISIBLE ) &&
-               pilot_inRangePilot( player.p, pilot_stack[p] ))
+               pilot_inRangePilot( player.p, pilot_stack[p], NULL ))
             return pilot_stack[p]->id;
          p--;
       }
@@ -209,7 +209,7 @@ unsigned int pilot_getPrevID( const unsigned int id, int mode )
       while (p >= 0) {
          if ( ( pilot_stack[p]->faction != FACTION_PLAYER ) &&
                !pilot_isFlag( pilot_stack[p], PILOT_INVISIBLE ) &&
-               pilot_inRangePilot( player.p, pilot_stack[p] ) &&
+               pilot_inRangePilot( player.p, pilot_stack[p], NULL ) == 1 &&
                pilot_isHostile( pilot_stack[p] ) )
             return pilot_stack[p]->id;
          p--;
@@ -240,7 +240,7 @@ int pilot_validTarget( const Pilot* p, const Pilot* target )
       return 0;
 
    /* Must be in range. */
-   if (!pilot_inRangePilot( p, target ))
+   if (!pilot_inRangePilot( p, target, NULL ))
       return 0;
 
    /* Pilot is a valid target. */
@@ -421,7 +421,7 @@ unsigned int pilot_getBoss( const Pilot* p )
    for (i=0; i<pilot_nstack; i++) {
 
       /* Must be in range. */
-      if (!pilot_inRangePilot( p, pilot_stack[i] ))
+      if (!pilot_inRangePilot( p, pilot_stack[i], NULL ))
          continue;
 
       /* Must not be self. */
@@ -550,7 +550,7 @@ double pilot_getNearestAng( const Pilot *p, unsigned int *tp, double ang, int di
          continue;
 
       /* Must be in range. */
-      if (!pilot_inRangePilot( p, pilot_stack[i] ))
+      if (!pilot_inRangePilot( p, pilot_stack[i], NULL ))
          continue;
 
       /* Only allow selection if off-screen. */
@@ -1098,7 +1098,7 @@ void pilot_message( Pilot *p, unsigned int target, const char *msg, int ignore_i
       return;
 
    /* Must be in range. */
-   if (!ignore_int && !pilot_inRangePilot( player.p, p ))
+   if (!ignore_int && !pilot_inRangePilot( player.p, p, NULL ))
       return;
 
    /* Only really affects player.p atm. */
@@ -1128,7 +1128,7 @@ void pilot_broadcast( Pilot *p, const char *msg, int ignore_int )
       return;
 
    /* Check if should ignore interference. */
-   if (!ignore_int && !pilot_inRangePilot( player.p, p ))
+   if (!ignore_int && !pilot_inRangePilot( player.p, p, NULL ))
       return;
 
    c = pilot_getFactionColourChar( p );
@@ -1189,7 +1189,7 @@ void pilot_distress( Pilot *p, Pilot *attacker, const char *msg, int ignore_int 
          continue;
 
       if (!ignore_int) {
-         if (!pilot_inRangePilot(p, pilot_stack[i])) {
+         if (!pilot_inRangePilot(p, pilot_stack[i], NULL)) {
             /*
              * If the pilots are within sensor range of each other, send the
              * distress signal, regardless of electronic warfare hide values.
@@ -1295,7 +1295,7 @@ const glColour* pilot_getColour( const Pilot* p )
 {
    const glColour *col;
 
-   if (pilot_inRangePilot(player.p, p) == -1) col = &cMapNeutral;
+   if (pilot_inRangePilot(player.p, p, NULL) == -1) col = &cMapNeutral;
    else if (pilot_isDisabled(p) || pilot_isFlag(p,PILOT_DEAD)) col = &cInert;
    else if (pilot_isFriendly(p)) col = &cFriend;
    else if (pilot_isHostile(p)) col = &cHostile;

--- a/src/pilot_ew.c
+++ b/src/pilot_ew.c
@@ -171,9 +171,10 @@ int pilot_inRange( const Pilot *p, double x, double y )
  *
  *    @param p Pilot who is trying to check to see if other is in sensor range.
  *    @param target Target of p to check to see if is in sensor range.
+ *    @param[out] dist2 Distance squared of the two pilots. Set to NULL if you're not interested.
  *    @return 1 if they are in range, 0 if they aren't and -1 if they are detected fuzzily.
  */
-int pilot_inRangePilot( const Pilot *p, const Pilot *target )
+int pilot_inRangePilot( const Pilot *p, const Pilot *target, double *dist2)
 {
    double d, sense;
 
@@ -185,6 +186,7 @@ int pilot_inRangePilot( const Pilot *p, const Pilot *target )
 
    /* Get distance. */
    d = vect_dist2( &p->solid->pos, &target->solid->pos );
+   if (dist2 != NULL) *dist2 = d;
 
    sense = sensor_curRange * p->ew_detect;
    if (d * target->ew_evasion < sense)

--- a/src/pilot_ew.h
+++ b/src/pilot_ew.h
@@ -17,7 +17,7 @@
 void pilot_updateSensorRange (void);
 double pilot_sensorRange( void );
 int pilot_inRange( const Pilot *p, double x, double y );
-int pilot_inRangePilot( const Pilot *p, const Pilot *target );
+int pilot_inRangePilot( const Pilot *p, const Pilot *target, double *dist2);
 int pilot_inRangePlanet( const Pilot *p, int target );
 int pilot_inRangeAsteroid( const Pilot *p, int ast, int fie );
 int pilot_inRangeJump( const Pilot *p, int target );

--- a/src/player.c
+++ b/src/player.c
@@ -1945,12 +1945,12 @@ void player_targetSet( unsigned int id )
 void player_targetHostile (void)
 {
    unsigned int tp;
-   int i;
    double d, td;
+   int inRange;
 
    tp = PLAYER_ID;
    d  = 0;
-   for (i=0; i<pilot_nstack; i++) {
+   for (int i=0; i<pilot_nstack; i++) {
       /* Shouldn't be disabled. */
       if (pilot_isDisabled(pilot_stack[i]))
          continue;
@@ -1961,8 +1961,8 @@ void player_targetHostile (void)
 
       /* Must be hostile. */
       if (pilot_isHostile(pilot_stack[i])) {
-         td = vect_dist2(&pilot_stack[i]->solid->pos, &player.p->solid->pos);
-         if ((tp == PLAYER_ID) || (td < d)) {
+         inRange = pilot_inRangePilot(pilot_stack[i], player.p, &td);
+         if (tp == PLAYER_ID || (inRange == 1 && td < d)) {
             d  = td;
             tp = pilot_stack[i]->id;
          }

--- a/src/player_autonav.c
+++ b/src/player_autonav.c
@@ -388,7 +388,7 @@ static void player_autonav (void)
          p = pilot_get( player.p->target );
          if (p == NULL)
             p = pilot_get( PLAYER_ID );
-         if ((p->id == PLAYER_ID) || (!pilot_inRangePilot( player.p, p ))) {
+         if ((p->id == PLAYER_ID) || (!pilot_inRangePilot( player.p, p, NULL ))) {
             /* TODO : handle the different reasons: pilot is too far, jumped, landed or died. */
             player_message( _("\ap%s has been lost."),
                               player.autonavmsg );
@@ -542,7 +542,7 @@ int player_autonavShouldResetSpeed (void)
    pstk = pilot_getAll( &n );
    for (i=0; i<n; i++) {
       if ( ( pstk[i]->id != PLAYER_ID ) && pilot_isHostile( pstk[i] )
-            && pilot_inRangePilot( player.p, pstk[i] )
+            && pilot_inRangePilot( player.p, pstk[i], NULL ) == 1
             && !pilot_isDisabled( pstk[i] ) ) {
          hostiles = 1;
          break;


### PR DESCRIPTION
Namely, 
1. AutoNav shouldn't disable until a hostile ship's identity is no longer hidden
2. Targeting hostile ships shouldn't select ships who's identity is hidden.