### PR TITLE
CI: Fix CI Failures, disable macOS temporarily and fix documentation uploads

### DIFF
--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -54,8 +54,6 @@ jobs:
             shell: bash
             config: macos.ini
             pkg-config-path: '/usr/local/opt/openal-soft/lib/pkgconfig'
-            env:
-              PATH: "/opt/local/bin:/opt/local/sbin:$PATH"
 
     defaults:
       run:
@@ -102,6 +100,7 @@ jobs:
       run: |
         wget https://github.com/macports/macports-base/releases/download/v2.6.3/MacPorts-2.6.3-10.15-Catalina.pkg
         sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target /
+        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         sudo port install \
           fontconfig \
           intltool \
@@ -136,6 +135,7 @@ jobs:
     - name: Meson Setup
       id: setup
       run: |
+        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         meson setup build source \
             --native-file='source/utils/build/${{ matrix.config }}' \
             --buildtype=release \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -156,7 +156,9 @@ jobs:
 
     - name: Meson Compile
       id: compile
-      run: meson compile -C build
+      run: |
+        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
+        meson compile -C build
 
     - name: Upload Compile Log
       uses: actions/upload-artifact@v2
@@ -168,7 +170,9 @@ jobs:
 
     - name: Meson Test
       id: tests
-      run: ${{ matrix.test-env }} meson test -C build --print-errorlogs
+      run: |
+        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
+        ${{ matrix.test-env }} meson test -C build --print-errorlogs
 
     - name: Upload test log
       uses: actions/upload-artifact@v2
@@ -180,8 +184,8 @@ jobs:
 
     - name: Package
       run: |
+        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         meson install -C build
-        tar -cf - ${{ env.DESTDIR }}/ | xz -9 -c - > ${{ env.DESTDIR }}/naev-${{ runner.os }}-${{ github.sha }}.tar.xz
       if: ${{ success() || steps.tests.outcome == 'failure' }}
 
     - name: Upload Artifact
@@ -189,7 +193,7 @@ jobs:
       if: ${{ success() || steps.tests.outcome == 'failure' }}
       with:
         name: naev-${{ runner.os }}-${{ github.sha }}
-        path: ${{ env.DESTDIR }}/*.tar.xz
+        path: ${{ env.DESTDIR }}/*
         if-no-files-found: error
 
   "Documentation":

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -54,6 +54,8 @@ jobs:
             shell: bash
             config: macos.ini
             pkg-config-path: '/usr/local/opt/openal-soft/lib/pkgconfig'
+            env:
+              PATH: "/opt/local/bin:/opt/local/sbin:$PATH"
 
     defaults:
       run:
@@ -100,7 +102,6 @@ jobs:
       run: |
         wget https://github.com/macports/macports-base/releases/download/v2.6.3/MacPorts-2.6.3-10.15-Catalina.pkg
         sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target /
-        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         sudo port install \
           fontconfig \
           intltool \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -100,6 +100,7 @@ jobs:
       run: |
         wget https://github.com/macports/macports-base/releases/download/v2.6.3/MacPorts-2.6.3-10.15-Catalina.pkg
         sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target /
+        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         sudo port install \
           fontconfig \
           intltool \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -95,22 +95,22 @@ jobs:
         update: true
         install: git tar mingw-w64-x86_64-clang mingw-w64-x86_64-fontconfig mingw-w64-x86_64-freetype mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libxml2 mingw-w64-x86_64-luajit mingw-w64-x86_64-mesa mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-openal mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer
 
-    - name: Install Homebrew Packages
+    - name: Install Macport Ports
       if: ${{ runner.os == 'macOS'}}
       run: |
-        brew update-reset
-        brew update
-        brew install \
+        wget https://github.com/macports/macports-base/releases/download/v2.6.3/MacPorts-2.6.3-10.15-Catalina.pkg
+        sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target
+        sudo port install \
           fontconfig \
           intltool \
           luajit \
           meson \
           ninja \
           openal-soft \
-          pkg-config \
-          sdl2 \
-          sdl2_image \
-          sdl2_mixer
+          pkgconfig \
+          libsdl2 \
+          libsdl2_image \
+          libsdl2_mixer
 
     - name: Setup Python
       if: ${{ runner.os == 'Linux'}}

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -111,7 +111,8 @@ jobs:
           pkgconfig \
           libsdl2 \
           libsdl2_image \
-          libsdl2_mixer
+          libsdl2_mixer \
+          libxml2
 
     - name: Setup Python
       if: ${{ runner.os == 'Linux'}}
@@ -237,12 +238,12 @@ jobs:
       if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
 
     - name: Upload Lua Documentation
-      run: rsync -e "ssh -o 'StrictHostKeyChecking no'" -rv --delete ${{ env.DESTDIR }}/doc/naev/lua travis@iandouglasscott.com:/srv/naevdoc
+      run: rsync -e "ssh -o 'StrictHostKeyChecking no'" -rv --delete ${{ env.DESTDIR }}/usr/local/doc/naev/lua/* travis@iandouglasscott.com:/srv/naevdoc
       if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
         name: naev-docs-${{ github.sha }}
-        path: ${{ env.DESTDIR }}/doc/naev/*
+        path: ${{ env.DESTDIR }}/usr/local/doc/naev/*
         if-no-files-found: error

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -99,7 +99,7 @@ jobs:
       if: ${{ runner.os == 'macOS'}}
       run: |
         wget https://github.com/macports/macports-base/releases/download/v2.6.3/MacPorts-2.6.3-10.15-Catalina.pkg
-        sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target
+        sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target /
         sudo port install \
           fontconfig \
           intltool \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -104,6 +104,8 @@ jobs:
           fontconfig \
           intltool \
           luajit \
+          meson \
+          ninja \
           openal-soft \
           pkg-config \
           sdl2 \
@@ -111,11 +113,11 @@ jobs:
           sdl2_mixer
 
     - name: Setup Python
-      if: ${{ runner.os != 'Windows'}}
+      if: ${{ runner.os == 'Linux'}}
       uses: actions/setup-python@v2
 
     - name: Install Meson
-      if: ${{ runner.os != 'Windows'}}
+      if: ${{ runner.os == 'Linux'}}
       run: |
         pip install meson ninja
 
@@ -233,12 +235,12 @@ jobs:
       if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
 
     - name: Upload Lua Documentation
-      run: rsync -e "ssh -o 'StrictHostKeyChecking no'" -rv --delete ${{ env.DESTDIR }}/docs/lua/ travis@iandouglasscott.com:/srv/naevdoc
+      run: rsync -e "ssh -o 'StrictHostKeyChecking no'" -rv --delete ${{ env.DESTDIR }}/doc/naev/lua travis@iandouglasscott.com:/srv/naevdoc
       if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
         name: naev-docs-${{ github.sha }}
-        path: ${{ env.DESTDIR }}/*
+        path: ${{ env.DESTDIR }}/doc/naev/*
         if-no-files-found: error

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -50,10 +50,6 @@ jobs:
             shell: msys2 {0}
             config: windows.ini
             pkg-config-path: "[]"
-          - os: macos-latest
-            shell: bash
-            config: macos.ini
-            pkg-config-path: '/usr/local/opt/openal-soft/lib/pkgconfig'
 
     defaults:
       run:
@@ -95,25 +91,6 @@ jobs:
         update: true
         install: git tar mingw-w64-x86_64-clang mingw-w64-x86_64-fontconfig mingw-w64-x86_64-freetype mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libxml2 mingw-w64-x86_64-luajit mingw-w64-x86_64-mesa mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-openal mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer
 
-    - name: Install Macport Ports
-      if: ${{ runner.os == 'macOS'}}
-      run: |
-        wget https://github.com/macports/macports-base/releases/download/v2.6.3/MacPorts-2.6.3-10.15-Catalina.pkg
-        sudo installer -pkg MacPorts-2.6.3-10.15-Catalina.pkg -target /
-        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
-        sudo port install \
-          fontconfig \
-          intltool \
-          luajit \
-          meson \
-          ninja \
-          openal-soft \
-          pkgconfig \
-          libsdl2 \
-          libsdl2_image \
-          libsdl2_mixer \
-          libxml2
-
     - name: Setup Python
       if: ${{ runner.os == 'Linux'}}
       uses: actions/setup-python@v2
@@ -136,7 +113,6 @@ jobs:
     - name: Meson Setup
       id: setup
       run: |
-        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         meson setup build source \
             --native-file='source/utils/build/${{ matrix.config }}' \
             --buildtype=release \
@@ -157,7 +133,6 @@ jobs:
     - name: Meson Compile
       id: compile
       run: |
-        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         meson compile -C build
 
     - name: Upload Compile Log
@@ -171,7 +146,6 @@ jobs:
     - name: Meson Test
       id: tests
       run: |
-        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         ${{ matrix.test-env }} meson test -C build --print-errorlogs
 
     - name: Upload test log
@@ -184,7 +158,6 @@ jobs:
 
     - name: Package
       run: |
-        export PATH=/opt/local/bin:/opt/local/sbin:$PATH
         meson install -C build
       if: ${{ success() || steps.tests.outcome == 'failure' }}
 

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -98,6 +98,7 @@ jobs:
     - name: Install Homebrew Packages
       if: ${{ runner.os == 'macOS'}}
       run: |
+        brew update-reset
         brew update
         brew install \
           fontconfig \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -179,7 +179,9 @@ jobs:
         if-no-files-found: ignore
 
     - name: Package
-      run: meson install -C build
+      run: |
+        meson install -C build
+        tar -cf - ${{ env.DESTDIR }}/ | xz -9 -c - > ${{ env.DESTDIR }}/naev-${{ runner.os }}-${{ github.sha }}.tar.xz
       if: ${{ success() || steps.tests.outcome == 'failure' }}
 
     - name: Upload Artifact
@@ -187,7 +189,7 @@ jobs:
       if: ${{ success() || steps.tests.outcome == 'failure' }}
       with:
         name: naev-${{ runner.os }}-${{ github.sha }}
-        path: ${{ env.DESTDIR }}/*
+        path: ${{ env.DESTDIR }}/*.tar.xz
         if-no-files-found: error
 
   "Documentation":

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis libtool autoconf autoconf-archive automake automake-wrapper git gettext pkgconfig make intltool zip unzip python3-pip itstool
+        install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis mingw-w64-pkg-config libtool autoconf autoconf-archive automake automake-wrapper git gettext pkg-config make intltool zip unzip python3-pip itstool
 
     - name: Checkout Naev Repository
       uses: actions/checkout@v2

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -158,59 +158,6 @@ jobs:
         name: steam-x86-64
         path: ${{ github.workspace }}/dist/release/naev.x64
 
-  "macOS":
-    runs-on: macos-latest
-
-    steps:
-    - name: Update Homebrew Cache
-      run: |
-        brew update
-
-    - name: Install Additional Build Dependencies
-      run: |
-        brew install \
-          automake \
-          autoconf-archive \
-          pkg-config \
-          luajit \
-          intltool \
-          sdl2 \
-          sdl2_mixer \
-          sdl2_image \
-          openal-soft
-
-    - name: Remove Homebrew Perl
-      run: |
-        brew uninstall --ignore-dependencies perl
-
-    - name: Checkout Naev Repository
-      uses: actions/checkout@v2
-
-    - name: Build Naev on MacOS
-      run: |
-        # PKGCONFIG configuration for OpenAL
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openal-soft/lib/pkgconfig"
-
-        ./autogen.sh
-        ./configure --disable-debug
-        make -j$(sysctl -n hw.logicalcpu)
-      env:
-        CFLAGS: "-O3 -mmacosx-version-min=10.7"
-
-    - name: Package MacOS Release
-      run: |
-        mkdir -p dist/release
-
-        ./extras/macos/bundle.sh
-        cp -r dat/ Naev.app/Contents/Resources/dat/
-        zip -r dist/release/naev-macos.zip Naev.app/*
-
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: macos
-        path: ${{ github.workspace }}/dist/release/naev-macos.zip
-
   "Generate-Source":
       runs-on: ubuntu-latest
 
@@ -269,7 +216,7 @@ jobs:
 
   "Upload-Release":
       runs-on: ubuntu-latest
-      needs: [Linux-x86_64, Windows-MinGW64, macOS, Generate-Source]
+      needs: [Linux-x86_64, Windows-MinGW64, Generate-Source]
       if: ${{ github.repository == 'naev/naev' }}
 
       steps:
@@ -329,7 +276,6 @@ jobs:
           fi
 
           mv dist/linux-x86-64/linux-x86-64.tar.gz dist/release/naev-$VERSION-$BUILD_DATE-linux-x86-64.tar.gz
-          mv dist/macos/naev-macos.zip dist/release/naev-$VERSION-$BUILD_DATE-macos.zip
           mv dist/win64/naev-win64.exe dist/release/naev-$VERSION-$BUILD_DATE-win64.exe
           mv dist/source/source.tar.gz dist/release/naev-$VERSION-$BUILD_DATE-source.tar.gz
 
@@ -345,7 +291,7 @@ jobs:
 
   "Upload-Steam":
       runs-on: ubuntu-latest
-      needs: [Linux-x86_64-SteamRuntime, Windows-MinGW64, macOS]
+      needs: [Linux-x86_64-SteamRuntime, Windows-MinGW64]
       if: ${{ github.repository == 'naev/naev' }}
 
       steps:

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis libtool autoconf autoconf-archive automake automake-wrapper git gettext pkgconfig make intltool zip unzip python3-pip itstool
+        install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis mingw-w64-pkg-config libtool autoconf autoconf-archive automake automake-wrapper git gettext pkg-config make intltool zip unzip python3-pip itstool
 
     - name: Checkout Naev Repository
       uses: actions/checkout@v2

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -156,59 +156,6 @@ jobs:
         name: steam-x86-64
         path: ${{ github.workspace }}/dist/release/naev.x64
 
-  "macOS":
-    runs-on: macos-latest
-
-    steps:
-    - name: Update Homebrew Cache
-      run: |
-        brew update
-
-    - name: Install Additional Build Dependencies
-      run: |
-        brew install \
-          automake \
-          autoconf-archive \
-          pkg-config \
-          luajit \
-          intltool \
-          sdl2 \
-          sdl2_mixer \
-          sdl2_image \
-          openal-soft
-
-    - name: Remove Homebrew Perl
-      run: |
-        brew uninstall --ignore-dependencies perl
-
-    - name: Checkout Naev Repository
-      uses: actions/checkout@v2
-
-    - name: Build Naev on MacOS
-      run: |
-        # PKGCONFIG configuration for OpenAL
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openal-soft/lib/pkgconfig"
-
-        ./autogen.sh
-        ./configure --disable-debug
-        make -j$(sysctl -n hw.logicalcpu)
-      env:
-        CFLAGS: "-O3 -mmacosx-version-min=10.7"
-
-    - name: Package MacOS Release
-      run: |
-        mkdir -p dist/release
-
-        ./extras/macos/bundle.sh
-        cp -r dat/ Naev.app/Contents/Resources/dat/
-        zip -r dist/release/naev-macos.zip Naev.app/*
-
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: macos
-        path: ${{ github.workspace }}/dist/release/naev-macos.zip
-
   "Generate-Source":
       runs-on: ubuntu-latest
 
@@ -267,7 +214,7 @@ jobs:
 
   "Upload-Release":
       runs-on: ubuntu-latest
-      needs: [Linux-x86_64, Windows-MinGW64, macOS, Generate-Source]
+      needs: [Linux-x86_64, Windows-MinGW64, Generate-Source]
       if: ${{ github.repository == 'naev/naev' }}
 
       steps:
@@ -325,7 +272,6 @@ jobs:
           fi
 
           mv dist/linux-x86-64/linux-x86-64.tar.gz dist/release/naev-$VERSION-linux-x86-64.tar.gz
-          mv dist/macos/naev-macos.zip dist/release/naev-$VERSION-macos.zip
           mv dist/win64/naev-win64.exe dist/release/naev-$VERSION-win64.exe
           mv dist/source/source.tar.gz dist/release/naev-$VERSION-source.tar.gz
 
@@ -339,7 +285,7 @@ jobs:
 
   "Upload-Steam":
       runs-on: ubuntu-latest
-      needs: [Linux-x86_64-SteamRuntime, Windows-MinGW64, macOS]
+      needs: [Linux-x86_64-SteamRuntime, Windows-MinGW64]
       if: ${{ github.repository == 'naev/naev' }}
 
       steps:

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -157,59 +157,6 @@ jobs:
         name: steam-x86-64
         path: ${{ github.workspace }}/dist/release/naev.x64
 
-  "macOS":
-    runs-on: macos-latest
-
-    steps:
-    - name: Update Homebrew Cache
-      run: |
-        brew update
-
-    - name: Install Additional Build Dependencies
-      run: |
-        brew install \
-          automake \
-          autoconf-archive \
-          pkg-config \
-          luajit \
-          intltool \
-          sdl2 \
-          sdl2_mixer \
-          sdl2_image \
-          openal-soft
-
-    - name: Remove Homebrew Perl
-      run: |
-        brew uninstall --ignore-dependencies perl
-
-    - name: Checkout Naev Repository
-      uses: actions/checkout@v2
-
-    - name: Build Naev on MacOS
-      run: |
-        # PKGCONFIG configuration for OpenAL
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openal-soft/lib/pkgconfig"
-
-        ./autogen.sh
-        ./configure --disable-debug
-        make -j$(sysctl -n hw.logicalcpu)
-      env:
-        CFLAGS: "-O3 -mmacosx-version-min=10.7"
-
-    - name: Package MacOS Release
-      run: |
-        mkdir -p dist/release
-
-        ./extras/macos/bundle.sh
-        cp -r dat/ Naev.app/Contents/Resources/dat/
-        zip -r dist/release/naev-macos.zip Naev.app/*
-
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: macos
-        path: ${{ github.workspace }}/dist/release/naev-macos.zip
-
   "Generate-Source":
       runs-on: ubuntu-latest
 
@@ -334,7 +281,7 @@ jobs:
 
   "Upload-Release":
       runs-on: ubuntu-latest
-      needs: [Linux-x86_64, Windows-MinGW64, macOS, Generate-Source, Generate-Soundtrack]
+      needs: [Linux-x86_64, Windows-MinGW64, Generate-Source, Generate-Soundtrack]
       if: ${{ github.repository == 'naev/naev' }}
 
       steps:
@@ -392,7 +339,6 @@ jobs:
           fi
 
           mv dist/linux-x86-64/linux-x86-64.tar.gz dist/release/naev-$VERSION-linux-x86-64.tar.gz
-          mv dist/macos/naev-macos.zip dist/release/naev-$VERSION-macos.zip
           mv dist/win64/naev-win64.exe dist/release/naev-$VERSION-win64.exe
           mv dist/source/source.tar.gz dist/release/naev-$VERSION-source.tar.gz
           mv dist/soundtrack/release/soundtrack.zip dist/release/naev-$VERSION-soundtrack.zip
@@ -407,7 +353,7 @@ jobs:
 
   "Upload-Steam":
       runs-on: ubuntu-latest
-      needs: [Linux-x86_64-SteamRuntime, Windows-MinGW64, macOS, Generate-Soundtrack]
+      needs: [Linux-x86_64-SteamRuntime, Windows-MinGW64, Generate-Soundtrack]
       if: ${{ github.repository == 'naev/naev' }}
 
       steps:

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis libtool autoconf autoconf-archive automake automake-wrapper git gettext pkgconfig make intltool zip unzip python3-pip itstool
+        install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis mingw-w64-pkg-config libtool autoconf autoconf-archive automake automake-wrapper git gettext pkg-config make intltool zip unzip python3-pip itstool
 
     - name: Checkout Naev Repository
       uses: actions/checkout@v2

--- a/extras/steam/SteamDeploy.sh
+++ b/extras/steam/SteamDeploy.sh
@@ -58,7 +58,8 @@ mv dist/steam/steam-x86-64/naev.x64 extras/steam/content/lin64/naev.x64
 chmod +x extras/steam/content/lin64/naev.x64
           
 # Move macOS bundle to deployment location
-unzip dist/steam/macos/naev-macos.zip -d extras/steam/content/macos/
+# Uncomment when we figure out how to properly release Darwin builds / can test them.
+# unzip dist/steam/macos/naev-macos.zip -d extras/steam/content/macos/
 
 # Unzip Windows binary and DLLs and move to deployment location
 unzip dist/steam/win64/naev-win64.zip -d extras/steam/content/win64/

--- a/extras/steam/scripts/app_build_598530_nightly.vdf
+++ b/extras/steam/scripts/app_build_598530_nightly.vdf
@@ -10,7 +10,6 @@
 	
 	"depots"
 	{
-		"598531" "depot_build_598531.vdf"
 		"598532" "depot_build_598532.vdf"
 		"598534" "depot_build_598534.vdf"
 		"598536" "depot_build_598536.vdf"

--- a/extras/steam/scripts/app_build_598530_prerelease.vdf
+++ b/extras/steam/scripts/app_build_598530_prerelease.vdf
@@ -10,7 +10,6 @@
 	
 	"depots"
 	{
-		"598531" "depot_build_598531.vdf"
 		"598532" "depot_build_598532.vdf"
 		"598534" "depot_build_598534.vdf"
 		"598536" "depot_build_598536.vdf"

--- a/extras/steam/scripts/app_build_598530_release.vdf
+++ b/extras/steam/scripts/app_build_598530_release.vdf
@@ -10,7 +10,6 @@
 	
 	"depots"
 	{
-		"598531" "depot_build_598531.vdf"
 		"598532" "depot_build_598532.vdf"
 		"598534" "depot_build_598534.vdf"
 		"598536" "depot_build_598536.vdf"


### PR DESCRIPTION
I tried, but I'm nearing the end of my rope with macOS. 
Right now the main failures in terms of CI are down to issues with homebrew mirrors, or build issues due to something failing to download.

This PR simply removes macos from the CI build matrix and release workflows (for now) until a more solid solution can be figured out. 
There's no need to block a release from happening if homebrew is unreachable (which has been happening more frequently than when this was initially added) 

I also fixed the upload to api.naev.org due to some paths not quite matching up with the upload step.

Back to macos.. we don't really have the testing capacity or hardware available to give players decent experience using the releases that are generated right now, and I don't think we should be pushing out something half-baked if it can be avoided.

For now I say we stop building for macOS at least until a better solution presents itself.
I tried to get macports working to no avail (some tinkering with the build system might be needed to get testing working.)

I'm (still) working on a more robust release solution that simplifies things quite a bit, opts to use appimages on linux and should allow us to release on itch.io but I've been getting slammed with irl things and work things so.. time and energy are not readily available from me.
Hopefully with that we might be able to get macos stuff going again, but I'm still not 100% on serving something out without proper testing.