### PR TITLE
Fix edge case in ship-stats tooltips caused by initial newline in the text.

### DIFF
--- a/src/equipment.c
+++ b/src/equipment.c
@@ -1293,7 +1293,7 @@ int equipment_shipStats( char *buf, int max_len,  const Pilot *s, int dpseps )
    if (dps > 0.)
       l += nsnprintf( &buf[l], (max_len-l),
             _("%s%.2f DPS [%.2f EPS]"), (l!=0)?"\n":"", dps, eps );
-   l += ss_statsDesc( &s->stats, &buf[l], (max_len-l), 1 );
+   l += ss_statsDesc( &s->stats, &buf[l], (max_len-l), l );
    return l;
 }
 

--- a/src/font.c
+++ b/src/font.c
@@ -907,7 +907,7 @@ static int gl_printTextRawBase( const glFont *ft_font,
    /* Clears restoration. */
    gl_printRestoreClear();
 
-   ch = '\0';
+   ch = text[0]; /* In case of a 0-width first line (ret==p) below, we just care if text is empty or not. */
    i = 0;
    s = 0;
    p = 0; /* where we last drew up to */


### PR DESCRIPTION
Not a great situation to be in, but it's way less confusing if we draw it. :)