### PR TITLE
zigzag AI

### DIFF
--- a/dat/ai/include/atk_drone.lua
+++ b/dat/ai/include/atk_drone.lua
@@ -55,6 +55,11 @@ function _atk_drone_ranged( target, dist )
    -- Check if in range
    if dist < ai.getweaprange( 4 ) and dir < 30 then
       ai.weapset( 4 )
+   else
+      -- First test if we should zz
+      if _atk_decide_zz() then
+         ai.pushsubtask("_atk_zigzag")
+      end
    end
 
    -- Always launch fighters
@@ -105,6 +110,11 @@ function _atk_d_flyby( target, dist )
    local range = ai.getweaprange(3)
    local dir = 0
    ai.weapset( 3 ) -- Forward/turrets
+
+   -- First test if we should zz
+   if _atk_decide_zz() then
+      ai.pushsubtask("_atk_zigzag")
+   end
 
    -- Far away, must approach
    if dist > (3 * range) then
@@ -164,6 +174,11 @@ function _atk_d_space_sup( target, dist )
    local range = ai.getweaprange(3)
    local dir   = 0
    ai.weapset( 3 ) -- Forward/turrets
+
+   -- First test if we should zz
+   if _atk_decide_zz() then
+      ai.pushsubtask("_atk_zigzag")
+   end
 
    --if we're far away from the target, then turn and approach
    if dist > (1.1*range) then

--- a/dat/ai/include/atk_fighter.lua
+++ b/dat/ai/include/atk_fighter.lua
@@ -84,6 +84,11 @@ function _atk_f_flyby( target, dist )
    local dir = 0
    ai.weapset( 3 ) -- Forward/turrets
 
+   -- First test if we should zz
+   if _atk_decide_zz() then
+      ai.pushsubtask("_atk_zigzag")
+   end
+
    -- Far away, must approach
    if dist > (3 * range) then
       dir = ai.idir(target)
@@ -140,6 +145,11 @@ function _atk_f_space_sup( target, dist )
    local range = ai.getweaprange(3)
    local dir   = 0
    ai.weapset( 3 ) -- Forward/turrets
+
+   -- First test if we should zz
+   if _atk_decide_zz() then
+      ai.pushsubtask("_atk_zigzag")
+   end
 
    --if we're far away from the target, then turn and approach 
    if dist > (range) then

--- a/dat/ai/include/atk_generic.lua
+++ b/dat/ai/include/atk_generic.lua
@@ -115,6 +115,11 @@ function _atk_g_ranged( target, dist )
       -- Check if in range to shoot missiles
       if dist < ai.getweaprange( 4 ) and dir < 30 then
          ai.weapset( 4 )
+      else
+         -- Test if we should zz
+         if ai.pilot():stats().mass < 400 and _atk_decide_zz() then
+            ai.pushsubtask("_atk_zigzag")
+         end
       end
 
       -- Approach for melee

--- a/dat/ai/include/atk_util.lua
+++ b/dat/ai/include/atk_util.lua
@@ -30,6 +30,61 @@ end
 
 
 --[[
+-- Decides if zigzag is a good option
+--]]
+function _atk_decide_zz()
+   -- The situation is the following: we're out of range, facing the target,
+   -- going towards the target, and someone is shooting on us.
+
+   local target = ai.target()
+   local pilot  = ai.pilot()
+   local range  = ai.getweaprange(3)
+   local dir = ai.idir(target)
+   local dist  = ai.dist( target )
+
+   local m, d1 = vec2.polar( pilot:vel() )
+   local m, d2 = vec2.polar( target:pos() - pilot:pos() )
+   local d = d1-d2
+
+--   print(dist)
+--   print(1.1*range)
+--   print(d)
+--   print(dir)
+--   print( ( (dist > (1.1*range)) and (ai.hasprojectile())
+--           and (dir < 10) and (dir > -10) and (d < 10) and (d > -10) ) )
+
+   return ( (dist > (1.1*range)) and (ai.hasprojectile())
+           and (dir < 10) and (dir > -10) and (d < 10) and (d > -10) )
+end
+
+
+--[[
+-- Zig zags towards the target
+--]]
+function _atk_zigzag()
+   local target = ai.target()
+   local range  = ai.getweaprange(3)
+
+   -- Is there something to dodge?
+   if (not target:exists()) or (not ai.hasprojectile()) then
+      ai.poptask()
+      return
+   end
+
+   local dist  = ai.dist( target )
+
+   -- Are we ready to shoot?
+   if dist < (1.1*range) then
+      ai.poptask()
+      return
+   end
+
+   local dir = ai.dir(ai.target())
+   __zigzag(dir, 30)
+end
+
+
+--[[
 -- Common control stuff
 --]]
 function _atk_com_think ()

--- a/dat/ai/include/atk_util.lua
+++ b/dat/ai/include/atk_util.lua
@@ -46,13 +46,6 @@ function _atk_decide_zz()
    local m, d2 = vec2.polar( target:pos() - pilot:pos() )
    local d = d1-d2
 
---   print(dist)
---   print(1.1*range)
---   print(d)
---   print(dir)
---   print( ( (dist > (1.1*range)) and (ai.hasprojectile())
---           and (dir < 10) and (dir > -10) and (d < 10) and (d > -10) ) )
-
    return ( (dist > (1.1*range)) and (ai.hasprojectile())
            and (dir < 10) and (dir > -10) and (d < 10) and (d > -10) )
 end

--- a/dat/ai/include/basic.lua
+++ b/dat/ai/include/basic.lua
@@ -49,6 +49,34 @@ end
 
 
 --[[
+-- Move in zigzag around a direction
+--]]
+function __zigzag ( dir, angle )
+   if mem.pm == nil then
+      mem.pm = 1
+   end
+
+   if (mem.pm*dir < angle-20) or (mem.pm*dir > angle+25) then
+      -- Orientation is totally wrong: reset timer
+      ai.settimer(0, 2000)
+   end
+
+   if (mem.pm*dir < angle) then
+      ai.turn(-mem.pm)
+   else
+      ai.turn(mem.pm)
+      if (mem.pm*dir < angle+5) then -- Right orientation, wait for max vel
+         --if ai.ismaxvel() then -- TODO : doesn't work well
+         if ai.timeup(0) then
+            mem.pm = -mem.pm
+         end
+      end
+   end
+   ai.accel()
+end
+
+
+--[[
 -- Goes to a target position without braking
 --]]
 function __goto_nobrake ()
@@ -414,6 +442,7 @@ function runaway_nojump ()
 end
 function __run_target ()
    local target = ai.target()
+   local pilot  = ai.pilot()
 
    -- Target must exist
    if not target:exists() then
@@ -424,11 +453,20 @@ function __run_target ()
    -- Good to set the target for distress calls
    ai.settarget( target )
 
-   local dir   = ai.face(target, true)
-   ai.accel()
+   -- See whether we have a chance to outrun the attacker
+   local relspe = pilot:stats().speed_max/target:stats().speed_max
+   if pilot:stats().mass <= 400 and relspe <= 1.01 and ai.hasprojectile() and (not ai.hasafterburner()) then
+      -- Pilot is agile, but too slow to outrun the enemy: dodge
+      local dir = ai.dir(target) + 180      -- Reverse (run away)
+      if dir > 180 then dir = dir - 360 end -- Because of periodicity
+      __zigzag(dir, 70)
+   else
+      ai.face(target, true)
+      ai.accel()
+   end
 
    -- Afterburner handling.         
-   if ai.hasafterburner() and ai.pilot():energy() > 10 then
+   if ai.hasafterburner() and pilot:energy() > 10 then
       ai.weapset( 8, true )
    end
 
@@ -459,25 +497,44 @@ function __run_hyp ()
    local jdir
    local bdist    = ai.minbrakedist()
    local jdist    = ai.dist(jump)
+   local pilot    = ai.pilot()
 
-   if jdist > 3*bdist and ai.pilot():stats().mass < 600 then
-      jdir = ai.careful_face(jump)
-   else --Heavy ships should rush to jump point
-      jdir = ai.face(jump)
+   if jdist > bdist then
+
+      local dozigzag = false
+      if ai.target():exists() then
+         local relspe = pilot:stats().speed_max/ai.target():stats().speed_max
+         if pilot:stats().mass <= 400 and relspe <= 1.01 and ai.hasprojectile() and
+            (not ai.hasafterburner()) and jdist > 3*bdist then
+            dozigzag = true
+         end
+      end
+
+      if dozigzag then
+         -- Pilot is agile, but too slow to outrun the enemy: dodge
+         local dir = ai.dir(jump)
+         __zigzag(dir, 70)
+      else
+         if jdist > 3*bdist and pilot:stats().mass < 600 then
+            jdir = ai.careful_face(jump)
+         else --Heavy ships should rush to jump point
+            jdir = ai.face(jump)
+         end
+         if jdir < 10 then       
+            ai.accel()
+         end
+      end
+   else
+      ai.pushsubtask( "__run_hypbrake" )
    end
-   
+
    --Afterburner: activate while far away from jump
-   if ai.hasafterburner() and ai.pilot():energy() > 10 then
+   if ai.hasafterburner() and pilot:energy() > 10 then
       if jdist > 3 * bdist then
          ai.weapset( 8, true )
       else
          ai.weapset( 8, false )
       end
-   end
-   if jdist > bdist and jdir < 10 then       
-      ai.accel()
-   elseif jdist < bdist then
-      ai.pushsubtask( "__run_hypbrake" )
    end
 end
 function __run_hypbrake ()
@@ -498,31 +555,47 @@ function __run_landgo ()
    local target   = mem.land
    local dist     = ai.dist( target )
    local bdist    = ai.minbrakedist()
+   local pilot    = ai.pilot()
 
-   -- 2 methods depending on mem.careful
-   local dir
-   if not mem.careful or dist < 3*bdist then
-      dir = ai.face( target )
+   if dist < bdist then -- Need to start braking
+      ai.pushsubtask( "__landstop" )
    else
-      dir = ai.careful_face( target )
+
+      local dozigzag = false
+      if ai.target():exists() then
+         local relspe = pilot:stats().speed_max/ai.target():stats().speed_max
+         if pilot:stats().mass <= 400 and relspe <= 1.01 and ai.hasprojectile() and
+            (not ai.hasafterburner()) and dist > 3*bdist then
+            dozigzag = true
+         end
+      end
+
+      if dozigzag then
+         -- Pilot is agile, but too slow to outrun the enemy: dodge
+         local dir = ai.dir(target)
+         __zigzag(dir, 70)
+      else
+
+         -- 2 methods depending on mem.careful
+         local dir
+         if not mem.careful or dist < 3*bdist then
+            dir = ai.face( target )
+         else
+            dir = ai.careful_face( target )
+         end
+         if dir < 10 then
+            ai.accel()
+         end
+      end
    end
 
    --Afterburner
-   if ai.hasafterburner() and ai.pilot():energy() > 10 then
+   if ai.hasafterburner() and pilot:energy() > 10 then
       if dist > 3 * bdist then
          ai.weapset( 8, true )
       else
          ai.weapset( 8, false )
       end
-   end
-
-   -- Need to get closer
-   if dir < 10 and dist > bdist then
-      ai.accel()
-
-   -- Need to start braking
-   elseif dist < bdist then
-      ai.pushsubtask( "__landstop" )
    end
 
 end

--- a/src/ai.c
+++ b/src/ai.c
@@ -175,6 +175,7 @@ static int aiL_isstopped( lua_State *L ); /* boolean isstopped() */
 static int aiL_isenemy( lua_State *L ); /* boolean isenemy( number ) */
 static int aiL_isally( lua_State *L ); /* boolean isally( number ) */
 static int aiL_haslockon( lua_State *L ); /* boolean haslockon() */
+static int aiL_hasprojectile( lua_State *L ); /* boolean hasprojectile() */
 
 /* movement */
 static int aiL_accel( lua_State *L ); /* accel(number); number <= 1. */
@@ -261,6 +262,7 @@ static const luaL_Reg aiL_methods[] = {
    { "isenemy", aiL_isenemy },
    { "isally", aiL_isally },
    { "haslockon", aiL_haslockon },
+   { "hasprojectile", aiL_hasprojectile },
    /* get */
    { "pilot", aiL_pilot },
    { "rndpilot", aiL_getrndpilot },
@@ -1510,7 +1512,9 @@ static int aiL_getstanding( lua_State *L )
  */
 static int aiL_ismaxvel( lua_State *L )
 {
-   lua_pushboolean(L,(VMOD(cur_pilot->solid->vel) > cur_pilot->speed-MIN_VEL_ERR));
+   //lua_pushboolean(L,(VMOD(cur_pilot->solid->vel) > (cur_pilot->speed-MIN_VEL_ERR)));
+   lua_pushboolean(L,(VMOD(cur_pilot->solid->vel) >
+                   (solid_maxspeed(cur_pilot->solid, cur_pilot->speed, cur_pilot->thrust)-MIN_VEL_ERR)));
    return 1;
 }
 
@@ -1590,6 +1594,20 @@ static int aiL_isally( lua_State *L )
 static int aiL_haslockon( lua_State *L )
 {
    lua_pushboolean(L, cur_pilot->lockons > 0);
+   return 1;
+}
+
+
+/**
+ * @brief Checks to see if pilot has a projectile after him.
+ *
+ *    @luatreturn boolean Whether the pilot has a projectile after him.
+ *    @luafunc hasprojectile()
+ */
+
+static int aiL_hasprojectile( lua_State *L )
+{
+   lua_pushboolean(L, cur_pilot->projectiles > 0);
    return 1;
 }
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -3078,6 +3078,7 @@ void pilots_clean (int persist)
          pilot_stack[i] = p;
          /* Misc clean up. */
          pilot_stack[persist_count]->lockons = 0; /* Clear lockons. */
+         pilot_stack[persist_count]->projectiles = 0; /* Clear projectiles. */
          pilot_clearTimers( pilot_stack[persist_count] ); /* Reset timers. */
          persist_count++;
       }

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -365,6 +365,7 @@ typedef struct Pilot_ {
    double dtimer_accum; /**< Accumulated disable timer. */
    int hail_pos;     /**< Hail animation position. */
    int lockons;      /**< Stores how many seeking weapons are targeting pilot */
+   int projectiles;      /**< Stores how many weapons are after the pilot */
    int *mounted;     /**< Number of mounted outfits on the mount. */
    double player_damage; /**< Accumulates damage done by player for hostileness.
                               In per one of max shield + armour. */

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1532,6 +1532,11 @@ static Weapon* weapon_create( const Outfit* outfit, double T,
    w->status   = WEAPON_STATUS_OK;
    w->strength = 1.;
 
+   /* Inform the target. */
+   pilot_target = pilot_get(target);
+   if (pilot_target != NULL)
+      pilot_target->projectiles++;
+
    switch (outfit->type) {
 
       /* Bolts treated together */
@@ -1846,12 +1851,14 @@ static void weapon_free( Weapon* w )
 {
    Pilot *pilot_target;
 
+   pilot_target = pilot_get( w->target );
+
    /* Decrement target lockons if needed */
-   if (outfit_isSeeker(w->outfit)) {
-      pilot_target = pilot_get( w->target );
-      if (pilot_target != NULL)
+   if (pilot_target != NULL) {
+      pilot_target->projectiles--;
+      if (outfit_isSeeker(w->outfit))
          pilot_target->lockons--;
-   }
+      }
 
    /* Stop playing sound if beam weapon. */
    if (outfit_isBeam(w->outfit)) {


### PR DESCRIPTION
With this commit, the AI is aware of the fact that there are ammos aimed at its ship. This is not supra-clean as theoretically it should be possible to shoot at someone while being out of sensor range but I supposed it's unlikely enough.

When being shot at, light ships use zigzag trajectories in two occasions:
* While running away
* While approaching for dogfight (and still being out of range for their own weapons)

This suppresses the main AI exploit I was using, namely running away from target, and then turning around and shooting with long-range weapons while the enemy was kindly flying straight towards me (and towards the ammos on the way)

/!\ Warning: In some occasions, the AI ships possibly become noticeably harder to kill (or better said less trivial to kill) with this change. I'm not sure if it doesn't unbalance some missions /!\