### PR TITLE
Make size parameters to array_create/array_resize size_t. Fixes #1365.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -5,7 +5,7 @@
 
 #include "nstring.h"
 
-void *_array_create_helper(size_t e_size, int capacity)
+void *_array_create_helper(size_t e_size, size_t capacity)
 {
    if ( capacity <= 0 )
       capacity = 1;
@@ -19,7 +19,7 @@ void *_array_create_helper(size_t e_size, int capacity)
    return c->_array;
 }
 
-static void _array_resize_container(_private_container **c_, size_t e_size, int new_size)
+static void _array_resize_container(_private_container **c_, size_t e_size, size_t new_size)
 {
    assert( new_size >= 0 );
    _private_container *c = *c_;
@@ -37,7 +37,7 @@ static void _array_resize_container(_private_container **c_, size_t e_size, int 
    *c_ = c;
 }
 
-void _array_resize_helper(void **a, size_t e_size, int new_size)
+void _array_resize_helper(void **a, size_t e_size, size_t new_size)
 {
    _private_container *c = _array_private_container(*a);
    _array_resize_container(&c, e_size, new_size);

--- a/src/array.h
+++ b/src/array.h
@@ -56,8 +56,8 @@ typedef struct {
 #ifdef DEBUGGING
    int _sentinel;         /**< Sentinel for when debugging. */
 #endif
-   int _reserved;         /**< Number of elements reserved */
-   int _size;             /**< Number of elements in the array */
+   size_t _reserved;      /**< Number of elements reserved */
+   size_t _size;          /**< Number of elements in the array */
    /* The following check is fairly nasty and is here to handle cases
     * when being compiled with too old versions of gcc. Note that this
     * does lead to undefined behaviour, but at the current time it is
@@ -70,9 +70,9 @@ typedef struct {
 } _private_container;
 
 
-void *_array_create_helper(size_t e_size, int initial_size);
+void *_array_create_helper(size_t e_size, size_t initial_size);
 void *_array_grow_helper(void **a, size_t e_size);
-void _array_resize_helper(void **a, size_t e_size, int new_size);
+void _array_resize_helper(void **a, size_t e_size, size_t new_size);
 void _array_erase_helper(void **a, size_t e_size, void *first, void *last);
 void _array_shrink_helper(void **a, size_t e_size);
 void _array_free_helper(void *a);


### PR DESCRIPTION
This approach is good enough for the venerable reallocarray(), but could theoretically make underflow bugs harder to catch immediately.