### PR TITLE
Add a Windows app manifest that declares us HiDPI-aware. Really aware. The Doors of Perception are open.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,11 @@ stdout.txt
 *.mode1v3
 extras/.dirstamp
 extras/macos/Info.plist
-extras/resource.rc
 extras/steam/2fa/2fa.txt
 extras/steam/content
 extras/steam/output
+extras/windows/naev.exe.manifest
+extras/windows/resource.rc
 extras/windows/installer/bin
 dist/*
 dat/LANGUAGES

--- a/extras/windows/naev.exe.manifest.in
+++ b/extras/windows/naev.exe.manifest.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1"
+    manifestVersion="1.0">
+	<assemblyIdentity
+	    name="org.naev.Naev"
+	    version="@VMAJOR@.@VMINOR@.@VREV@.0"
+	    type="win32"/>
+	<asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+		<asmv3:windowsSettings
+		    xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+			<!-- Per Monitor V1 [OS >= Windows 8.1] -->
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+			<!-- Per Monitor V1 [OS >= Windows 10 Anniversary Update (1607, 10.0.14393, Redstone 1)] -->
+			<!-- Per Monitor V2 [OS >= Windows 10 Creators Update (1703, 10.0.15063, Redstone 2)] -->
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+</assembly>

--- a/extras/windows/resource.rc.in
+++ b/extras/windows/resource.rc.in
@@ -1,5 +1,7 @@
 #include <winresrc.h>
+#include <winuser.h>
 
+1 RT_MANIFEST "naev.exe.manifest"
 101 ICON DISCARDABLE "logo.ico"
 
 VS_VERSION_INFO VERSIONINFO

--- a/meson.build
+++ b/meson.build
@@ -192,8 +192,9 @@ if buildExec.disabled() == false
       windows = import('windows')
       icon = files('extras/logos/logo.ico')
       res_include = include_directories('extras/logos')
-      win_rc = configure_file(input: 'extras/resource.rc.in', output: 'resource.rc', configuration: config_data)
-      naev_source += windows.compile_resources(win_rc, depend_files: icon, include_directories: res_include)
+      win_manifest = configure_file(input: 'extras/windows/naev.exe.manifest.in', output: 'naev.exe.manifest', configuration: config_data)
+      win_rc = configure_file(input: 'extras/windows/resource.rc.in', output: 'resource.rc', configuration: config_data)
+      naev_source += windows.compile_resources(win_rc, depend_files: [win_manifest, icon], include_directories: res_include)
    endif
 
    shaders_c_gen = executable(

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -321,7 +321,7 @@ naev_SOURCES = \
 	weapon.h
 
 if HAVE_WINDRES
-naev_SOURCES += ../extras/windows/resource.rc
+nodist_naev_SOURCES = ../extras/windows/resource.rc
 CLEANFILES += ../extras/windows/naev.exe.manifest ../extras/windows/resource.rc
 ../extras/windows/naev.exe.manifest: ../extras/windows/resource.rc.in
 	../config.status -q --file=$@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,8 +5,6 @@ bin_PROGRAMS = naev
 AM_CFLAGS = $(NAEV_CFLAGS)
 AM_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\"
 CLEANFILES =
-MACOS_SOURCE =
-WINDOWS_RESOURCE =
 naev_LDADD = $(NAEV_LIBS) $(LIBINTL)
 naev_DEPENDENCIES = $(NAEV_DEPENDENCIES)
 
@@ -22,7 +20,7 @@ BUILT_SOURCES = shaders.gen.c shaders.gen.h
 endif
 
 
-CODE_SOURCE = \
+naev_SOURCES = \
 	ai.c \
 	array.c \
 	background.c \
@@ -323,16 +321,16 @@ CODE_SOURCE = \
 	weapon.h
 
 if HAVE_WINDRES
-WINDOWS_RESOURCE += ../extras/resource.rc
-../extras/resource.rc: ../extras/resource.rc.in
+naev_SOURCES += ../extras/windows/resource.rc
+CLEANFILES += ../extras/windows/naev.exe.manifest ../extras/windows/resource.rc
+../extras/windows/naev.exe.manifest: ../extras/windows/resource.rc.in
+	../config.status -q --file=$@
+../extras/windows/resource.rc: ../extras/windows/naev.exe.manifest ../extras/windows/resource.rc.in
 	../config.status -q --file=$@
 .rc.o:
 	@WINDRES@ -I../extras/logos $< -O coff $@
 endif
 
 if HAVE_MACOS
-MACOS_SOURCE += glue_macos.m
+naev_SOURCES += glue_macos.m
 endif
-
-naev_SOURCES = $(CODE_SOURCE) $(WINDOWS_RESOURCE) $(MACOS_SOURCE)
-CLEANFILES += $(WINDOWS_RESOURCE)


### PR DESCRIPTION
Also, I have no proof this crap is actually going to improve Windows users' experiences. 😭
But I've been through mountains of docs implying that (a correct version of) this is what we need for SDL_WINDOW_ALLOW_HIGHDPI to do its thing without extra OS-specific C code.

Although it's not strictly necessary, I figured this would be a good time to move resource.rc.in to extras/**windows**/ since it's irrelevant to everyone else.