### PR TITLE
Point to new API link location

### DIFF
--- a/docs/lua/ldoc.ltp
+++ b/docs/lua/ldoc.ltp
@@ -39,7 +39,7 @@
           "https://github.com/naev/naev">Github</a></li>
           <li class="nav-item"><a class="nav-link" href=
           "https://github.com/naev/naev/wiki">Wiki</a></li>
-          <li class="nav-item"><a class="nav-link" href="https://discord.gg/nd2M5BR">Discord</a></li>
+          <li class="nav-item"><a class="nav-link" href="https://discord.com/invite/nd2M5BR">Discord</a></li>
           <li class="nav-item"><a class="nav-link" href="https://naev.org/api">Lua API</a></li>
         </ul>
       </div>

--- a/docs/lua/ldoc.ltp
+++ b/docs/lua/ldoc.ltp
@@ -40,7 +40,7 @@
           <li class="nav-item"><a class="nav-link" href=
           "https://github.com/naev/naev/wiki">Wiki</a></li>
           <li class="nav-item"><a class="nav-link" href="https://discord.gg/nd2M5BR">Discord</a></li>
-          <li class="nav-item"><a class="nav-link" href="http://api.naev.org">Lua API</a></li>
+          <li class="nav-item"><a class="nav-link" href="https://naev.org/api">Lua API</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Fixes an overlooked link in ldoc, and updates the discord invite link to discord.com (their new domain name).