### PR TITLE
More UI tweaks/cleanup/fixes

### DIFF
--- a/src/equipment.c
+++ b/src/equipment.c
@@ -542,7 +542,6 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    double percent;
    double x, y;
    double w, h;
-   const glColour *lc, *dc;
 
    /* Must have selected ship. */
    if (eq_wgt.selected == NULL)

--- a/src/equipment.c
+++ b/src/equipment.c
@@ -317,7 +317,7 @@ void equipment_open( unsigned int wid )
    equipment_genLists( wid );
 
    /* Separator. */
-   window_addRect( wid, 20 + sw + 20, -40, 2, h-60, "rctDivider", &cGrey50, 0 );
+   // window_addRect( wid, 20 + sw + 20, -40, 2, h-60, "rctDivider", &cGrey50, 0 );
 
    /* Slot widget. */
    equipment_slotWidget( wid, 20 + sw + 40, -40, ew, eh, &eq_wgt );
@@ -551,8 +551,6 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
    p = eq_wgt.selected;
 
    /* Render CPU and energy bars. */
-   lc = &cWhite;
-   dc = &cGrey60;
    w = 120;
    h = 20;
    x = bx + 50.;
@@ -562,10 +560,8 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
       x, y + h + 10., &cFontWhite, -1, _("CPU Free") );
 
    percent = (p->cpu_max > 0) ? CLAMP(0., 1., (float)p->cpu / (float)p->cpu_max) : 0.;
-   toolkit_drawRect( x, y, w * percent, h, &cFriend, NULL );
-   toolkit_drawRect( x + w * percent, y, w * (1.-percent), h, &cHostile, NULL );
-   toolkit_drawOutline( x, y, w, h, 1., lc, NULL  );
-   toolkit_drawOutline( x, y, w, h, 2., dc, NULL  );
+   toolkit_drawRect( x, y - 2, w * percent, h + 4, &cFriend, NULL );
+   toolkit_drawRect( x + w * percent, y - 2, w * (1.-percent), h + 4, &cHostile, NULL );
    gl_printMid( &gl_smallFont, w,
       x, y + h / 2. - gl_smallFont.h / 2.,
       &cFontWhite, "%d / %d", p->cpu, p->cpu_max );
@@ -579,10 +575,8 @@ static void equipment_renderMisc( double bx, double by, double bw, double bh, vo
 
    percent = (p->stats.engine_limit > 0) ? CLAMP(0., 1.,
       (p->stats.engine_limit - p->solid->mass) / p->stats.engine_limit) : 0.;
-   toolkit_drawRect( x, y, w * percent, h, &cFriend, NULL );
-   toolkit_drawRect( x + w * percent, y, w * (1.-percent), h, &cRestricted, NULL );
-   toolkit_drawOutline( x, y, w, h, 1., lc, NULL  );
-   toolkit_drawOutline( x, y, w, h, 2., dc, NULL  );
+   toolkit_drawRect( x, y - 2, w * percent, h + 4, &cFriend, NULL );
+   toolkit_drawRect( x + w * percent, y - 2, w * (1.-percent), h + 4, &cRestricted, NULL );
    gl_printMid( &gl_smallFont, w,
       x, y + h / 2. - gl_smallFont.h / 2.,
       &cFontWhite, "%.0f / %.0f", p->stats.engine_limit - p->solid->mass, p->stats.engine_limit );
@@ -1450,7 +1444,7 @@ static void equipment_genOutfitList( unsigned int wid )
 
       /* Only create the filter widget if it will be a reasonable size. */
       if (iw >= 30) {
-         window_addInput( wid, ix, iy, iw, ih, EQUIPMENT_FILTER, 32, 1, &gl_smallFont );
+         window_addInput( wid, ix+15, iy+1, iw, ih, EQUIPMENT_FILTER, 32, 1, &gl_smallFont );
          window_setInputCallback( wid, EQUIPMENT_FILTER, equipment_filterOutfits );
       }
    }
@@ -1479,8 +1473,8 @@ static void equipment_genOutfitList( unsigned int wid )
    free(outfits);
 
    /* Create the actual image array. */
-   window_addImageArray( wid, x, y, ow, oh - 31,
-         EQUIPMENT_OUTFITS, 50., 50.,
+   window_addImageArray( wid, x + 4, y + 3, ow - 6, oh - 37,
+         EQUIPMENT_OUTFITS, 96., 96.,
          coutfits, noutfits,
          equipment_updateOutfits,
          equipment_rightClickOutfits );

--- a/src/info.c
+++ b/src/info.c
@@ -234,15 +234,20 @@ static void info_openMain( unsigned int wid )
          BUTTON_WIDTH, BUTTON_HEIGHT,
          "btnSetGUI", _("Set GUI"), info_setGui );
 
-   /* List. */
    buf = player_getLicenses( &nlicenses );
-   licenses = malloc(sizeof(char*)*nlicenses);
-   for (i=0; i<nlicenses; i++)
-      licenses[i] = strdup(buf[i]);
+   /* List. */
+   if(nlicenses == 0){
+     licenses = malloc(sizeof(char*));
+     licenses[0] = strdup("None");
+   } else {
+     licenses = malloc(sizeof(char*) * nlicenses);
+     for (i=0; i<nlicenses; i++)
+        licenses[i] = strdup(buf[i]);
+   }
    window_addText( wid, -20, -40, w-80-200-40-40, 20, 1, "txtList",
          NULL, NULL, _("Licenses") );
    window_addList( wid, -20, -70, w-80-200-40-40, h-110-BUTTON_HEIGHT,
-         "lstLicenses", licenses, nlicenses, 0, NULL );
+         "lstLicenses", licenses, (nlicenses || 1), 0, NULL );
 }
 
 

--- a/src/land_outfits.c
+++ b/src/land_outfits.c
@@ -316,7 +316,7 @@ static void outfits_genList( unsigned int wid )
 
       /* Only create the filter widget if it will be a reasonable size. */
       if (iw >= 30) {
-         window_addInput( wid, fx, fy, fw, fh, OUTFITS_FILTER, 32, 1, &gl_smallFont );
+         window_addInput( wid, fx + 15, fy +1, fw, fh, OUTFITS_FILTER, 32, 1, &gl_smallFont );
          window_setInputCallback( wid, OUTFITS_FILTER, outfits_regenList );
       }
    }
@@ -353,7 +353,7 @@ static void outfits_genList( unsigned int wid )
    free(outfits);
 
    window_addImageArray( wid, 20, 20,
-         iw, ih - 31, OUTFITS_IAR, 128, 128,
+         iw, ih - 34, OUTFITS_IAR, 128, 128,
          coutfits, noutfits, outfits_update, outfits_rmouse );
 
    /* write the outfits stuff */

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -169,7 +169,7 @@ void shipyard_open( unsigned int wid )
       free(ships);
    }
    window_addImageArray( wid, 20, 20,
-         iw, ih, "iarShipyard", 96., 96.,
+         iw, ih, "iarShipyard", 128., 128.,
          cships, nships, shipyard_update, shipyard_rmouse );
 
    /* write the shipyard stuff */

--- a/src/map_system.c
+++ b/src/map_system.c
@@ -886,7 +886,7 @@ static void map_system_genOutfitsList( unsigned int wid, float goodsSpace, float
       yh = (h - 100 - (i+1)*5 ) * outfitSpace;
       ypos = 65 + 5*(shipSpace!=0) + (h - 100 - (i+1)*5)*shipSpace;
       window_addImageArray( wid, xpos, ypos,
-                            xw, yh, MAPSYS_OUTFITS, 64, 64,
+                            xw, yh, MAPSYS_OUTFITS, 96, 96,
                             coutfits, noutfits, map_system_array_update, map_system_array_rmouse );
       toolkit_unsetSelection( wid, MAPSYS_OUTFITS );
    }
@@ -935,7 +935,7 @@ static void map_system_genShipsList( unsigned int wid, float goodsSpace, float o
       yh = (h - 100 - (i+1)*5 ) * shipSpace;
       ypos = 65;
       window_addImageArray( wid, xpos, ypos,
-         xw, yh, MAPSYS_SHIPS, 64., 64.,
+         xw, yh, MAPSYS_SHIPS, 96., 96.,
          cships, nships, map_system_array_update, map_system_array_rmouse );
       toolkit_unsetSelection( wid, MAPSYS_SHIPS );
    }
@@ -980,7 +980,7 @@ static void map_system_genTradeList( unsigned int wid, float goodsSpace, float o
       ypos = 60 + 5*i + (h-100 - (i+1)*5 )*(outfitSpace + shipSpace);
 
       window_addImageArray( wid, xpos, ypos,
-         xw, yh, MAPSYS_TRADE, 64, 64,
+         xw, yh, MAPSYS_TRADE, 96, 96,
          cgoods, ngoods, map_system_array_update, map_system_array_rmouse );
       toolkit_unsetSelection( wid, MAPSYS_TRADE );
    }

--- a/src/tk/widget/imagearray.c
+++ b/src/tk/widget/imagearray.c
@@ -268,8 +268,8 @@ static void iar_render( Widget* iar, double bx, double by )
    /*
     * Final outline.
     */
-   toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 1., toolkit_colLight, NULL );
-   toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 2., toolkit_colDark, NULL );
+   // toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 1., toolkit_colLight, NULL );
+   // toolkit_drawOutline( x+1, y+1, iar->w-2, iar->h-2, 2., toolkit_colDark, NULL );
 }
 
 

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -103,7 +103,7 @@ static void inp_render( Widget* inp, double bx, double by )
    y = by + inp->y;
 
    /* main background */
-   toolkit_drawRect( x, y, inp->w, inp->h, &cWhite, NULL );
+   toolkit_drawRect( x, y, inp->w, inp->h, &cBlack, NULL );
 
    if (inp->dat.inp.oneline)
       /* center vertically */
@@ -114,7 +114,7 @@ static void inp_render( Widget* inp, double bx, double by )
 
    /* Draw text. */
    gl_printTextRaw( inp->dat.inp.font, inp->w-10., inp->h,
-         x+5., ty, &cBlack, -1., &inp->dat.inp.input[ inp->dat.inp.view ] );
+         x+5., ty, &cGreen, -1., &inp->dat.inp.input[ inp->dat.inp.view ] );
 
    /* Draw cursor. */
    if (wgt_isFlag( inp, WGT_FLAG_FOCUSED )) {
@@ -124,7 +124,7 @@ static void inp_render( Widget* inp, double bx, double by )
          buf[ m ] = '\0';
          w = gl_printWidthRaw( inp->dat.inp.font, buf );
          toolkit_drawRect( x + 5. + w, y + (inp->h - inp->dat.inp.font->h - 4.)/2.,
-               1., inp->dat.inp.font->h + 4., &cBlack, &cBlack );
+               1., inp->dat.inp.font->h + 4., &cGreen, &cGreen );
       }
       else {
          /* Wrap the cursor around if the text is longer than the width of the widget. */
@@ -153,13 +153,10 @@ static void inp_render( Widget* inp, double bx, double by )
 
          /* Get the actual width now. */
          toolkit_drawRect( x + 5. + w, y + inp->h - lines * (inp->dat.inp.font->h + 5) - 3.,
-               1., inp->dat.inp.font->h + 4., &cBlack, &cBlack );
+               1., inp->dat.inp.font->h + 4., &cGreen, &cGreen );
       }
    }
 
-   /* inner outline */
-   toolkit_drawOutline( x, y, inp->w, inp->h, 0.,
-         toolkit_colLight, NULL );
    /* outer outline */
    toolkit_drawOutline( x-2, y-2, inp->w + 4, inp->h + 4, 1.,
          &cGrey20, NULL );

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -161,8 +161,8 @@ static void inp_render( Widget* inp, double bx, double by )
    toolkit_drawOutline( x, y, inp->w, inp->h, 0.,
          toolkit_colLight, NULL );
    /* outer outline */
-   toolkit_drawOutline( x, y, inp->w, inp->h, 1.,
-         toolkit_colDark, NULL );
+   toolkit_drawOutline( x-2, y-2, inp->w + 4, inp->h + 4, 1.,
+         &cGrey20, NULL );
 }
 
 

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -129,20 +129,19 @@ static void lst_render( Widget* lst, double bx, double by )
       toolkit_drawScrollbar( x + lst->w - 12. + 1, y -1, 12., lst->h + 2, scroll_pos );
    }
 
-   /* draw selected */
-   toolkit_drawRect( x, y - 3. + lst->h -
-         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_smallFont.h+6.),
-         w-1, gl_smallFont.h + 6., &cHilight, NULL );
-
    /* draw content */
    tx = x + 2.;
-   ty = y + lst->h - 6. - gl_smallFont.h;
-   miny = ty - lst->h + 6 + gl_smallFont.h;
+   ty = y + lst->h - 4. - gl_smallFont.h;
+   miny = ty - lst->h + 4 + gl_smallFont.h;
    w -= 4;
    for (i=lst->dat.lst.pos; i<lst->dat.lst.noptions; i++) {
+      /* (green) selected item background */
+      if(i == lst->dat.lst.selected){
+         toolkit_drawRect( x, ty - 6, w+2, gl_smallFont.h + 10., &cHilight, NULL );
+      }
       gl_printMaxRaw( &gl_smallFont, (int)w,
-            tx, ty, &cFontWhite, -1., lst->dat.lst.options[i] );
-      ty -= 6 + gl_smallFont.h;
+            tx + 4, ty - 2, &cFontWhite, -1., lst->dat.lst.options[i] );
+      ty -= 12 + gl_smallFont.h;
 
       /* Check if out of bounds. */
       if (ty < miny)

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -14,6 +14,9 @@
 #include <stdlib.h>
 #include "nstring.h"
 
+#define CELLPADV 12
+#define CELLPADV_D 12.
+
 
 static void lst_render( Widget* lst, double bx, double by );
 static int lst_key( Widget* lst, SDL_Keycode key, SDL_Keymod mod );
@@ -75,12 +78,12 @@ void window_addList( const unsigned int wid,
 
    /* position/size */
    wgt->w = (double) w;
-   wgt->h = (double) h - ((h % (gl_smallFont.h+12)) - 12);
+   wgt->h = (double) h - ((h % (gl_smallFont.h + CELLPADV)) - CELLPADV);
    toolkit_setPos( wdw, wgt, x, y );
 
    /* check if needs scrollbar. */
-   if (2 + (nitems * (gl_smallFont.h + 12)) > (int)wgt->h)
-      wgt->dat.lst.height = (12 + gl_smallFont.h) * nitems + 6;
+   if (2 + (nitems * (gl_smallFont.h + CELLPADV)) > (int)wgt->h)
+      wgt->dat.lst.height = (CELLPADV + gl_smallFont.h) * nitems + 6;
    else
       wgt->dat.lst.height = 0;
 
@@ -131,8 +134,8 @@ static void lst_render( Widget* lst, double bx, double by )
 
    /* draw (green) selected item background */
    toolkit_drawRect( x, y - 1. + lst->h -
-         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_smallFont.h+12.),
-         w-1, gl_smallFont.h + 12., &cHilight, NULL );
+         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_smallFont.h + CELLPADV_D),
+         w-1, gl_smallFont.h + CELLPADV_D, &cHilight, NULL );
 
    /* draw content */
    tx = x + 2.;
@@ -142,7 +145,7 @@ static void lst_render( Widget* lst, double bx, double by )
    for (i=lst->dat.lst.pos; i<lst->dat.lst.noptions; i++) {
       gl_printMaxRaw( &gl_smallFont, (int)w,
             tx + 4, ty - 2, &cFontWhite, -1., lst->dat.lst.options[i] );
-      ty -= 12 + gl_smallFont.h;
+      ty -= CELLPADV + gl_smallFont.h;
 
       /* Check if out of bounds. */
       if (ty < miny)
@@ -169,6 +172,18 @@ static int lst_key( Widget* lst, SDL_Keycode key, SDL_Keymod mod )
          return 1;
       case SDLK_DOWN:
          lst_scroll( lst, -1 );
+         return 1;
+      case SDLK_HOME:
+         lst_scroll( lst, +(lst->dat.lst.noptions) );
+         return 1;
+      case SDLK_END:
+         lst_scroll( lst, -(lst->dat.lst.noptions) );
+         return 1;
+      case SDLK_PAGEUP:
+         lst_scroll( lst, +8);
+         return 1;
+      case SDLK_PAGEDOWN:
+         lst_scroll( lst, -8);
          return 1;
 
       default:
@@ -210,9 +225,9 @@ static int lst_mclick( Widget* lst, int button, int x, int y )
 static int lst_mwheel( Widget* lst, SDL_MouseWheelEvent event )
 {
    if (event.y > 0)
-      lst_scroll( lst, +5 );
+      lst_scroll( lst, +1 );
    else
-      lst_scroll( lst, -5 );
+      lst_scroll( lst, -1 );
 
    return 1;
 }
@@ -238,7 +253,7 @@ static int lst_focus( Widget* lst, double bx, double by )
       w -= 10.;
 
    if (bx < w) {
-      i = lst->dat.lst.pos + (lst->h - by - 4) / (gl_smallFont.h + 12.);
+      i = lst->dat.lst.pos + (lst->h - by - 4) / (gl_smallFont.h + CELLPADV_D);
       if (i < lst->dat.lst.noptions) { /* shouldn't be out of boundaries */
          lst->dat.lst.selected = i;
          lst_scroll( lst, 0 ); /* checks boundaries and triggers callback */
@@ -246,7 +261,7 @@ static int lst_focus( Widget* lst, double bx, double by )
    }
    else {
       /* Get bar position (center). */
-      scroll_pos  = (double)(lst->dat.lst.pos * (12 + gl_smallFont.h));
+      scroll_pos  = (double)(lst->dat.lst.pos * (CELLPADV + gl_smallFont.h));
       scroll_pos /= (double)lst->dat.lst.height - lst->h;
       y = (lst->h - 30.) * (1.-scroll_pos) + 15.;
 
@@ -286,14 +301,14 @@ static int lst_mmove( Widget* lst, int x, int y, int rx, int ry )
       /* Make sure Y inbounds. */
       y = CLAMP( 15., lst->h-15., lst->h - y );
 
-      h = lst->h / (12 + gl_smallFont.h) - 1;
+      h = lst->h / (CELLPADV + gl_smallFont.h) - 1;
 
       /* Save previous position. */
       psel = lst->dat.lst.pos;
 
       /* Find absolute position. */
       p  = (y - 15. ) / (lst->h - 30.) * (lst->dat.lst.height - lst->h);
-      p /= (12 + gl_smallFont.h);
+      p /= (CELLPADV + gl_smallFont.h);
       lst->dat.lst.pos = CLAMP( 0, lst->dat.lst.noptions, (int)ceil(p) );
 
       /* Does boundary checks. */
@@ -356,8 +371,8 @@ static void lst_scroll( Widget* lst, int direction )
       if (lst->dat.lst.pos < 0)
          lst->dat.lst.pos = 0;
    }
-   else if (12 + (pos+1) * (gl_smallFont.h + 12) > lst->h)
-      lst->dat.lst.pos += (12 + (pos+1) * (gl_smallFont.h + 12) - lst->h) / (gl_smallFont.h + 12);
+   else if (CELLPADV + (pos+1) * (gl_smallFont.h + CELLPADV) > lst->h)
+      lst->dat.lst.pos += (CELLPADV + (pos+1) * (gl_smallFont.h + CELLPADV) - lst->h) / (gl_smallFont.h + CELLPADV);
 
    if (lst->dat.lst.fptr)
       lst->dat.lst.fptr( lst->wdw, lst->name );

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -129,16 +129,17 @@ static void lst_render( Widget* lst, double bx, double by )
       toolkit_drawScrollbar( x + lst->w - 12. + 1, y -1, 12., lst->h + 2, scroll_pos );
    }
 
+   /* draw (green) selected item background */
+   toolkit_drawRect( x, y - 1. + lst->h -
+         (1 + lst->dat.lst.selected - lst->dat.lst.pos)*(gl_smallFont.h+12.),
+         w-1, gl_smallFont.h + 12., &cHilight, NULL );
+
    /* draw content */
    tx = x + 2.;
    ty = y + lst->h - 4. - gl_smallFont.h;
    miny = ty - lst->h + 4 + gl_smallFont.h;
    w -= 4;
    for (i=lst->dat.lst.pos; i<lst->dat.lst.noptions; i++) {
-      /* (green) selected item background */
-      if(i == lst->dat.lst.selected){
-         toolkit_drawRect( x, ty - 6, w+2, gl_smallFont.h + 10., &cHilight, NULL );
-      }
       gl_printMaxRaw( &gl_smallFont, (int)w,
             tx + 4, ty - 2, &cFontWhite, -1., lst->dat.lst.options[i] );
       ty -= 12 + gl_smallFont.h;

--- a/src/tk/widget/list.c
+++ b/src/tk/widget/list.c
@@ -75,12 +75,12 @@ void window_addList( const unsigned int wid,
 
    /* position/size */
    wgt->w = (double) w;
-   wgt->h = (double) h - ((h % (gl_smallFont.h+6)) - 6);
+   wgt->h = (double) h - ((h % (gl_smallFont.h+12)) - 12);
    toolkit_setPos( wdw, wgt, x, y );
 
    /* check if needs scrollbar. */
-   if (2 + (nitems * (gl_smallFont.h + 6)) > (int)wgt->h)
-      wgt->dat.lst.height = (6 + gl_smallFont.h) * nitems + 6;
+   if (2 + (nitems * (gl_smallFont.h + 12)) > (int)wgt->h)
+      wgt->dat.lst.height = (12 + gl_smallFont.h) * nitems + 6;
    else
       wgt->dat.lst.height = 0;
 
@@ -238,7 +238,7 @@ static int lst_focus( Widget* lst, double bx, double by )
       w -= 10.;
 
    if (bx < w) {
-      i = lst->dat.lst.pos + (lst->h - by - 4) / (gl_smallFont.h + 6.);
+      i = lst->dat.lst.pos + (lst->h - by - 4) / (gl_smallFont.h + 12.);
       if (i < lst->dat.lst.noptions) { /* shouldn't be out of boundaries */
          lst->dat.lst.selected = i;
          lst_scroll( lst, 0 ); /* checks boundaries and triggers callback */
@@ -246,7 +246,7 @@ static int lst_focus( Widget* lst, double bx, double by )
    }
    else {
       /* Get bar position (center). */
-      scroll_pos  = (double)(lst->dat.lst.pos * (6 + gl_smallFont.h));
+      scroll_pos  = (double)(lst->dat.lst.pos * (12 + gl_smallFont.h));
       scroll_pos /= (double)lst->dat.lst.height - lst->h;
       y = (lst->h - 30.) * (1.-scroll_pos) + 15.;
 
@@ -286,14 +286,14 @@ static int lst_mmove( Widget* lst, int x, int y, int rx, int ry )
       /* Make sure Y inbounds. */
       y = CLAMP( 15., lst->h-15., lst->h - y );
 
-      h = lst->h / (6 + gl_smallFont.h) - 1;
+      h = lst->h / (12 + gl_smallFont.h) - 1;
 
       /* Save previous position. */
       psel = lst->dat.lst.pos;
 
       /* Find absolute position. */
       p  = (y - 15. ) / (lst->h - 30.) * (lst->dat.lst.height - lst->h);
-      p /= (6 + gl_smallFont.h);
+      p /= (12 + gl_smallFont.h);
       lst->dat.lst.pos = CLAMP( 0, lst->dat.lst.noptions, (int)ceil(p) );
 
       /* Does boundary checks. */
@@ -356,8 +356,8 @@ static void lst_scroll( Widget* lst, int direction )
       if (lst->dat.lst.pos < 0)
          lst->dat.lst.pos = 0;
    }
-   else if (6 + (pos+1) * (gl_smallFont.h + 6) > lst->h)
-      lst->dat.lst.pos += (6 + (pos+1) * (gl_smallFont.h + 6) - lst->h) / (gl_smallFont.h + 6);
+   else if (12 + (pos+1) * (gl_smallFont.h + 12) > lst->h)
+      lst->dat.lst.pos += (12 + (pos+1) * (gl_smallFont.h + 12) - lst->h) / (gl_smallFont.h + 12);
 
    if (lst->dat.lst.fptr)
       lst->dat.lst.fptr( lst->wdw, lst->name );

--- a/src/tk/widget/tabwin.c
+++ b/src/tk/widget/tabwin.c
@@ -20,6 +20,9 @@
 
 
 #define TAB_HEIGHT   30
+#define TAB_HMARGIN 3
+#define TAB_HPADDING 15
+
 
 
 /*
@@ -246,7 +249,7 @@ static int tab_mouse( Widget* tab, SDL_Event *event )
       if (x < p)
          break;
 
-      p += 30 + tab->dat.tab.namelen[i];
+      p += (TAB_HPADDING * 2) + tab->dat.tab.namelen[i];
 
       /* Too far right, try next tab. */
       if (x >= p)
@@ -384,40 +387,36 @@ static void tab_render( Widget* tab, double bx, double by )
    if (tab->dat.tab.tabpos == 1)
       y += tab->h-TAB_HEIGHT;
 
+   /* Draw tab bar backgrund */
+   toolkit_drawRect( x, y, wdw->w, TAB_HEIGHT+2, &cGrey10, NULL);
+
    /* Iterate through tabs */
    for (i=0; i<tab->dat.tab.ntabs; i++) {
-      if (i!=tab->dat.tab.active) {
-         /* Draw border rect */
-         toolkit_drawOutline( x+1, y+1, tab->dat.tab.namelen[i] + 30,
-               TAB_HEIGHT-2, 1., tab_inactiveB, NULL );
-         /* Draw contents rect */
-         toolkit_drawRect( x, y, tab->dat.tab.namelen[i] + 30,
-               TAB_HEIGHT, tab_inactive, NULL );
-      }
-      else {
-         if (i==0)
-            toolkit_drawRect( x-1, y+0,
-                  1, TAB_HEIGHT+1, tab_active, NULL );
-         else if (i==tab->dat.tab.ntabs-1)
-            toolkit_drawRect( x+tab->dat.tab.namelen[i]+29, y+0,
-                  1, TAB_HEIGHT+1, tab_active, NULL ); 
-         toolkit_drawRect( x, y, tab->dat.tab.namelen[i] + 30,
-               TAB_HEIGHT, tab_active, NULL );
-      }
+
+      /* Draw border rect - first tab doesn't have left border */
+      /* toolkit_drawRect( 
+          (i == 0 ? x : x-2), 
+          y, 
+          (i == 0 ? 2 : 4 ) + tab->dat.tab.namelen[i] + (TAB_HPADDING * 2),
+          TAB_HEIGHT + 2, &cGrey10, NULL ); */
+
+      /* Draw contents rect */
+      toolkit_drawRect( 
+          x, y, tab->dat.tab.namelen[i] + (TAB_HPADDING * 2),
+          ( i == tab->dat.tab.active ? TAB_HEIGHT  + 2: TAB_HEIGHT ), 
+          ( i == tab->dat.tab.active ? tab_active : tab_inactive), 
+          NULL );
+      
       /* Draw text. */
-      gl_printRaw( tab->dat.tab.font, x + 15,
+      gl_printRaw( tab->dat.tab.font, x + TAB_HPADDING,
             y + (TAB_HEIGHT-tab->dat.tab.font->h)/2, &cFontWhite, -1.,
             tab->dat.tab.tabnames[i] );
 
       /* Go to next line. */
-      x += 30 + tab->dat.tab.namelen[i];
-      dx += 30 + tab->dat.tab.namelen[i];
+      x += (TAB_HPADDING * 2) + TAB_HMARGIN + tab->dat.tab.namelen[i];
+      dx += (TAB_HPADDING * 2) + TAB_HMARGIN + tab->dat.tab.namelen[i];
    }
 
-   if(dx < wdw->w){
-      /* Draw tab bar backgrund */
-      toolkit_drawRect( x, by+tab->y + 1, tab->w - dx, TAB_HEIGHT+2, &cGrey10, NULL);
-   }
 
 }
 
@@ -609,9 +608,9 @@ int window_tabWinGetBarWidth( const unsigned int wid, const char* tab )
    if (wgt == NULL)
       return 0;
 
-   w = 20;
+   w = 18;
    for (i=0; i<wgt->dat.tab.ntabs; i++)
-      w += 10 + wgt->dat.tab.namelen[i];
+      w += 18 + wgt->dat.tab.namelen[i];
 
    return w;
 }

--- a/src/tk/widget/tabwin.c
+++ b/src/tk/widget/tabwin.c
@@ -608,9 +608,9 @@ int window_tabWinGetBarWidth( const unsigned int wid, const char* tab )
    if (wgt == NULL)
       return 0;
 
-   w = 18;
+   w = (TAB_HMARGIN + TAB_HPADDING);
    for (i=0; i<wgt->dat.tab.ntabs; i++)
-      w += 18 + wgt->dat.tab.namelen[i];
+      w += (TAB_HMARGIN + TAB_HPADDING) + wgt->dat.tab.namelen[i] + (TAB_HPADDING);
 
    return w;
 }

--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -1329,7 +1329,7 @@ void window_render( Window *w )
       y  += wgt->y;
       wid = wgt->w;
       hei = wgt->h;
-      toolkit_drawOutline( x, y, wid, hei, 3, &cBlack, NULL );
+      toolkit_drawOutline( x, y, wid, hei, 3, &cGrey30, NULL );
    }
 }
 


### PR DESCRIPTION
- Simplify tab button logic
- Simplify widget outlines and make highlight color lighter
- Fix tab width calculation issue
- Change image widths in map_system from 64 to 96
- Fix input box alignment on tab windows, remove one border from the input boxes, harmonize border with widget highlight, lighten outline
- Use define'd variables for tab sizes 
- Fix text input color (green-on-black instead of black-on-white), which also fixes  associated text outline glitch
- Removed mass/CPU bar outlines and expand their height
- Fix tab background logic for non-bottomed tab bars

![1604165673](https://user-images.githubusercontent.com/2954343/97785831-e6161180-1b7d-11eb-819f-4b2958098e6c.png)
![1604165662](https://user-images.githubusercontent.com/2954343/97785832-e6161180-1b7d-11eb-9d3c-b9b50e9f5e53.png)
![1604165637](https://user-images.githubusercontent.com/2954343/97785833-e6aea800-1b7d-11eb-864c-73007d0d8be4.png)
![1604165161](https://user-images.githubusercontent.com/2954343/97785834-e6aea800-1b7d-11eb-9c16-101549bbeb81.png)
![1604165154](https://user-images.githubusercontent.com/2954343/97785835-e6aea800-1b7d-11eb-8ee2-2c19335f9157.png)



