### PR TITLE
Free the SDL surfaces and file handles after loading asteroid sprites.

### DIFF
--- a/src/space.c
+++ b/src/space.c
@@ -3397,7 +3397,8 @@ static int asteroidTypes_load (void)
 
                at->gfxs[i] = gl_loadImagePadTrans( file, surface, rw,
                              OPENGL_TEX_MAPTRANS | OPENGL_TEX_MIPMAPS,
-                             w, h, 1, 1, 0 );
+                             w, h, 1, 1, 1 );
+               SDL_RWclose( rw );
                i++;
             }
 


### PR DESCRIPTION
I spotted some minor resource leaks. After talking it over on Discord, I'm raising separate PRs so the fixes which are obviously safe/correct (from Naev devs' perspective) can be merged first.
These changes are all battle-tested (in space!) -- but on this project that's a low bar. :)
