### PR TITLE
Resize text boxes (quick fix to #1288)

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -371,11 +371,11 @@ static unsigned int comm_open( glTexture *gfx, int faction,
 
    /* Name. */
    window_addText( wid, 19 + namex, -30 - GRAPHIC_HEIGHT - y + font->h*2 + 10,
-         GRAPHIC_WIDTH - logow, 20, 0, "txtName", font, &cWhite, name );
+         GRAPHIC_WIDTH - namex - logow, 20, 0, "txtName", font, &cWhite, name );
 
    /* Standing. */
    window_addText( wid, 19 + standx, -30 - GRAPHIC_HEIGHT - y + font->h + 5,
-         GRAPHIC_WIDTH - logow, 20, 0, "txtStanding", font, c, stand );
+         GRAPHIC_WIDTH - standx - logow, 20, 0, "txtStanding", font, c, stand );
 
    /* Buttons. */
    window_addButton( wid, -20, 20, BUTTON_WIDTH, BUTTON_HEIGHT,

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -304,16 +304,16 @@ void equipment_open( unsigned int wid )
    x = 20 + sw + 20 + 180 + 20 + 30;
    y = -190;
    window_addText( wid, x, y,
-         100, h+y, 0, "txtSDesc", &gl_smallFont, NULL, buf );
+         100, y-20+h-bh, 0, "txtSDesc", &gl_smallFont, NULL, buf );
    x += 150;
    window_addText( wid, x, y,
-         w - x - 20, h+y, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
+         w - x - 20, y-20+h-bh, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
 
    /* Generate lists. */
    window_addText( wid, 30, -20,
-         130, 500, 0, "txtShipTitle", &gl_defFont, NULL, _("Available Ships") );
+         ow, gl_defFont.h, 0, "txtShipTitle", &gl_defFont, NULL, _("Available Ships") );
    window_addText( wid, 30, -40-sh-20,
-         130, 500, 0, "txtOutfitTitle", &gl_defFont, NULL, _("Available Outfits") );
+         ow, gl_defFont.h, 0, "txtOutfitTitle", &gl_defFont, NULL, _("Available Outfits") );
    equipment_genLists( wid );
 
    /* Separator. */

--- a/src/info.c
+++ b/src/info.c
@@ -222,7 +222,7 @@ static void info_openMain( unsigned int wid )
          player.p->name,
          player.p->fuel, pilot_getJumps(player.p) );
    window_addText( wid, 180, 20,
-         200, h-80,
+         w-80-200-40+20-180, h-80,
          0, "txtPilot", &gl_smallFont, NULL, str );
    free(nt);
 
@@ -412,7 +412,7 @@ static void info_openShip( unsigned int wid )
          "\n"
          "\anStats:\a0\n")
          );
-   window_addText( wid, 180, -60, w-300., h-60, 0, "txtDDesc", &gl_smallFont,
+   window_addText( wid, 180, -60, w-20-180-180., h-60, 0, "txtDDesc", &gl_smallFont,
          NULL, NULL );
 
    /* Custom widget. */

--- a/src/land.c
+++ b/src/land.c
@@ -568,7 +568,7 @@ static void misn_open( unsigned int wid )
          _("Date:\n"
          "Free Space:"));
    window_addText( wid, w/2 + 110, y,
-         w/2 - 90, 40, 0,
+         w/2 - 130, 40, 0,
          "txtDate", NULL, NULL, NULL );
    y -= 2 * gl_defFont.h + 50;
    window_addText( wid, w/2 + 10, y,
@@ -576,7 +576,7 @@ static void misn_open( unsigned int wid )
          "txtReward", &gl_smallFont, NULL, _("\anReward:\a0 None") );
    y -= 20;
    window_addText( wid, w/2 + 10, y,
-         w/2 - 30, h/2-90, 0,
+         w/2 - 30, y - 40 + h - 2*LAND_BUTTON_HEIGHT, 0,
          "txtDesc", &gl_smallFont, NULL, NULL );
 
    /* map */

--- a/src/land_outfits.c
+++ b/src/land_outfits.c
@@ -183,9 +183,9 @@ void outfits_open( unsigned int wid, Outfit **outfits, int noutfits )
 
    /* the descriptive text */
    window_addText( wid, 20 + iw + 20, -60,
-         280, 160, 0, "txtOutfitName", &gl_defFont, NULL, NULL );
+         w - (20 + iw + 20) - 200 - 20, 160, 0, "txtOutfitName", &gl_defFont, NULL, NULL );
    window_addText( wid, 20 + iw + 20, -60 - gl_defFont.h - 20,
-         280, 320, 0, "txtDescShort", &gl_smallFont, NULL, NULL );
+         w - (20 + iw + 20) - 200 - 20, 320, 0, "txtDescShort", &gl_smallFont, NULL, NULL );
 
    window_addText( wid, 20 + iw + 20, -60-128-10-32,
          60, 160, 0, "txtSDesc", &gl_smallFont, NULL,
@@ -199,10 +199,10 @@ void outfits_open( unsigned int wid, Outfit **outfits, int noutfits )
          "\anMoney:\a0\n"
          "\anLicense:\a0\n") );
    window_addText( wid, 20 + iw + 20 + 60, -60-128-10-32,
-         250, 160, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
+         w - (20 + iw + 20 + 60), 160, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
    window_addText( wid, 20 + iw + 20, -60-128-10-160-32,
-         w-(iw+80), 180, 0, "txtDescription",
-         &gl_smallFont, NULL, NULL );
+         w-(iw+80), MAX(180, h - 500), /* TODO: Size exactly and resize instead of moving? */
+	 0, "txtDescription", &gl_smallFont, NULL, NULL );
 
    /* Create the image array. */
    outfits_genList( wid );

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -111,7 +111,7 @@ void shipyard_open( unsigned int wid )
          shipyard_renderSlots, NULL, NULL );
 
    /* stat text */
-   window_addText( wid, -40, -SHIP_TARGET_H-60-70-20, 128, 400, 0, "txtStats",
+   window_addText( wid, -40, -SHIP_TARGET_H-60-70-20, 128, -SHIP_TARGET_H-60-70-20-20+h-bh, 0, "txtStats",
          &gl_smallFont, NULL, NULL );
 
    /* text */
@@ -142,10 +142,10 @@ void shipyard_open( unsigned int wid )
    window_addText( wid, 40+iw+20, y,
          100, th, 0, "txtSDesc", &gl_smallFont, NULL, buf );
    window_addText( wid, 40+iw+20+100, y,
-         w-(40+iw+20+100)-20, th, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
+         w-SHIP_TARGET_W-40-(40+iw+20+100), th, 0, "txtDDesc", &gl_smallFont, NULL, NULL );
    y -= th;
    window_addText( wid, 20+iw+40, y,
-         w-(20+iw+40) - 180, 185, 0, "txtDescription",
+         w-(20+iw+40) - 180, y-20+h-bh, 0, "txtDescription",
          &gl_smallFont, NULL, NULL );
 
    /* set up the ships to buy/sell */

--- a/src/land_trade.c
+++ b/src/land_trade.c
@@ -93,7 +93,7 @@ void commodity_exchange_open( unsigned int wid )
    window_addText( wid, -20, -190, LAND_BUTTON_WIDTH/2 + 40, 100, 0,
          "txtDInfo", &gl_smallFont, NULL, NULL );
    window_addText( wid, -40, -300, LAND_BUTTON_WIDTH-20 + 80,
-         h-140-LAND_BUTTON_HEIGHT, 0,
+         -300 - (46 + 2*LAND_BUTTON_HEIGHT) + h - (gl_smallFont.h + 6), 0,
          "txtDesc", &gl_smallFont, NULL, NULL );
 
    /* goods list */

--- a/src/map_find.c
+++ b/src/map_find.c
@@ -1084,7 +1084,7 @@ void map_inputFind( unsigned int parent, char* str )
 
    /* Text. */
    y = -40;
-   window_addText( wid, 20, y, w, gl_defFont.h+4, 0,
+   window_addText( wid, 20, y, w - 50, gl_defFont.h+4, 0,
          "txtDescription", &gl_defFont, NULL,
          _("Enter keyword to search for:") );
    y -= 30;

--- a/src/options.c
+++ b/src/options.c
@@ -560,7 +560,7 @@ static void opt_keybinds( unsigned int wid )
    /* Text stuff. */
    window_addText( wid, 20+lw+20, -40, w-(20+lw+20), 30, 1, "txtName",
          NULL, NULL, NULL );
-   window_addText( wid, 20+lw+20, -90, w-(20+lw+20), h-70-60-bh,
+   window_addText( wid, 20+lw+20, -90, w-(20+lw+20), h-170-3*bh,
          0, "txtDesc", &gl_smallFont, NULL, NULL );
 
    /* Generate the list. */


### PR DESCRIPTION
Recalculate the text widgets' ideal size and position based on the current layout. This serves as a tactical fix to #1288.