### PR TITLE
Fix ndata path with releases.

### DIFF
--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -102,15 +102,15 @@ jobs:
           VERSION="${BASEVER}.0-beta.${BETAVER}"
         fi 
 
-        mkdir -p dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64
+        mkdir -p dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64/ndata
         mkdir -p dist/release/tar
 
         mv src/naev dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64/naev-$VERSION-$BUILD_DATE-linux-x86-64
         chmod +x dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64/naev-$VERSION-$BUILD_DATE-linux-x86-64
 
-        cp -r dat/ dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64
-        cp AUTHORS dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64
-        cp VERSION dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64
+        cp -r dat/ dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64/ndata
+        cp AUTHORS dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64/ndata
+        cp VERSION dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64/ndata
 
         cd dist/release
         tar -czvf linux-x86-64.tar.gz naev-$VERSION-$BUILD_DATE-linux-x86-64
@@ -206,9 +206,9 @@ jobs:
         mkdir -p dist/release
 
         ./extras/macos/bundle.sh
-        cp AUTHORS Naev.app/Contents/Resources/
-        cp VERSION Naev.app/Contents/Resources/
-        cp -r dat/ Naev.app/Contents/Resources/dat/
+        cp AUTHORS Naev.app/Contents/Resources/ndata/
+        cp VERSION Naev.app/Contents/Resources/ndata/
+        cp -r dat/ Naev.app/Contents/Resources/ndata/
         zip -r dist/release/naev-macos.zip Naev.app/*
 
     - name: Upload Artifact

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -100,15 +100,15 @@ jobs:
           VERSION="${BASEVER}.0-beta.${BETAVER}"
         fi 
 
-        mkdir -p dist/release/naev-$VERSION-linux-x86-64
+        mkdir -p dist/release/naev-$VERSION-linux-x86-64/ndata
         mkdir -p dist/release/tar
 
         mv src/naev dist/release/naev-$VERSION-linux-x86-64/naev-$VERSION-linux-x86-64
         chmod +x dist/release/naev-$VERSION-linux-x86-64/naev-$VERSION-linux-x86-64
 
-        cp -r dat/ dist/release/naev-$VERSION-linux-x86-64
-        cp AUTHORS dist/release/naev-$VERSION-linux-x86-64
-        cp VERSION dist/release/naev-$VERSION-linux-x86-64
+        cp -r dat/ dist/release/naev-$VERSION-linux-x86-64/ndata
+        cp AUTHORS dist/release/naev-$VERSION-linux-x86-64/ndata
+        cp VERSION dist/release/naev-$VERSION-linux-x86-64/ndata
 
         cd dist/release
         tar -czvf linux-x86-64.tar.gz naev-$VERSION-linux-x86-64
@@ -204,9 +204,9 @@ jobs:
         mkdir -p dist/release
 
         ./extras/macos/bundle.sh
-        cp AUTHORS Naev.app/Contents/Resources/
-        cp VERSION Naev.app/Contents/Resources/
-        cp -r dat/ Naev.app/Contents/Resources/dat/
+        cp AUTHORS Naev.app/Contents/Resources/ndata/
+        cp VERSION Naev.app/Contents/Resources/ndata/
+        cp -r dat/ Naev.app/Contents/Resources/ndata/
         zip -r dist/release/naev-macos.zip Naev.app/*
 
     - name: Upload Artifact

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -100,15 +100,15 @@ jobs:
           VERSION="${BASEVER}.0-beta.${BETAVER}"
         fi 
 
-        mkdir -p dist/release/naev-$VERSION-linux-x86-64
+        mkdir -p dist/release/naev-$VERSION-linux-x86-64/ndata
         mkdir -p dist/release/tar
 
         mv src/naev dist/release/naev-$VERSION-linux-x86-64/naev-$VERSION-linux-x86-64
         chmod +x dist/release/naev-$VERSION-linux-x86-64/naev-$VERSION-linux-x86-64
 
-        cp -r dat/ dist/release/naev-$VERSION-linux-x86-64
-        cp AUTHORS dist/release/naev-$VERSION-linux-x86-64
-        cp VERSION dist/release/naev-$VERSION-linux-x86-64
+        cp -r dat/ dist/release/naev-$VERSION-linux-x86-64/ndata
+        cp AUTHORS dist/release/naev-$VERSION-linux-x86-64/ndata
+        cp VERSION dist/release/naev-$VERSION-linux-x86-64/ndata
 
         cd dist/release
         tar -czvf linux-x86-64.tar.gz naev-$VERSION-linux-x86-64
@@ -204,9 +204,9 @@ jobs:
         mkdir -p dist/release
 
         ./extras/macos/bundle.sh
-        cp AUTHORS Naev.app/Contents/Resources/
-        cp VERSION Naev.app/Contents/Resources/
-        cp -r dat/ Naev.app/Contents/Resources/dat/
+        cp AUTHORS Naev.app/Contents/Resources/ndata/
+        cp VERSION Naev.app/Contents/Resources/ndata/
+        cp -r dat/ Naev.app/Contents/Resources/ndata/
         zip -r dist/release/naev-macos.zip Naev.app/*
 
     - name: Upload Artifact

--- a/extras/macos/bundle.sh
+++ b/extras/macos/bundle.sh
@@ -18,6 +18,8 @@ rm -fr Naev.app
 
 # Build basic structure.
 mkdir -p Naev.app/Contents/{MacOS,Resources,Frameworks}/
+mkdir -p Naev.app/Contents/Resources/ndata
+
 cp extras/macos/Info.plist Naev.app/Contents/
 cp extras/macos/naev.icns Naev.app/Contents/Resources/
 cp src/naev Naev.app/Contents/MacOS/

--- a/extras/steam/scripts/depot_build_598532.vdf
+++ b/extras/steam/scripts/depot_build_598532.vdf
@@ -10,7 +10,7 @@
     "LocalPath" "./ndata/*"
     
     // This is a path relative to the install folder of your game
-    "DepotPath" "."
+    "DepotPath" "./ndata"
     
     // If LocalPath contains wildcards, setting this means that all
     // matching files within subdirectories of LocalPath will also

--- a/extras/windows/packageWindows.sh
+++ b/extras/windows/packageWindows.sh
@@ -70,13 +70,13 @@ pip3 install mingw-ldd
 # Move compiled binary to staging folder.
 
 echo "creating staging area"
-mkdir -p extras/windows/installer/bin
+mkdir -p extras/windows/installer/bin/ndata
 
 # Move data to staging folder
 echo "moving data to staging area"
-cp -r dat/ extras/windows/installer/bin
-cp AUTHORS extras/windows/installer/bin
-cp VERSION extras/windows/installer/bin
+cp -r dat/ extras/windows/installer/bin/ndata
+cp AUTHORS extras/windows/installer/bin/ndata
+cp VERSION extras/windows/installer/bin/ndata
 
 # Collect DLLs
  


### PR DESCRIPTION
Should fix the steam launch issue by changing the mountpoint of the ndata depot (598532) from the game install root to ./ndata
Additionally will fix the windows installer, the macOS bundle (doesn't work quite right either way) and the Linux tar.gz