### PR TITLE
Support subprojects/luajit for Windows builds, at the expense of sanity.

### DIFF
--- a/subprojects/packagefiles/luajit/meson.build
+++ b/subprojects/packagefiles/luajit/meson.build
@@ -1,18 +1,47 @@
 project('luajit', 'c', version : '2.0.5', license : 'mit')
 
 # TODO: This is not ideal. We should translate the enough of the makefile to have Meson handle the build.
-run_command(
-    'make', '-C', meson.current_source_dir(), 'install',
-    check: true,
-    env: ['DESTDIR="' + (meson.current_source_dir() / 'out') + '"'])
-
 cc = meson.get_compiler('c')
-libs = cc.find_library(
-    'luajit-5.1',
-    dirs: meson.current_source_dir() / 'out/usr/local/lib',
-    static: true)
+
+env = ['DESTDIR="' + (meson.current_source_dir() / 'out') + '"']
+if meson.is_cross_build()
+    # Construct the compiler prefix, e.g. 'x86_64-w64-mingw32-'.
+    # FIXME: This is absolutely disgusting. I'm not sure whether to loathe myself or blame the Meson team.
+    cc_name_parts = cc.cmd_array()[0].split('/')[-1].split('\\')[-1].split('-')
+    cc_name_hyphen = ''
+    foreach cc_name_part: cc_name_parts
+        cc_name_prefix = cc_name_hyphen
+        cc_name_hyphen += cc_name_part + '-'
+    endforeach
+
+    env += ['CROSS=' + cc_name_prefix]
+    if host_machine.system() == 'darwin'
+        env += 'TARGET_SYS=Darwin'
+    elif host_machine.system() == 'linux'
+        env += 'TARGET_SYS=Linux'
+    elif host_machine.system() == 'windows'
+        env += 'TARGET_SYS=Windows'
+    endif
+endif
+
+run_command(
+    'make', '-C', meson.current_source_dir(), 'amalg',
+    check: true,
+    env: env)
+
+if host_machine.system() == 'windows'
+    libs = cc.find_library(
+        'lua51',
+        dirs: meson.current_source_dir() / 'src',
+	static: false)
+else
+    libs = cc.find_library(
+        'luajit',
+        dirs: meson.current_source_dir() / 'src',
+        static: true)
+endif
 
 luajit_dep = declare_dependency(
     dependencies: libs,
-    include_directories: include_directories('out/usr/local/include/luajit-2.0'),
+    include_directories: include_directories('src'),
     version: meson.project_version())


### PR DESCRIPTION
(Would be awesome if @nloewen  or @ProjectSynchro could review.)

Here's the reasoning, though I still hate it.
- LuaJIT's makefile's "install" target hardcodes binary names (e.g., "luajit" and not "luajit.exe"), so it fails on Windows. Since the directory structure is pretty flat, we can get away with making "amalg" (build everything but don't install into the prefix). The "install" step also renames the static library, though, so that name changes too.
- https://luajit.org/install.html explains that static linking isn't good enough on Windows (and also that the DLL name absolutly must be lua51.dll).
- A cross-compile via LuaJIT's makefile looks like "make CROSS=x86_64-w64-mingw32- TARGET_SYS=Windows". AFAIK, Meson provides no accessor for the value of "CROSS", and its general-purpose programming facilities are extremely limited, so I've resorted to this dumpster fire.

As a pre-existing comment points out, there is a better way because translating LuaJIT's Makefiles to Meson is a better way. Then again, that sounds like a lot to maintain outside their tree. I'm worried this patch might be the most practical way for now.