### PR TITLE
Fix existence-check and destination paths for nfile_backupIfExists.

### DIFF
--- a/src/nfile.c
+++ b/src/nfile.c
@@ -446,16 +446,15 @@ int _nfile_fileExists( const char *path )
  */
 int _nfile_backupIfExists( const char *path )
 {
-   char file[ PATH_MAX ];
    char backup[ PATH_MAX ];
 
    if ( path == NULL )
       return -1;
 
-   if ( !nfile_fileExists( file ) )
+   if ( !nfile_fileExists( path ) )
       return 0;
 
-   nsnprintf(backup, PATH_MAX, "%s.backup", file);
+   nsnprintf(backup, PATH_MAX, "%s.backup", path);
 
    return nfile_copyIfExists( path, backup );
 }


### PR DESCRIPTION
(Side effect: players will start seeing backup saves appear.)
Hello, I noticed a strange error when Naev tried to save my game: "Warning: [nfile_copyIfExists] Failure to copy '/home/justinb/.local/share/naev/saves/Justin.ns' to '/usr/share/naev/dat/missions/empire/common.lua.backup': Permission denied"
It's because this function accidentally used an uninitialized "file" array instead of "path". In practice, it would usually check a nonexistent path and do nothing. That time, it tried something naughty.
Based on some quick testing, the underlying save-backup feature works fine once this is fixed.
Thanks,
Justin