### PR TITLE
As suggested by @nloewen, use an environment object in luajit/meson.build.

### DIFF
--- a/subprojects/packagefiles/luajit/meson.build
+++ b/subprojects/packagefiles/luajit/meson.build
@@ -3,7 +3,7 @@ project('luajit', 'c', version : '2.0.5', license : 'mit')
 # TODO: This is not ideal. We should translate the enough of the makefile to have Meson handle the build.
 cc = meson.get_compiler('c')
 
-env = ['DESTDIR="' + (meson.current_source_dir() / 'out') + '"']
+env = environment()
 if meson.is_cross_build()
     # Construct the compiler prefix, e.g. 'x86_64-w64-mingw32-'.
     # FIXME: This is absolutely disgusting. I'm not sure whether to loathe myself or blame the Meson team.
@@ -14,13 +14,13 @@ if meson.is_cross_build()
         cc_name_hyphen += cc_name_part + '-'
     endforeach
 
-    env += ['CROSS=' + cc_name_prefix]
+    env.set('CROSS', cc_name_prefix)
     if host_machine.system() == 'darwin'
-        env += 'TARGET_SYS=Darwin'
+        env.set('TARGET_SYS', 'Darwin')
     elif host_machine.system() == 'linux'
-        env += 'TARGET_SYS=Linux'
+        env.set('TARGET_SYS', 'Linux')
     elif host_machine.system() == 'windows'
-        env += 'TARGET_SYS=Windows'
+        env.set('TARGET_SYS', 'Windows')
     endif
 endif
 


### PR DESCRIPTION
Also clean up the "PREFIX" bit, which was needed for "make install" but isn't for "make amalg".

I feel compelled to make fun of Meson for saying:

1. All objects are immutable!
2. You may add to env, an environment object, by calling env.set(...).

(even though  it's not actually a contradiction...)

I've been thinking about whether to leave it here. This guy has demonstrated that translating the whole luajit build to Meson isn't too daunting (though I'm not sure he covered all cases): https://github.com/franko/luajit
The idea is attractive because the current wrapped "make" builds in-tree, so it's easy to get into Big Trouble trying to do native builds and cross-compiles of the same repo. My understanding is that the pure Meson version would build out of tree and have no such problem.