### PR TITLE
backport hidpi fixes that can already benefit mainline

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1182,7 +1182,7 @@ static void input_mouseMove( SDL_Event* event )
 static void input_clickevent( SDL_Event* event )
 {
    unsigned int pid;
-   int mx, my, mxr, myr, pntid, jpid, astid, fieid;
+   int mx, my, pntid, jpid, astid, fieid;
    int rx, ry, rh, rw, res;
    int autonav;
    double x, y, zoom, px, py;
@@ -1255,16 +1255,13 @@ static void input_clickevent( SDL_Event* event )
       /* Fall-through and handle as a normal click. */
    }
 
-   /* Radar targeting requires raw coordinates. */
-   mxr = event->button.x;
-   myr = gl_screen.rh - event->button.y;
    gui_radarGetPos( &rx, &ry );
    gui_radarGetDim( &rw, &rh );
-   if ((mxr > rx) && (mxr <= rx + rw) && (myr > ry) && (myr <= ry + rh)) { /* Radar */
+   if ((mx > rx) && (mx <= rx + rw) && (my > ry) && (my <= ry + rh)) { /* Radar */
       zoom = 1.;
       gui_radarGetRes( &res );
-      x = (mxr - (rx + rw / 2.)) * res + px;
-      y = (myr - (ry + rh / 2.)) * res + py;
+      x = (mx - (rx + rw / 2.)) * res + px;
+      y = (my - (ry + rh / 2.)) * res + py;
       if (input_clickPos( event, x, y, zoom, 10. * res, 15. * res ))
          return;
    }

--- a/src/land.c
+++ b/src/land.c
@@ -915,7 +915,7 @@ void land_genWindows( int load, int changetab )
    regen = landed;
 
    /* Create window. */
-   if ((gl_screen.rw < 1024) || (gl_screen.rh < 768)) {
+   if (SCREEN_W < 1024 || SCREEN_H < 768) {
       w = -1; /* Fullscreen. */
       h = -1;
    }

--- a/src/nebula.c
+++ b/src/nebula.c
@@ -131,13 +131,9 @@ static int nebu_init_recursive( int iter )
       return -1;
    }
 
-   /* Special code to regenerate the nebula */
-   if ((nebu_w == -9) && (nebu_h == -9))
-      nebu_generate();
-
    /* Set expected sizes */
-   nebu_w  = SCREEN_W;
-   nebu_h  = SCREEN_H;
+   nebu_w  = gl_screen.rw;
+   nebu_h  = gl_screen.rh;
    if (gl_needPOT()) {
       nebu_pw = gl_pot(nebu_w);
       nebu_ph = gl_pot(nebu_h);
@@ -146,6 +142,10 @@ static int nebu_init_recursive( int iter )
       nebu_pw = nebu_w;
       nebu_ph = nebu_h;
    }
+
+   /* Special code to regenerate the nebula */
+   if ((nebu_w == -9) && (nebu_h == -9))
+      nebu_generate();
 
    /* Load each, checking for compatibility and padding */
    for (i=0; i<NEBULA_Z; i++) {
@@ -508,15 +508,10 @@ static int nebu_generate (void)
    float *nebu;
    const char *cache;
    char nebu_file[PATH_MAX];
-   int w,h;
    int ret;
 
    /* Warn user of what is happening. */
    loadscreen_render( 0.05, _("Generating Nebula (slow, run once)...") );
-
-   /* Get resolution to create at. */
-   w = SCREEN_W;
-   h = SCREEN_H;
 
    /* Try to make the dir first if it fails. */
    cache = nfile_cachePath();
@@ -524,15 +519,15 @@ static int nebu_generate (void)
    nfile_dirMakeExist( cache, NEBULA_PATH );
 
    /* Generate all the nebula backgrounds */
-   nebu = noise_genNebulaMap( w, h, NEBULA_Z, 5. );
+   nebu = noise_genNebulaMap( nebu_w, nebu_h, NEBULA_Z, 5. );
 
    /* Start saving - compression can take a bit. */
    loadscreen_render( 0.05, _("Compressing Nebula layers...") );
 
    /* Save each nebula as an image */
    for (i=0; i<NEBULA_Z; i++) {
-      nsnprintf( nebu_file, PATH_MAX, NEBULA_PATH_BG, w, h, i );
-      ret = saveNebula( &nebu[ i*w*h ], w, h, nebu_file );
+      nsnprintf( nebu_file, PATH_MAX, NEBULA_PATH_BG, nebu_w, nebu_h, i );
+      ret = saveNebula( &nebu[ i*nebu_w*nebu_h ], nebu_w, nebu_h, nebu_file );
       if (ret != 0)
          break; /* An error has happened */
    }

--- a/src/nlua_tk.c
+++ b/src/nlua_tk.c
@@ -304,7 +304,7 @@ static int tk_merchantOutfit( lua_State *L )
    }
 
    /* Create window. */
-   if ((gl_screen.rw < 1024) || (gl_screen.rh < 768)) {
+   if (SCREEN_W < 1024 || SCREEN_H < 768) {
       w = -1; /* Fullscreen. */
       h = -1;
    }


### PR DESCRIPTION
A few nasties can be reproduced without any hidpi patches -- just set an extreme config like width=3072; height=1728; scalefactor=2.4;
There's also some UI code which mixes an unscaled-distance threshold with a scaled-distance behavior. This is evil, and I've enforced some consistency, but it's an aesthetic judgment that the simplest correction (what I did) looks fine at all scales.
If we merge this I'll rebase https://github.com/naev/naev/pull/1336/