### PR TITLE
Set "NSHighResolutionCapable" when building a Mac bundle.

### DIFF
--- a/extras/macos/Info.plist.in
+++ b/extras/macos/Info.plist.in
@@ -14,5 +14,7 @@
 	<string></string>
 	<key>CFBundleVersion</key>
 	<string>@VMAJOR@.@VMINOR@.@VREV@</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Warning: help needed from a Mac tester. I don't have one.
Based on the docs I've run across, this change is necessary and sufficient for our final app bundles to get the desired behavior from SDL_WINDOW_ALLOW_HIGHDPI.

On various forums, I've run into speculation about how the OS can cache Info.plist settings (making it harder to pick up an update) and what to do about it. If necessary, the command "defaults read org.naev.Naev" sounds like a reasonable way to check.