### PR TITLE
Fix data files not installing to $DESTDIR on "make install"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,7 +101,7 @@ utils:
 endif # HAVE_UTILS
 
 install-data-local:
-	(cd $(top_srcdir)/dat; find . -type f -exec install -Dm 644 "{}" "$(pkgdatadir)/dat/{}" \;)
+	(cd $(top_srcdir)/dat; find . -type f -exec install -Dm 644 "{}" "$(DESTDIR)$(pkgdatadir)/dat/{}" \;)
 
 uninstall-hook:
 	echo " rm -rf '$(DESTDIR)$(pkgdatadir)'"; \


### PR DESCRIPTION
### Description

A small fix to the make process, so that when using a command such as `make install DESTDIR=/tmp/package`, all files obey DESTDIR as expected.

Before this commit, the dat/ folder destined for /usr/share/naev would attempt to install there even when a DESTDIR was given to "make install", often causing several "permission denied" errors. Other files, oddly enough, would obey DESTDIR as expected.

### Background

I found this while investigating a comment in the aur `naev-git` build [here](https://aur.archlinux.org/packages/naev-git/). The user was able to make the package successfully but the game wouldn't launch because of a missing ndata folder. I built the package myself and found the same problem - when looking in `/usr/share/naev` I did not see the expected `dat` folder, but I did see lots of errors in the package step:

```
==> Starting package()...
Making install in lib
Making install in csparse
Making install in src
Making install in tk
Making install in widget
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/bin'
  /usr/bin/install -c naev '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/bin'
Making install in utils
Making install in mkspr
Making install in po
installing de.gmo as /home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/locale/de/LC_MESSAGES/naev.mo
installing ja.gmo as /home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/locale/ja/LC_MESSAGES/naev.mo
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/applications'
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/metainfo'
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/icons/hicolor/256x256/apps'
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/doc/naev'
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/naev'
 /usr/bin/mkdir -p '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/man/man6'
 /usr/bin/install -c -m 644 org.naev.Naev.desktop '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/applications'
 /usr/bin/install -c -m 644 README TODO LICENSE '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/doc/naev'
install: cannot remove '/usr/share/naev/dat/./AUTHORS' /usr/bin/install -c -m 644 extras/logos/naev.png '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/icons/hicolor/256x256/apps'
: Permission denied
 /usr/bin/install -c -m 644 naev-confupdate.sh '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/naev'
install: cannot remove '/usr/share/naev/dat/./start.xml': Permission denied
 /usr/bin/install -c -m 644 org.naev.Naev.appdata.xml '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/metainfo'
install: cannot remove '/usr/share/naev/dat/./missions/shadow/darkshadow.lua': Permission denied
 /usr/bin/install -c -m 644 naev.6 '/home/camjh/Documents/makepkg/naev-git/pkg/naev-git/usr/share/man/man6'
install: cannot remove '/usr/share/naev/dat/./missions/shadow/shadowvigil.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/shadow/common.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/shadow/shadowrun.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/flf_pirates.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/flf_empatrol.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk07.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk03.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk06.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk02.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk01.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk05.lua': Permission denied
install: cannot remove '/usr/share/naev/dat/./missions/flf/dvk/flf_dvk04.lua': Permission denied

... this continues on for hundreds of lines, you get the point.
```

This has the side effect that the created package does not contain a dat/ folder and, as a result, does not create a launch-able game, but otherwise contains a filesystem as you would expect. 
