### PR TITLE
Unify three procedures for displaying faction presence on maps.

### DIFF
--- a/src/dev_mapedit.c
+++ b/src/dev_mapedit.c
@@ -656,7 +656,6 @@ void mapedit_selectText (void)
    int i, l;
    char buf[1024];
    StarSystem *sys;
-   int hasPresence;
 
    /* Built list of all selected systems names */
    l = 0;
@@ -680,27 +679,7 @@ void mapedit_selectText (void)
       /* Compute and display presence text. */
       if (mapedit_iLastClickedSystem != 0) {
          sys = system_getIndex( mapedit_iLastClickedSystem );
-         buf[0]      = '\0';
-         hasPresence = 0;
-         l           = 0;
-
-         for (i=sys->npresence-1; i >= 0 ; i--) {
-
-            /* Must have presence. */
-            if (sys->presence[i].value <= 0)
-               continue;
-
-            hasPresence = 1;
-            /* Use map grey instead of default neutral colour */
-            l += nsnprintf( &buf[l], sizeof(buf)-l, "%s\e0%s: %.0f",
-                  (l==0)?"":"\n", faction_name(sys->presence[i].faction),
-                  sys->presence[i].value);
-         }
-         if (hasPresence == 0) {
-            nsnprintf( buf, sizeof(buf), "None" );
-         }
-
-         window_modifyText( mapedit_wid, "txtPresence", buf );
+         map_updateFactionPresence( mapedit_wid, "txtPresence", sys, 1 );
          buf[0]      = '\0';
          nsnprintf( &buf[0], sizeof(buf), "Presence (%s)", sys->name );
          window_modifyText( mapedit_wid, "txtSPresence", buf );

--- a/src/dev_uniedit.c
+++ b/src/dev_uniedit.c
@@ -938,7 +938,6 @@ void uniedit_selectText (void)
    int i, l;
    char buf[1024];
    StarSystem *sys;
-   int hasPresence;
 
    l = 0;
    for (i=0; i<uniedit_nsys; i++) {
@@ -953,26 +952,7 @@ void uniedit_selectText (void)
       /* Presence text. */
       if (uniedit_nsys == 1) {
          sys         = uniedit_sys[0];
-         buf[0]      = '\0';
-         hasPresence = 0;
-         l           = 0;
-
-         for (i=0; i < sys->npresence ; i++) {
-
-            /* Must have presence. */
-            if (sys->presence[i].value <= 0)
-               continue;
-
-            hasPresence = 1;
-            /* Use map grey instead of default neutral colour */
-            l += nsnprintf( &buf[l], sizeof(buf)-l, "%s\a0%s: %.0f",
-                  (l==0)?"":"\n", faction_name(sys->presence[i].faction),
-                  sys->presence[i].value);
-         }
-         if (hasPresence == 0)
-            nsnprintf( buf, sizeof(buf), _("None") );
-
-         window_modifyText( uniedit_wid, "txtPresence", buf );
+         map_updateFactionPresence( uniedit_wid, "txtPresence", sys, 1 );
       }
       else
          window_modifyText( uniedit_wid, "txtPresence", _("Multiple selected") );

--- a/src/map.c
+++ b/src/map.c
@@ -395,15 +395,13 @@ static void map_update( unsigned int wid )
    StarSystem *sys;
    int f, h, x, y;
    unsigned int services;
-   int l;
-   int hasPresence, hasPlanets;
+   int hasPlanets;
    char t;
    const char *sym, *adj;
    char buf[PATH_MAX];
    int p;
    glTexture *logo;
    double w;
-   double unknownPresence;
    Commodity *c;
 
    /* Needs map to update. */
@@ -551,40 +549,11 @@ static void map_update( unsigned int wid )
    window_moveWidget( wid, "txtStanding", x + 50, y - gl_smallFont.h - 5 );
    y -= 2 * gl_smallFont.h + 5 + 15;
 
-   /* Get presence. */
-   hasPresence = 0;
-   buf[0]      = '\0';
-   l           = 0;
-   unknownPresence = 0;
-   for (i=0; i < sys->npresence; i++) {
-      if (sys->presence[i].value <= 0)
-         continue;
-      hasPresence = 1;
-      if (faction_isKnown( sys->presence[i].faction )) {
-         t = faction_getColourChar(sys->presence[i].faction);
-         /* Use map grey instead of default neutral colour */
-         l += nsnprintf( &buf[l], PATH_MAX-l, "%s\a0%s: \a%c%.0f",
-                        (l==0)?"":"\n", faction_shortname(sys->presence[i].faction),
-                        t, sys->presence[i].value);
-      }
-      else
-         unknownPresence += sys->presence[i].value;
-      if (l > PATH_MAX)
-         break;
-   }
-   if (unknownPresence != 0)
-      l += nsnprintf( &buf[l], PATH_MAX-l, "%s\a0%s: \a%c%.0f",
-                     (l==0)?"":"\n", _("Unknown"), 'N', unknownPresence);
-   (void)l;
-
-   if (hasPresence == 0)
-      nsnprintf(buf, PATH_MAX, "N/A");
-
    window_moveWidget( wid, "txtSPresence", x, y );
    window_moveWidget( wid, "txtPresence", x + 50, y-gl_smallFont.h-5 );
-   window_modifyText( wid, "txtPresence", buf );
+   map_updateFactionPresence( wid, "txtPresence", sys, 0 );
    /* Scroll down. */
-   h  = gl_printHeightRaw( &gl_smallFont, w, buf );
+   h = window_getTextHeight( wid, "txtPresence" );
    y -= 40 + (h - gl_smallFont.h);
 
    /* Get planets */
@@ -1560,6 +1529,53 @@ void map_renderCommod( double bx, double by, double x, double y,
    }
 }
 #undef setcolour
+
+/**
+ * @brief Updates a text widget with a system's presence info.
+ *
+ *    @param wid Window to which the text widget belongs.
+ *    @param name Name of the text widget.
+ *    @param sys System whose faction presence we're reporting.
+ *    @param omniscient Whether to dispaly complete information (editor view)
+ */
+void map_updateFactionPresence( const unsigned int wid, const char *name, const StarSystem *sys, int omniscient )
+{
+   int    i, l;
+   char   buf[ 1024 ];
+   int    hasPresence;
+   double unknownPresence;
+
+   buf[ 0 ]        = '\0';
+   l               = 0;
+   hasPresence     = 0;
+   unknownPresence = 0;
+
+   for ( i = 0; i < sys->npresence; i++ ) {
+      if ( sys->presence[ i ].value <= 0 )
+         continue;
+
+      hasPresence = 1;
+      if ( !omniscient && !faction_isKnown( sys->presence[ i ].faction ) ) {
+         unknownPresence += sys->presence[ i ].value;
+         break;
+      }
+      /* Use map grey instead of default neutral colour */
+      l += nsnprintf( &buf[ l ], sizeof( buf ) - l, "%s\a0%s: \a%c%.0f", ( l == 0 ) ? "" : "\n",
+                      omniscient ? faction_name( sys->presence[ i ].faction )
+                                 : faction_shortname( sys->presence[ i ].faction ),
+                      faction_getColourChar( sys->presence[ i ].faction ), sys->presence[ i ].value );
+      if ( l > sizeof( buf ) )
+         break;
+   }
+   if ( unknownPresence != 0 && l <= sizeof( buf ) )
+      l += nsnprintf( &buf[ l ], sizeof( buf ) - l, "%s\a0%s: \a%c%.0f", ( l == 0 ) ? "" : "\n", _( "Unknown" ), 'N',
+                      unknownPresence );
+
+   if ( hasPresence == 0 )
+      nsnprintf( buf, sizeof( buf ), _( "None" ) );
+
+   window_modifyText( wid, name, buf );
+}
 
 /**
  * @brief Map custom widget mouse handling.

--- a/src/map.h
+++ b/src/map.h
@@ -60,6 +60,7 @@ void map_renderSystems( double bx, double by, double x, double y,
       double w, double h, double r, int editor );
 void map_renderNames( double bx, double by, double x, double y,
       double w, double h, int editor );
+void map_updateFactionPresence( const unsigned int wid, const char *name, const StarSystem *sys, int omniscient );
 int map_load (void);
 
 #endif /* MAP_H */

--- a/src/tk/widget/text.c
+++ b/src/tk/widget/text.c
@@ -131,3 +131,21 @@ void window_modifyText( const unsigned int wid,
    wgt->dat.txt.text = (newstring) ?  strdup(newstring) : NULL;
 }
 
+
+/**
+ * @brief Gets the content height of a text box, without drawing.
+ *
+ *    @param wid Window to which the text widget belongs.
+ *    @param name Name of the text widget.
+ */
+int window_getTextHeight( const unsigned int wid, const char *name )
+{
+   Widget *wgt;
+
+   /* Get the widget. */
+   wgt = window_getwgt( wid, name );
+   if ( wgt == NULL || wgt->type != WIDGET_TEXT )
+      return 0;
+
+   return gl_printHeightRaw( wgt->dat.txt.font, wgt->w, wgt->dat.txt.text );
+}

--- a/src/tk/widget/text.h
+++ b/src/tk/widget/text.h
@@ -30,9 +30,8 @@ void window_addText( const unsigned int wid,
       glFont* font, const glColour* colour, const char* string ); /* font, colour and actual text */
 
 /* Misc functions. */
-void window_modifyText( const unsigned int wid,
-      const char* name, const char* newstring );
-
+void window_modifyText( const unsigned int wid, const char *name, const char *newstring );
+int  window_getTextHeight( const unsigned int wid, const char *name );
 
 #endif /* WGT_TEXT_H */
 


### PR DESCRIPTION
The goal is to stop them from having their own separate problems, now or in the future. The issue I noticed was the editor view. (Its format string was different -- instead of \a escapes it had something else that rendered incorrectly.)
One of them also had extra guards around size_t underflow. Why not all of them... :)
There were a few ways of doing this. This way exposes a UI function (rather than an interface that refers to the text buffer) and needs to add a function for measuring the content height of a text box (which seems like a useful capability).