### PR TITLE
Add VSCode configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ utils/starmap/*.svg
 utils/starmap/*.png
 utils/starmap/*.jpg
 utils/starmap/*.log
+/compile_commands.json

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,14 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "defines": [],
+            "cStandard": "gnu99",
+            "includePath": [
+                "${workspaceFolder}/src"
+            ],
+            "compileCommands": "${workspaceFolder}/compile_commands.json"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Naev",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/naev",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "Make"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json",
+    "C_Cpp.default.cStandard": "gnu99"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "Make",
+            "command": "bear --append make",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "dependsOn": "Configure",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "shell",
+            "label": "AutoGen",
+            "command": "[ -f configure ] && echo 'Already generated' || autogen.sh",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "type": "shell",
+            "label": "Configure",
+            "command": "[ -f Makefile ] && echo 'Already configured' || ./configure --enable-debug",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [],
+            "group": "build",
+            "dependsOn": "AutoGen"
+        },
+        {
+            "type": "shell",
+            "label": "AutoGen (force)",
+            "command": "autogen.sh",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "type": "shell",
+            "label": "Configure (force)",
+            "command": "./configure --enable-debug",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [],
+            "group": "build",
+            "dependsOn": "AutoGen"
+        }
+
+    ],
+    "version": "2.0.0"
+}


### PR DESCRIPTION
Includes
 - Build tasks
 - Launch with GDB
 - Auto complete with the C/C++ extension

Unfortunately, the only way I can get VSCode to understand the includes set up by `configure` is by running `make` through `bear`. `bear` captures the commands sent to `gcc`/`clang`/etc and creates a `compile_commands.json` database that can be understood by VSCode and other Clang tooling. Hopefully anyone wanting to develop in VSCode is okay with installing that.

References
- https://clang.llvm.org/docs/JSONCompilationDatabase.html
- https://github.com/rizsotto/Bear