### PR TITLE
fix shipstats modification procedure for integers

### DIFF
--- a/src/shipstats.c
+++ b/src/shipstats.c
@@ -304,7 +304,8 @@ int ss_statsModSingle( ShipStats *stats, const ShipStatList* list, const ShipSta
          break;
 
       case SS_DATA_TYPE_INTEGER:
-         memcpy(&i, &ptr[ sl->offset ], sizeof(int*));
+         fieldptr = &ptr[ sl->offset ];
+         memcpy(&i, &fieldptr, sizeof(int*));
          *i   += list->d.i;
          if (amount != NULL) {
             if ((sl->inverted && (list->d.i < 0)) ||


### PR DESCRIPTION
Before that, i was erroneously pointing into a forbidden region of
memory and writing to it caused a segmetation fault.
This went undetected because of a relative lack of integer stats
tickling this branch of logic.

I discovered the problem when playing with Hidden Jump Detector.
(it segfaulted on activation, and now it works)

Also, the problem is obvious if one compares to the same code for
doubles.