### PR TITLE
poptask -> popsubtask

### DIFF
--- a/dat/ai/include/atk_util.lua
+++ b/dat/ai/include/atk_util.lua
@@ -58,9 +58,14 @@ function _atk_zigzag()
    local target = ai.target()
    local range  = ai.getweaprange(3)
 
-   -- Is there something to dodge?
-   if (not target:exists()) or (not ai.hasprojectile()) then
+   if (not target:exists()) then
       ai.poptask()
+      return
+   end
+
+   -- Is there something to dodge?
+   if (not ai.hasprojectile()) then
+      ai.popsubtask()
       return
    end
 
@@ -68,7 +73,7 @@ function _atk_zigzag()
 
    -- Are we ready to shoot?
    if dist < (1.1*range) then
-      ai.poptask()
+      ai.popsubtask()
       return
    end
 


### PR DESCRIPTION
Exiting from zigzag was accidentally causing exiting the attack task.
This had no impact usually because the pilot was re-initializing an other attack task.
but in missions, where the pilot is under manual control, the pilot just stayed idle.