### PR TITLE
Jump point convenience fields

### DIFF
--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -484,7 +484,7 @@ static int pilotL_addFleetFrom( lua_State *L, int from_ship )
       ss = system_getIndex( lua_tosystem(L,3) );
       for (i=0; i<cur_system->njumps; i++) {
          if ((cur_system->jumps[i].target == ss)
-               && !jp_isFlag( jump_getTarget( cur_system, cur_system->jumps[i].target ), JP_EXITONLY )) {
+               && !jp_isFlag( cur_system->jumps[i].returnJump, JP_EXITONLY )) {
             jump = i;
             break;
          }

--- a/src/nlua_system.c
+++ b/src/nlua_system.c
@@ -565,8 +565,7 @@ static int systemL_jumps( lua_State *L )
    lua_newtable(L);
    for (i=0; i<s->njumps; i++) {
       /* Skip exit-only jumps if requested. */
-      if ((exitonly) && (jp_isFlag( jump_getTarget( s->jumps[i].target, s ),
-            JP_EXITONLY)))
+      if ((exitonly) && (jp_isFlag( &s->jumps[i],  JP_EXITONLY)))
             continue;
 
       lj.srcid  = s->id;

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -2882,7 +2882,7 @@ void pilot_choosePoint( Vector2d *vp, int *planet, int *jump, int lf, int ignore
           * (excepted if the pilot is guerilla) and have faction
           * presence matching the pilot's on the remote side.
           */
-         target = jump_getTarget( cur_system, cur_system->jumps[i].target );
+         target = cur_system->jumps[i].returnJump;
 
          limit = 0.;
          if (guerilla) {/* Test enemy presence on the other side. */

--- a/src/space.c
+++ b/src/space.c
@@ -699,7 +699,7 @@ int space_sysReachable( StarSystem *sys )
 
    /* check to see if it is adjacent to known */
    for (i=0; i<sys->njumps; i++) {
-      jp = jump_getTarget( sys, sys->jumps[i].target );
+      jp = sys->jumps[i].returnJump;
       if (jp && jp_isKnown( jp ))
          return 1;
    }

--- a/src/space.c
+++ b/src/space.c
@@ -2583,8 +2583,10 @@ void system_reconstructJumps (StarSystem *sys)
    double a;
 
    for (j=0; j<sys->njumps; j++) {
-      jp          = &sys->jumps[j];
-      jp->target  = system_getIndex( jp->targetid );
+      jp             = &sys->jumps[j];
+      jp->from       = sys;
+      jp->target     = system_getIndex( jp->targetid );
+      jp->returnJump = jump_getTarget( sys, jp->target );
 
       /* Get heading. */
       dx = jp->target->pos.x - sys->pos.x;
@@ -2932,6 +2934,7 @@ static int system_parseJumpPoint( const xmlNodePtr node, StarSystem *sys )
    memset( j, 0, sizeof(JumpPoint) );
 
    /* Set some stuff. */
+   j->from = sys;
    j->target = target;
    free(buf);
    j->targetid = j->target->id;

--- a/src/space.h
+++ b/src/space.h
@@ -172,9 +172,12 @@ typedef struct SystemPresence_ {
 /**
  * @brief Represents a jump lane.
  */
-typedef struct JumpPoint_ {
-   StarSystem *target; /**< Target star system to jump to. */
+typedef struct JumpPoint_ JumpPoint;
+struct JumpPoint_ {
+   StarSystem *from; /**< System containing this jump point. */
    int targetid; /**< ID of the target star system. */
+   StarSystem *target; /**< Target star system to jump to. */
+   JumpPoint *returnJump; /**< How to get back. Can be NULL */
    Vector2d pos; /**< Position in the system. */
    double radius; /**< Radius of jump range. */
    unsigned int flags; /**< Flags related to the jump point's status. */
@@ -184,7 +187,7 @@ typedef struct JumpPoint_ {
    double sina; /**< Sinus of the angle. */
    int sx; /**< X sprite to use. */
    int sy; /**< Y sprite to use. */
-} JumpPoint;
+};
 extern glTexture *jumppoint_gfx; /**< Jump point graphics. */
 
 


### PR DESCRIPTION
Add some convenience fields to `JumpPoint`.

`JumpPoint.returnJump`
Adding a pointer to the return jump allows us to avoid looping over jump points in a number of places. The looping still needs to happen, but we only need to do in once after our memory allocations are finished.

`JumpPoint.from`
The reference to the containing system is not yet used, but will be in an upcoming PR.The idea is that you'll be able to perform an operation such as an adjacency search, and get access to the relevant `JumpPoint` and `StarSystem` in one struct. This will be a bigger deal once hypergates are added, which will introduce adjacent systems that aren't directly reachable through `system->jumps[i].target`.