### PR TITLE
Renamed Boarding Androids outfits to comply with typical naming conventions.

### DIFF
--- a/dat/factions/equip/generic.lua
+++ b/dat/factions/equip/generic.lua
@@ -335,14 +335,14 @@ equip_classOutfits_utilities = {
       {
          varied = true;
          "Reactor Class II", "Medium Shield Booster", "Milspec Scrambler",
-         "Droid Repair Crew", "Boarding Androids MKI"
+         "Droid Repair Crew", "Boarding Androids MK1"
       }
    },
    ["Armoured Transport"] = {
       {
          varied = true;
          "Reactor Class II", "Medium Shield Booster", "Milspec Scrambler",
-         "Droid Repair Crew", "Boarding Androids MKI"
+         "Droid Repair Crew", "Boarding Androids MK1"
       }
    },
    ["Fighter"] = {
@@ -363,28 +363,28 @@ equip_classOutfits_utilities = {
       {
          varied = true;
          "Reactor Class II", "Medium Shield Booster", "Milspec Scrambler",
-         "Droid Repair Crew", "Boarding Androids MKI", "Hellburner"
+         "Droid Repair Crew", "Boarding Androids MK1", "Hellburner"
       }
    },
    ["Destroyer"] = {
       {
          varied = true;
          "Reactor Class II", "Medium Shield Booster", "Droid Repair Crew",
-         "Boarding Androids MKI"
+         "Boarding Androids MK1"
       }
    },
    ["Cruiser"] = {
       {
          varied = true;
          "Reactor Class III", "Large Shield Booster", "Droid Repair Crew",
-         "Boarding Androids MKII"
+         "Boarding Androids MK2"
       }
    },
    ["Carrier"] = {
       {
          varied = true;
          "Reactor Class III", "Large Shield Booster", "Droid Repair Crew",
-         "Boarding Androids MKII"
+         "Boarding Androids MK2"
       }
    },
    ["Drone"] = {

--- a/dat/factions/equip/thurion.lua
+++ b/dat/factions/equip/thurion.lua
@@ -65,7 +65,7 @@ equip_typeOutfits_utilities["Perspicacity"] = {
 equip_typeOutfits_utilities["Ingenuity"] = {
    {
       num = 1;
-      "Droid Repair Crew", "Boarding Androids MKI", "Thurion Reactor Class II",
+      "Droid Repair Crew", "Boarding Androids MK1", "Thurion Reactor Class II",
       "Medium Shield Booster"
    },
    {
@@ -84,7 +84,7 @@ equip_typeOutfits_utilities["Scintillation"] = {
 equip_typeOutfits_utilities["Virtuosity"] = {
    {
       varied = true;
-      "Droid Repair Crew", "Boarding Androids MKI", "Thurion Reactor Class II",
+      "Droid Repair Crew", "Boarding Androids MK1", "Thurion Reactor Class II",
       "Medium Shield Booster"
    },
    {
@@ -96,7 +96,7 @@ equip_typeOutfits_utilities["Virtuosity"] = {
 equip_typeOutfits_utilities["Taciturnity"] = {
    {
       varied = true;
-      "Droid Repair Crew", "Boarding Androids MKI", "Thurion Reactor Class II",
+      "Droid Repair Crew", "Boarding Androids MK1", "Thurion Reactor Class II",
       "Medium Shield Booster"
    },
    {
@@ -108,7 +108,7 @@ equip_typeOutfits_utilities["Taciturnity"] = {
 equip_typeOutfits_utilities["Apprehension"] = {
    {
       varied = true;
-      "Boarding Androids MKII", "Thurion Reactor Class II",
+      "Boarding Androids MK2", "Thurion Reactor Class II",
       "Medium Shield Booster", "Droid Repair Crew", "Sensor Array",
       "Milspec Scrambler"
    }
@@ -116,7 +116,7 @@ equip_typeOutfits_utilities["Apprehension"] = {
 equip_typeOutfits_utilities["Certitude"] = {
    {
       varied = true;
-      "Boarding Androids MKII", "Thurion Reactor Class III",
+      "Boarding Androids MK2", "Thurion Reactor Class III",
       "Large Shield Booster", "Droid Repair Crew", "Sensor Array",
       "Milspec Scrambler"
    }

--- a/dat/factions/equip/zalek.lua
+++ b/dat/factions/equip/zalek.lua
@@ -138,7 +138,7 @@ equip_typeOutfits_utilities["Demon"] = {
    },
    {
       varied = true;
-      "Droid Repair Crew", "Milspec Scrambler", "Boarding Androids MKI"
+      "Droid Repair Crew", "Milspec Scrambler", "Boarding Androids MK1"
    }
 }
 

--- a/dat/missions/soromid/comingout/srm_comingout5.lua
+++ b/dat/missions/soromid/comingout/srm_comingout5.lua
@@ -1,24 +1,24 @@
 --[[
 <?xml version='1.0' encoding='utf8'?>
 <mission name="Garbage Person">
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>2</priority>
-   <done>Visiting Family</done>
-   <chance>30</chance>
-   <location>Bar</location>
-   <faction>Soromid</faction>
-  </avail>
-  <notes>
-   <campaign>Coming Out</campaign>
-  </notes>
- </mission>
- --]]
+ <flags>
+  <unique />
+ </flags>
+ <avail>
+  <priority>2</priority>
+  <done>Visiting Family</done>
+  <chance>30</chance>
+  <location>Bar</location>
+  <faction>Soromid</faction>
+ </avail>
+ <notes>
+  <campaign>Coming Out</campaign>
+ </notes>
+</mission>
+--]]
 --[[
 
-   Garbage Person
+   Waste Collector
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -127,7 +127,7 @@ function spawnChelseaShip( param )
    chelsea:addOutfit( "Fury Missile", 80 )
    chelsea:addOutfit( "Droid Repair Crew" )
    chelsea:addOutfit( "Milspec Scrambler" )
-   chelsea:addOutfit( "Boarding Androids MKI" )
+   chelsea:addOutfit( "Boarding Androids MK1" )
    chelsea:addOutfit( "Cargo Pod", 4 )
 
    chelsea:setHealth( 100, 100 )

--- a/dat/outfits/modifiers/boarding_androids_mk1.xml
+++ b/dat/outfits/modifiers/boarding_androids_mk1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<outfit name="Boarding Androids MKI">
+<outfit name="Boarding Androids MK1">
  <general>
   <typename>Crew enhancement</typename>
   <slot>utility</slot>

--- a/dat/outfits/modifiers/boarding_androids_mk2.xml
+++ b/dat/outfits/modifiers/boarding_androids_mk2.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<outfit name="Boarding Androids MKII">
+<outfit name="Boarding Androids MK2">
  <general>
   <typename>Crew enhancement</typename>
   <slot>utility</slot>
   <size>large</size>
   <mass>3</mass>
   <price>50000</price>
-  <description>The Boarding Android Mark II improves upon the wide variety of implements sported by its predecessor, additionally including scissor-hands and a rape whistle. </description>
+  <description>The Boarding Android Mark 2 improves upon the wide variety of implements sported by its predecessor, additionally including scissor-hands and a sewing needle.</description>
   <gfx_store>cargo_pod</gfx_store>
  </general>
  <specific type="modification">

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -123,8 +123,8 @@
   <item>Cargo Pod</item>
   <item>Medium Cargo Pod</item>
   <item>Large Cargo Pod</item>
-  <item>Boarding Androids MKI</item>
-  <item>Boarding Androids MKII</item>
+  <item>Boarding Androids MK1</item>
+  <item>Boarding Androids MK2</item>
   <item>Targeting Array</item>
   <item>Asteroid Scanner</item>
   <item>Forward Shock Absorbers</item>
@@ -529,7 +529,7 @@
   <item>Cargo Pod</item>
   <item>Medium Cargo Pod</item>
   <item>Large Cargo Pod</item>
-  <item>Boarding Androids MKI</item>
+  <item>Boarding Androids MK1</item>
   <item>Star Maps</item>
   <item>Unicorp Scrambler</item>
   <item>Unicorp Jammer</item>
@@ -606,8 +606,8 @@
   <item>Cargo Pod</item>
   <item>Medium Cargo Pod</item>
   <item>Large Cargo Pod</item>
-  <item>Boarding Androids MKI</item>
-  <item>Boarding Androids MKII</item>
+  <item>Boarding Androids MK1</item>
+  <item>Boarding Androids MK2</item>
   <item>Star Maps</item>
   <item>Unicorp Scrambler</item>
   <item>Unicorp Jammer</item>
@@ -636,8 +636,8 @@
   <item>Cargo Pod</item>
   <item>Medium Cargo Pod</item>
   <item>Large Cargo Pod</item>
-  <item>Boarding Androids MKI</item>
-  <item>Boarding Androids MKII</item>
+  <item>Boarding Androids MK1</item>
+  <item>Boarding Androids MK2</item>
   <item>Targeting Array</item>
   <item>Forward Shock Absorbers</item>
   <item>Power Regulation Override</item>


### PR DESCRIPTION
This is a change that breaks compatibility with saves, so while Naev should definitely do it at some point (so that naming of outfits is consistent), I'm not sure whether it should be done now or later (perhaps after version 0.8).

🕵️