### PR TITLE
Refinement of ids1024's hidpi branch (CAUTION)

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -248,18 +248,19 @@ void conf_setAudioDefaults (void)
 void conf_setVideoDefaults (void)
 {
    int w, h, f;
+   SDL_DisplayMode resolution;
 
    /* More complex resolution handling. */
    f = 0;
-   if ((gl_screen.desktop_w > 0) && (gl_screen.desktop_h > 0)) {
+   if (SDL_GetCurrentDisplayMode( 0, &resolution ) == 0) {
       /* Try higher resolution. */
       w = RESOLUTION_W_DEFAULT;
       h = RESOLUTION_H_DEFAULT;
 
       /* Fullscreen and fit everything onscreen. */
-      if ((gl_screen.desktop_w <= w) || (gl_screen.desktop_h <= h)) {
-         w = gl_screen.desktop_w;
-         h = gl_screen.desktop_h;
+      if ((resolution.w <= w) || (resolution.h <= h)) {
+         w = resolution.w;
+         h = resolution.h;
          f = FULLSCREEN_DEFAULT;
       }
    }

--- a/src/naev.c
+++ b/src/naev.c
@@ -801,7 +801,7 @@ void naev_resize (void)
       return;
 
    /* Resize the GL context, etc. */
-   gl_resize( w, h );
+   gl_resize();
 
    /* Regenerate the background stars. */
    if (cur_system != NULL)

--- a/src/naev.c
+++ b/src/naev.c
@@ -244,15 +244,6 @@ int main( int argc, char** argv )
       return -1;
    }
 
-   /* Get desktop dimensions. */
-   SDL_DisplayMode current;
-   if ( SDL_GetCurrentDisplayMode( 0, &current ) ) {
-      ERR( _( "Unable to get display mode: %s" ), SDL_GetError() );
-      return -1;
-   }
-   gl_screen.desktop_w = current.w;
-   gl_screen.desktop_h = current.h;
-
    /* We'll be parsing XML. */
    LIBXML_TEST_VERSION
    xmlInitParser();

--- a/src/naev.c
+++ b/src/naev.c
@@ -793,6 +793,9 @@ void naev_resize (void)
    int w, h;
    SDL_GL_GetDrawableSize( gl_screen.window, &w, &h );
 
+   /* Update options menu, if open. (Never skip, in case the fullscreen mode alone changed.) */
+   opt_resize();
+
    /* Nothing to do. */
    if ((w == gl_screen.rw) && (h == gl_screen.rh))
       return;
@@ -823,9 +826,6 @@ void naev_resize (void)
 
    /* Reposition main menu, if open. */
    menu_main_resize();
-
-   /* Update options menu, if open. */
-   opt_resize();
 }
 
 /*
@@ -833,43 +833,7 @@ void naev_resize (void)
  */
 void naev_toggleFullscreen (void)
 {
-   int w, h, mode;
-   SDL_DisplayMode current;
-
-   /* @todo Remove code duplication between this and opt_videoSave */
-   if (conf.fullscreen) {
-      conf.fullscreen = 0;
-      /* Restore windowed mode. */
-      SDL_SetWindowFullscreen( gl_screen.window, 0 );
-
-      SDL_SetWindowSize( gl_screen.window, conf.width, conf.height );
-      naev_resize();
-      SDL_SetWindowPosition( gl_screen.window,
-            SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED );
-
-      return;
-   }
-
-   conf.fullscreen = 1;
-
-   if (conf.modesetting) {
-      mode = SDL_WINDOW_FULLSCREEN;
-
-      SDL_GetWindowDisplayMode( gl_screen.window, &current );
-
-      current.w = conf.width;
-      current.h = conf.height;
-
-      SDL_SetWindowDisplayMode( gl_screen.window, &current );
-   }
-   else
-      mode = SDL_WINDOW_FULLSCREEN_DESKTOP;
-
-   SDL_SetWindowFullscreen( gl_screen.window, mode );
-
-   SDL_GetWindowSize( gl_screen.window, &w, &h );
-   if ((w != conf.width) || (h != conf.height))
-      naev_resize();
+   opt_setVideoMode( conf.width, conf.height, !conf.fullscreen, 0 );
 }
 
 

--- a/src/naev.c
+++ b/src/naev.c
@@ -791,7 +791,7 @@ void naev_resize (void)
 {
    /* Auto-detect window size. */
    int w, h;
-   SDL_GetWindowSize( gl_screen.window, &w, &h );
+   SDL_GL_GetDrawableSize( gl_screen.window, &w, &h );
 
    /* Nothing to do. */
    if ((w == gl_screen.rw) && (h == gl_screen.rh))

--- a/src/naev.c
+++ b/src/naev.c
@@ -640,11 +640,12 @@ void loadscreen_render( double done, const char *msg )
    /* Draw text. */
    gl_printRaw( &gl_defFont, x, y + h + 3., &cFontGreen, -1., msg );
 
-   /* Flip buffers. */
-   SDL_GL_SwapWindow( gl_screen.window );
-
    /* Get rid of events again. */
    while (SDL_PollEvent(&event));
+
+   /* Flip buffers. HACK: Also try to catch a late-breaking resize from the WM (...or a crazy user?). */
+   SDL_GL_SwapWindow( gl_screen.window );
+   naev_resize();
 }
 
 

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -303,6 +303,7 @@ static int gl_setupAttributes (void)
 /**
  * @brief Tries to apply the configured display mode to the window.
  *
+ *    @note Caller is responsible for calling gl_resize/naev_resize afterward.
  *    @return 0 on success.
  */
 int gl_setupFullscreen (void)
@@ -577,7 +578,7 @@ int gl_init (void)
    gl_defState();
 
    /* Handles resetting the viewport and scaling, rw/rh are set in createWindow. */
-   gl_resize( gl_screen.rw, gl_screen.rh );
+   gl_resize();
 
    /* Finishing touches. */
    glClear( GL_COLOR_BUFFER_BIT ); /* must clear the buffer first */
@@ -609,16 +610,13 @@ int gl_init (void)
 
 /**
  * @brief Handles a window resize and resets gl_screen parameters.
- *
- *    @param w New real/drawable width.
- *    @param h New real/drawable height.
  */
-void gl_resize( int w, int h )
+void gl_resize (void)
 {
-   glViewport( 0, 0, w, h );
+   SDL_GetWindowSize(gl_screen.window, &gl_screen.w, &gl_screen.h);
+   SDL_GL_GetDrawableSize(gl_screen.window, &gl_screen.rw, &gl_screen.rh);
 
-   gl_screen.rw = w;
-   gl_screen.rh = h;
+   glViewport( 0, 0, gl_screen.rw, gl_screen.rh );
 
    /* Reset scaling. */
    gl_screen.scale = 1./conf.scalefactor;

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -525,17 +525,11 @@ static int gl_hint (void)
 int gl_init (void)
 {
    unsigned int flags;
-   int dw, dh;
    GLuint VaoId;
 
    /* Defaults. */
-   /* desktop_w and desktop_h get set in naev.c when initializing. */
-   dw = gl_screen.desktop_w;
-   dh = gl_screen.desktop_h;
    memset( &gl_screen, 0, sizeof(gl_screen) );
    flags  = SDL_WINDOW_OPENGL;
-   gl_screen.desktop_w = dw;
-   gl_screen.desktop_h = dh;
 
    /* Load configuration. */
 

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -374,8 +374,6 @@ static int gl_createWindow( unsigned int flags )
 
    /* Finish getting attributes. */
    SDL_GL_GetAttribute( SDL_GL_DEPTH_SIZE, &gl_screen.depth );
-   gl_screen.rw = SCREEN_W;
-   gl_screen.rh = SCREEN_H;
    gl_activated = 1; /* Opengl is now activated. */
 
    return 0;
@@ -457,23 +455,23 @@ static int gl_defState (void)
 
 
 /**
- * @brief Checks to see if window needs to handle scaling.
+ * @brief Sets up dimensions in gl_screen, including scaling as needed.
  *
  *    @return 0 on success.
  */
 static int gl_setupScaling (void)
 {
    double scalew, scaleh;
-   int drawable_w, drawable_h, window_w, window_h;
 
+   /* Get the basic dimensions from SDL2. */
+   SDL_GetWindowSize(gl_screen.window, &gl_screen.w, &gl_screen.h);
+   SDL_GL_GetDrawableSize(gl_screen.window, &gl_screen.rw, &gl_screen.rh);
    /* Calculate scale factor, if OS has native HiDPI scaling. */
-   SDL_GL_GetDrawableSize(gl_screen.window, &drawable_w, &drawable_h);
-   SDL_GetWindowSize(gl_screen.window, &window_w, &window_h);
-   gl_screen.dwscale = (double)window_w / (double)drawable_w;
-   gl_screen.dhscale = (double)window_h / (double)drawable_h;
+   gl_screen.dwscale = (double)gl_screen.w / (double)gl_screen.rw;
+   gl_screen.dhscale = (double)gl_screen.h / (double)gl_screen.rh;
 
    /* Combine scale factor from OS with the one in Naev's config */
-   gl_screen.scale *= fmax(gl_screen.dwscale, gl_screen.dhscale);
+   gl_screen.scale = fmax(gl_screen.dwscale, gl_screen.dhscale) / conf.scalefactor;
 
    /* New window is real window scaled. */
    gl_screen.nw = (double)gl_screen.rw * gl_screen.scale;
@@ -613,15 +611,8 @@ int gl_init (void)
  */
 void gl_resize (void)
 {
-   SDL_GetWindowSize(gl_screen.window, &gl_screen.w, &gl_screen.h);
-   SDL_GL_GetDrawableSize(gl_screen.window, &gl_screen.rw, &gl_screen.rh);
-
-   glViewport( 0, 0, gl_screen.rw, gl_screen.rh );
-
-   /* Reset scaling. */
-   gl_screen.scale = 1./conf.scalefactor;
-
    gl_setupScaling();
+   glViewport( 0, 0, gl_screen.rw, gl_screen.rh );
    gl_setDefViewport( 0, 0, gl_screen.nw, gl_screen.nh );
    gl_defViewport();
 

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -424,8 +424,7 @@ static int gl_getGLInfo (void)
    intel_vendor = !!(nstrcasestr(vendor, "Intel") != NULL);
 
    /* Debug happiness */
-   DEBUG(_("OpenGL Window Created: %dx%d@%dbpp %s"), SCREEN_W, SCREEN_H, gl_screen.depth,
-         gl_has(OPENGL_FULLSCREEN)?_("fullscreen"):_("window"));
+   DEBUG(_("OpenGL Drawable Created: %dx%d@%dbpp"), gl_screen.rw, gl_screen.rh, gl_screen.depth);
    DEBUG(_("r: %d, g: %d, b: %d, a: %d, db: %s, fsaa: %d, tex: %d"),
          gl_screen.r, gl_screen.g, gl_screen.b, gl_screen.a,
          gl_has(OPENGL_DOUBLEBUF) ? _("yes") : _("no"),
@@ -545,8 +544,6 @@ int gl_init (void)
    memset( &gl_screen, 0, sizeof(gl_screen) );
 
    flags = SDL_WINDOW_OPENGL | gl_getFullscreenMode();
-   if (conf.fullscreen)
-      gl_screen.flags |= OPENGL_FULLSCREEN;
 
    /* Initializes Video */
    if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) {

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -71,6 +71,8 @@ typedef struct glInfo_ {
    double scale; /**< Scale factor. */
    double wscale; /**< Width scale factor. */
    double hscale; /**< Height scale factor. */
+   double dwscale; /**< Drawable height scale factor. */
+   double dhscale; /**< Drawable width scale factor. */
    double mxscale; /**< Mouse X scale factor. */
    double myscale; /**< Mouse y scale factor. */
    int depth; /**< Depth in bpp */

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -47,7 +47,6 @@
 /*
  * Contains info about the opengl screen
  */
-#define OPENGL_FULLSCREEN  (1<<0) /**< Fullscreen. */
 #define OPENGL_DOUBLEBUF   (1<<1) /**< Doublebuffer. */
 #define OPENGL_VSYNC       (1<<2) /**< Sync to monitor vertical refresh rate. */
 #define gl_has(f)    (gl_screen.flags & (f)) /**< Check for the flag */

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -127,6 +127,7 @@ void gl_screenToWindowPos( int *wx, int *wy, int sx, int sy );
 void gl_viewport( int x, int y, int w, int h );
 void gl_defViewport (void);
 void gl_setDefViewport( int x, int y, int w, int h );
+int gl_setupFullscreen (void);
 
 
 /*

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -55,8 +55,6 @@
  * @brief Stores data about the current opengl environment.
  */
 typedef struct glInfo_ {
-   int desktop_w; /**< Desktop width. */
-   int desktop_h; /**< Desktop height. */
    int x; /**< X offset of window viewport. */
    int y; /**< Y offset of window viewport. */
    /* Viewport considers x/y offset. */

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -109,7 +109,7 @@ extern gl_Matrix4 gl_view_matrix;
  */
 int gl_init (void);
 void gl_exit (void);
-void gl_resize( int w, int h );
+void gl_resize (void);
 
 
 /*

--- a/src/options.c
+++ b/src/options.c
@@ -1250,10 +1250,11 @@ static void opt_video( unsigned int wid )
    y -= 30;
    SDL_DisplayMode mode;
    int k;
-   int n = SDL_GetNumDisplayModes( 0 );
+   int display_index = SDL_GetWindowDisplayIndex( gl_screen.window );
+   int n = SDL_GetNumDisplayModes( display_index );
    j = 1;
    for (i=0; i<n; i++) {
-      SDL_GetDisplayMode( 0, i, &mode  );
+      SDL_GetDisplayMode( display_index, i, &mode  );
       if ((mode.w == conf.width) && (mode.h == conf.height))
          j = 0;
    }
@@ -1266,7 +1267,7 @@ static void opt_video( unsigned int wid )
       nres     = 1;
    }
    for (i=0; i<n; i++) {
-      SDL_GetDisplayMode( 0, i, &mode  );
+      SDL_GetDisplayMode( display_index, i, &mode  );
       res[ nres ] = malloc(16);
       nsnprintf( res[ nres ], 16, "%dx%d", mode.w, mode.h );
 

--- a/src/options.c
+++ b/src/options.c
@@ -1403,7 +1403,7 @@ static int opt_videoSave( unsigned int wid, char *str )
    SDL_DisplayMode current;
 
    changed = 0;
-   SDL_GetWindowSize( gl_screen.window, &rw, &rh );
+   SDL_GL_GetDrawableSize( gl_screen.window, &rw, &rh );
    SDL_GetWindowDisplayMode( gl_screen.window, &current );
    mode = (conf.modesetting) ?
          SDL_WINDOW_FULLSCREEN : SDL_WINDOW_FULLSCREEN_DESKTOP;

--- a/src/options.h
+++ b/src/options.h
@@ -10,6 +10,7 @@
 
 void opt_menu (void);
 void opt_resize (void);
+int opt_setVideoMode( int w, int h, int fullscreen, int confirm );
 
 
 #endif /* OPTIONS_H */


### PR DESCRIPTION
[Rebased 2020-11-05]
At this point, I believe all the major issues are sorted, but it's going to take more testing to be sure.

Potential gotcha which is not a bug: the dimensions for windowed modes will now be "screen coordinates" (so if your scale factor is 2, "1600x900" gives you 3200px x 1800px. This is the convention adopted by WM's/compositors/SDL2 so that the results are sane when one drags a window between displays with different scale factors.

This PR depends on a gross hack at the end of gl_setupFullscreen. Without it, early init (load screen and nebula generation) will misunderstand the window/drawable size. The basic issue is that SDL2 (and the desktop compositor) might not immediately size our window the way we asked. To get SDL2 to process a resize, we must pump events and trigger the internal Wayland_HandlePendingResize function via SDL_GL_SwapWindow. (A comment in SDL2 says "Wayland-EGL forbids drawing calls in-between SwapBuffers and wl_egl_window_resize".)

This PR does not include the Windows/Mac stuff I mentioned in #970 comments. AFAIK, testing those platforms is the main thing left to do. I can add speculative platform-specific stuff and log whether SDL2 reports SDL_HINT_VIDEO_HIGHDPI_DISABLED -- that's about it.