### PR TITLE
Always log to stdout

### DIFF
--- a/src/naev.c
+++ b/src/naev.c
@@ -183,15 +183,6 @@ int main( int argc, char** argv )
 
    if (!log_isTerminal())
       log_copy(1);
-#if HAS_WIN32
-   else {
-      /* Windows has no line-buffering, so use unbuffered output
-       * when running from a terminal.
-       */
-      setvbuf( stdout, NULL, _IONBF, 0 );
-      setvbuf( stderr, NULL, _IONBF, 0 );
-   }
-#endif /* HAS_WIN32 */
 
 #if defined ENABLE_NLS && ENABLE_NLS
    /* Set up locales. */


### PR DESCRIPTION
Keep logging to stdout/stderr even when logging to a file or not in a console. This makes it a lot easier to grab Naev's output inside a test.

Also, this removes the windows specific unbuffered console output by manually forcing line buffering.