### PR TITLE
Armoured Transport -> Armored Transport

### DIFF
--- a/dat/events/tutorial/tutorial_land.lua
+++ b/dat/events/tutorial/tutorial_land.lua
@@ -40,7 +40,7 @@ end
 function ship_buy( shp )
    if not var.peek( "tutorial_time_dilation" ) then
       local class = ship.get(shp):class()
-      if class == "Freighter" or class == "Armoured Transport"
+      if class == "Freighter" or class == "Armored Transport"
             or class == "Corvette" or class == "Destroyer"
             or class == "Cruiser" or class == "Carrier" then
          tk.msg( "", time_dilation_text:format(shp) )

--- a/dat/factions/equip/generic.lua
+++ b/dat/factions/equip/generic.lua
@@ -18,7 +18,7 @@ equip_classOutfits_coreSystems = {
    ["Freighter"] = {
       "Unicorp PT-600 Core System", "Milspec Aegis 5401 Core System"
    },
-   ["Armoured Transport"] = {
+   ["Armored Transport"] = {
       "Milspec Aegis 5401 Core System", "Milspec Orion 5501 Core System"
    },
    ["Fighter"] = {
@@ -67,7 +67,7 @@ equip_classOutfits_engines = {
    ["Freighter"] = {
       "Unicorp Falcon 1200 Engine", "Melendez Buffalo XL Engine"
    },
-   ["Armoured Transport"] = {
+   ["Armored Transport"] = {
       "Melendez Buffalo XL Engine"
    },
    ["Fighter"] = {
@@ -121,7 +121,7 @@ equip_classOutfits_hulls = {
    ["Freighter"] = {
       "Unicorp D-12 Medium Plating", "S&K Medium Cargo Hull"
    },
-   ["Armoured Transport"] = {
+   ["Armored Transport"] = {
       "S&K Medium Cargo Hull"
    },
    ["Fighter"] = {
@@ -192,7 +192,7 @@ equip_classOutfits_weapons = {
          "Pulse Beam"
       }
    },
-   ["Armoured Transport"] = {
+   ["Armored Transport"] = {
       {
          num = 2, varied = true;
          "Pulse Beam", "Enygma Systems Turreted Fury Launcher",
@@ -338,7 +338,7 @@ equip_classOutfits_utilities = {
          "Droid Repair Crew", "Boarding Androids MKI"
       }
    },
-   ["Armoured Transport"] = {
+   ["Armored Transport"] = {
       {
          varied = true;
          "Reactor Class II", "Medium Shield Booster", "Milspec Scrambler",
@@ -444,7 +444,7 @@ equip_classOutfits_structurals = {
          "Cargo Pod", "Medium Fuel Pod"
       }
    },
-   ["Armoured Transport"] = {
+   ["Armored Transport"] = {
       {
          varied = true, probability = {
             ["Cargo Pod"] = 15, ["Medium Fuel Pod"] = 3

--- a/dat/landing.lua
+++ b/dat/landing.lua
@@ -191,7 +191,7 @@ end
 -- NOTE: This should be replaced by something better in time.
 function getshipmod()
    local light = {"Yacht", "Luxury Yacht", "Drone", "Fighter", "Bomber", "Scout"}
-   local medium = {"Destroyer", "Corvette", "Courier", "Armoured Transport", "Freighter"}
+   local medium = {"Destroyer", "Corvette", "Courier", "Armored Transport", "Freighter"}
    local heavy = {"Cruiser", "Carrier"}
    local ps = player.pilot():ship()
    for _, j in ipairs(light) do

--- a/dat/missions/shark/sh02_tapping.lua
+++ b/dat/missions/shark/sh02_tapping.lua
@@ -1,29 +1,29 @@
 --[[
 <?xml version='1.0' encoding='utf8'?>
 <mission name="Unfair Competition">
-  <flags>
-   <unique />
-  </flags>
-  <avail>
-   <priority>3</priority>
-   <cond>diff.isApplied("collective_dead")</cond>
-   <done>Sharkman Is Back</done>
-   <chance>3</chance>
-   <location>Bar</location>
-   <faction>Dvaered</faction>
-   <faction>Empire</faction>
-   <faction>Frontier</faction>
-   <faction>Goddard</faction>
-   <faction>Independent</faction>
-   <faction>Soromid</faction>
-   <faction>Traders Guild</faction>
-   <faction>Za'lek</faction>
-  </avail>
-  <notes>
-   <requires name="The Collective is dead and no one will miss them"/>
-   <campaign>Nexus show their teeth</campaign>
-  </notes>
- </mission>
+ <flags>
+  <unique />
+ </flags>
+ <avail>
+  <priority>3</priority>
+  <cond>diff.isApplied("collective_dead")</cond>
+  <done>Sharkman Is Back</done>
+  <chance>3</chance>
+  <location>Bar</location>
+  <faction>Dvaered</faction>
+  <faction>Empire</faction>
+  <faction>Frontier</faction>
+  <faction>Goddard</faction>
+  <faction>Independent</faction>
+  <faction>Soromid</faction>
+  <faction>Traders Guild</faction>
+  <faction>Za'lek</faction>
+ </avail>
+ <notes>
+  <requires name="The Collective is dead and no one will miss them"/>
+  <campaign>Nexus show their teeth</campaign>
+ </notes>
+</mission>
  --]]
 --[[
 
@@ -219,7 +219,7 @@ function ambush()
          hvy_intercept()
       end
 
-      elseif playerclass == "Cruiser" or playerclass == "Armoured Transport" or playerclass == "Carrier" then
+      elseif playerclass == "Cruiser" or playerclass == "Armored Transport" or playerclass == "Carrier" then
 
       if rnd.rnd() < 0.7 then
          bombers()

--- a/dat/missions/trader/trader_escort.lua
+++ b/dat/missions/trader/trader_escort.lua
@@ -1,27 +1,27 @@
 --[[
 <?xml version='1.0' encoding='utf8'?>
 <mission name="Trader Escort">
-  <avail>
-   <priority>5</priority>
-   <cond>player.numOutfit("Mercenary License") &gt; 0</cond>
-   <chance>560</chance>
-   <location>Computer</location>
-   <faction>Dvaered</faction>
-   <faction>Empire</faction>
-   <faction>Frontier</faction>
-   <faction>Goddard</faction>
-   <faction>Independent</faction>
-   <faction>Proteron</faction>
-   <faction>Sirius</faction>
-   <faction>Soromid</faction>
-   <faction>Thurion</faction>
-   <faction>Traders Guild</faction>
-   <faction>Za'lek</faction>
-  </avail>
-  <notes>
-   <tier>3</tier>
-  </notes>
- </mission>
+ <avail>
+  <priority>5</priority>
+  <cond>player.numOutfit("Mercenary License") &gt; 0</cond>
+  <chance>560</chance>
+  <location>Computer</location>
+  <faction>Dvaered</faction>
+  <faction>Empire</faction>
+  <faction>Frontier</faction>
+  <faction>Goddard</faction>
+  <faction>Independent</faction>
+  <faction>Proteron</faction>
+  <faction>Sirius</faction>
+  <faction>Soromid</faction>
+  <faction>Thurion</faction>
+  <faction>Traders Guild</faction>
+  <faction>Za'lek</faction>
+ </avail>
+ <notes>
+  <tier>3</tier>
+ </notes>
+</mission>
  --]]
 --Escort a convoy of traders to a destination--
 
@@ -334,7 +334,7 @@ function spawnConvoy ()
             p:addOutfit( "Unicorp PT-200 Core System" )
             p:addOutfit( "Melendez Ox XL Engine" )
             p:addOutfit( "S&K Small Cargo Hull" )
-         elseif class == "Freighter" or class == "Armoured Transport"
+         elseif class == "Freighter" or class == "Armored Transport"
                or class == "Corvette" or class == "Destroyer" then
             p:addOutfit( "Unicorp PT-600 Core System" )
             p:addOutfit( "Melendez Buffalo XL Engine" )

--- a/dat/ships/pirate_rhino.xml
+++ b/dat/ships/pirate_rhino.xml
@@ -5,7 +5,7 @@
  <rarity>2</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
- <class>Armoured Transport</class>
+ <class>Armored Transport</class>
  <price>1500000</price>
  <time_mod>2</time_mod>
  <fabricator>Skull and Bones</fabricator>

--- a/dat/ships/rhino.xml
+++ b/dat/ships/rhino.xml
@@ -4,7 +4,7 @@
  <GFX sx="10" sy="10">rhino</GFX>
  <GUI>brushed</GUI>
  <sound>engine</sound>
- <class>Armoured Transport</class>
+ <class>Armored Transport</class>
  <price>1100000</price>
  <time_mod>2</time_mod>
  <fabricator>Melendez Corp.</fabricator>

--- a/dat/ships/thurion_taciturnity.xml
+++ b/dat/ships/thurion_taciturnity.xml
@@ -5,7 +5,7 @@
  <rarity>3</rarity>
  <GUI>brushed</GUI>
  <sound>engine</sound>
- <class>Armoured Transport</class>
+ <class>Armored Transport</class>
  <price>1600000</price>
  <time_mod>2</time_mod>
  <fabricator>Thurion shipyards</fabricator>


### PR DESCRIPTION
This PR changes the "Armoured Transport" class to "Armored Transport" and converts all references in the dat/ folder thusly. This could potentially break saves, though I'm not sure about that.