### PR TITLE
Replace formatting _("%s credits") with a call to creditstring(). 

### DIFF
--- a/dat/missions/empire/collective/ec00.lua
+++ b/dat/missions/empire/collective/ec00.lua
@@ -36,7 +36,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("You see an Empire Lt. Commander who seems to be motioning you over to the counter.")
 misn_title = _("Collective Scout")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Find a scout last seen in the %s system")
 misn_desc[2] = _("Travel back to %s in %s")
@@ -96,7 +95,7 @@ function accept ()
 
    -- Mission details
    misn.setTitle(misn_title)
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    misn.setDesc( string.format(misn_desc[1],misn_nearby:name()))
 
    -- Flavour text and mini-briefing

--- a/dat/missions/empire/collective/ec01.lua
+++ b/dat/missions/empire/collective/ec01.lua
@@ -35,7 +35,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("You notice Lt. Commander Dimitri motioning for you to come over to him.")
 misn_title = _("Collective Espionage")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Scan the Collective systems for wireless communications")
 misn_desc[2] = _("Travel back to %s in %s")
@@ -86,7 +85,7 @@ function accept ()
    -- Mission details
    misn_desc[2] = misn_desc[2]:format(misn_base:name(), misn_base_sys:name())
    misn.setTitle(misn_title)
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    misn.setDesc(misn_desc[1])
    misn_marker1 = misn.markerAdd(targsys1, "low")
    misn_marker2 = misn.markerAdd(targsys2, "low")

--- a/dat/missions/empire/collective/ec02.lua
+++ b/dat/missions/empire/collective/ec02.lua
@@ -31,10 +31,11 @@
 ]]--
 
 require "missions/empire/common.lua"
+require "numstring.lua"
 
 bar_desc = _("You notice Lt. Commander Dimitri at one of the booths.")
 misn_title = _("Collective Espionage")
-misn_reward = _("700,000 credits")
+misn_reward = creditstring(700000) -- 700K
 misn_desc = {}
 misn_desc[1] = _("Land on %s in the %s system to monitor Collective communications")
 misn_desc[2] = _("Travel back to %s in %s")

--- a/dat/missions/empire/collective/ec03.lua
+++ b/dat/missions/empire/collective/ec03.lua
@@ -37,7 +37,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("You see Lt. Commander Dimitri at the bar as usual.")
 misn_title = _("Collective Distraction")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Go to draw the Collective's attention in the %s system")
 misn_desc[2] = _("Travel back to %s in %s")
@@ -91,7 +90,7 @@ function accept ()
 
       -- Mission details
       misn.setTitle(misn_title)
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
       misn.setDesc( string.format(misn_desc[1], misn_target_sys:name() ))
 
       tk.msg( title[1], string.format(text[2], commando_planet, commando_planet ) )

--- a/dat/missions/empire/collective/ec04.lua
+++ b/dat/missions/empire/collective/ec04.lua
@@ -37,7 +37,6 @@ require "numstring.lua"
 require "missions/empire/common.lua"
 
 misn_title = _("Collective Extraction")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Check for survivors on %s in %s")
 misn_desc[2] = _("Travel back to %s in %s")
@@ -90,7 +89,7 @@ function create ()
 
       -- Mission details
       misn.setTitle(misn_title)
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
       misn.setDesc( string.format(misn_desc[1], misn_target:name(), misn_target_sys:name() ))
       tk.msg( title[1], string.format(text[2], misn_target_sys:name(), misn_target:name()) )
       osd_msg[1] = osd_msg[1]:format(misn_target_sys:name())

--- a/dat/missions/empire/collective/ec05.lua
+++ b/dat/missions/empire/collective/ec05.lua
@@ -52,7 +52,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Dimitri should be around here, but you can't see him. You should probably look for him.")
 misn_title = _("Operation Black Trinity")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Arrest the ESS Trinity in %s")
 misn_desc[2] = _("Return to base at %s in %s")
@@ -138,7 +137,7 @@ function accept ()
 
    -- Mission details
    misn.setTitle(misn_title)
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    misn.setDesc( string.format(misn_desc[1], misn_target_sys:name() ))
    osd_msg[1] = osd_msg[1]:format(misn_target_sys:name())
    osd_msg[3] = osd_msg[3]:format(misn_base:name())

--- a/dat/missions/empire/emp_cargo00.lua
+++ b/dat/missions/empire/emp_cargo00.lua
@@ -30,7 +30,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("You see an Empire Lieutenant who seems to be looking at you.")
 misn_title = _("Empire Recruitment")
-misn_reward = _("%s credits")
 misn_desc = _("Deliver some parcels for the Empire to %s in %s.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -86,7 +85,7 @@ function accept ()
    -- Mission details
    reward = 30000
    misn.setTitle(misn_title)
-   misn.setReward( string.format(misn_reward, numstring(reward)) )
+   misn.setReward( creditstring(reward) )
    misn.setDesc( string.format(misn_desc,dest:name(),sys:name()))
 
    -- Flavour text and mini-briefing

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua
@@ -31,7 +31,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Soromid Long Distance Recruitment")
-misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Soromid Customs Central in the Oberon system")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -74,9 +73,9 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 500000
+   reward = 500000 -- 500K
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward)
+   misn.setReward(creditstring(reward))
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )
    misn.osdCreate(title[2], {misn_desc})
    -- Set up the goal

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo2.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo2.lua
@@ -31,7 +31,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Dvaered Long Distance Recruitment")
-misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Praxis in the Ogat system")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -74,9 +73,9 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 500000
+   reward = 500000 -- 500K
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward)
+   misn.setReward(creditstring(reward))
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )
    misn.osdCreate(title[2], {misn_desc})
    -- Set up the goal

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo3.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo3.lua
@@ -31,7 +31,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Za'lek Long Distance Recruitment")
-misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Gerhart Station in the Ganth system")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -74,9 +73,9 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 500000
+   reward = 500000 -- 500K
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward)
+   misn.setReward(creditstring(reward))
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )
    misn.osdCreate(title[2], {misn_desc})
    -- Set up the goal

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo4.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo4.lua
@@ -31,7 +31,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Frontier Long Distance Recruitment")
-misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to The Frontier Council in Gilligan's Light system")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -74,9 +73,9 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 500000
+   reward = 500000 -- 500K
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward)
+   misn.setReward(creditstring(reward))
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )
    misn.osdCreate(title[2], {misn_desc})
    -- Set up the goal

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo5.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo5.lua
@@ -31,7 +31,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Sirius Long Distance Recruitment")
-misn_reward = _("500,000 credits")
 misn_desc = _("Deliver a shipping diplomat for the Empire to Madria in the Esker system")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -74,9 +73,9 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 500000
+   reward = 500000 -- 500K
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward)
+   misn.setReward(creditstring(reward))
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )
    misn.osdCreate(title[2], {misn_desc})
    -- Set up the goal

--- a/dat/missions/empire/longdistanceshipping/emp_longdistancecargo6.lua
+++ b/dat/missions/empire/longdistanceshipping/emp_longdistancecargo6.lua
@@ -31,7 +31,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("Lieutenant Czesc from the Empire Armada Shipping Division is sitting at the bar.")
 misn_title = _("Empire Long Distance Recruitment")
-misn_reward = _("50,000 credits")
 misn_desc = _("Deliver Lieutenant Czesc to Halir in the Gamma Polaris system")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -77,9 +76,9 @@ function accept ()
    misn.accept()
   
    -- Description is visible in OSD and the onboard computer, it shouldn't be too long either.
-   reward = 50000
+   reward = 50000 -- 500K
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward)
+   misn.setReward(creditstring(reward))
    misn.setDesc( string.format( misn_desc, targetworld:name(), targetworld_sys:name() ) )
    misn.osdCreate(title[2], {misn_desc})
    -- Set up the goal

--- a/dat/missions/empire/shipping/es00.lua
+++ b/dat/missions/empire/shipping/es00.lua
@@ -32,7 +32,6 @@ require "missions/empire/common.lua"
 
 bar_desc = _("You see an Empire Commander. He seems to have noticed you.")
 misn_title = _("Prisoner Exchange")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Go to %s in the %s system to exchange prisoners with the FLF")
 misn_desc[2] = _("Return to %s in the %s system to report what happened")
@@ -87,7 +86,7 @@ function accept ()
    misn_stage = 0
    reward = 500000
    misn.setTitle(misn_title)
-   misn.setReward( string.format(misn_reward, numstring(reward)) )
+   misn.setReward( creditstring(reward) )
    misn.setDesc( string.format(misn_desc[1], dest:name(), destsys:name()))
 
    -- Flavour text and mini-briefing

--- a/dat/missions/empire/shipping/es01.lua
+++ b/dat/missions/empire/shipping/es01.lua
@@ -32,7 +32,6 @@ require "missions/empire/common.lua"
 -- Mission details
 bar_desc = _("You see Commander Soldner who is expecting you.")
 misn_title = _("Empire Shipping Delivery")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Pick up a package at %s in the %s system")
 misn_desc[2] = _("Deliver the package to %s in the %s system") 
@@ -94,7 +93,7 @@ function accept ()
    misn_stage = 0
    reward = 500000
    misn.setTitle(misn_title)
-   misn.setReward( string.format(misn_reward, numstring(reward)) )
+   misn.setReward( creditstring(reward) )
    misn.setDesc( string.format(misn_desc[1], pickup:name(), pickupsys:name()))
 
    -- Flavour text and mini-briefing

--- a/dat/missions/empire/shipping/es02.lua
+++ b/dat/missions/empire/shipping/es02.lua
@@ -42,7 +42,6 @@ require "missions/empire/common.lua"
 -- Mission details
 bar_desc = _("Commander Soldner is waiting for you.")
 misn_title = _("Empire VIP Rescue")
-misn_reward = _("%s credits")
 misn_desc = {}
 misn_desc[1] = _("Rescue the VIP from a transport ship in the %s system")
 misn_desc[2] = _("Return to %s in the %s system with the VIP")
@@ -103,7 +102,7 @@ function accept ()
    misn_stage = 0
    reward = 750000
    misn.setTitle(misn_title)
-   misn.setReward( string.format( misn_reward, numstring(reward) ) )
+   misn.setReward( creditstring(reward) )
    misn.setDesc( string.format( misn_desc[1], destsys:name() ) )
 
    -- Flavour text and mini-briefing

--- a/dat/missions/flf/dvk/flf_dvk04.lua
+++ b/dat/missions/flf/dvk/flf_dvk04.lua
@@ -59,7 +59,6 @@ pay_text[1] = _([[When you return, Benito hands you the agreed-upon payment, aft
 
 misn_title = _("Diversion from Haleb")
 misn_desc = _("A covert operation is being conducted in Haleb. You are to create a diversion from this operation by wreaking havoc in the nearby %s system.")
-misn_reward = _("%s credits")
 
 npc_name = _("Benito")
 npc_desc = _("Benito looks in your direction and waves you over. It seems your services are needed again.")
@@ -92,7 +91,7 @@ function accept ()
       misn.setTitle( misn_title )
       misn.setDesc( misn_desc:format( missys:name() ) )
       marker = misn.markerAdd( missys, "plot" )
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
 
       dv_attention = 0
       job_done = false

--- a/dat/missions/flf/dvk/flf_dvk05.lua
+++ b/dat/missions/flf/dvk/flf_dvk05.lua
@@ -47,8 +47,6 @@ text[2] = _([["Thanks! As always, you're a life saver. Well, for us, that is." B
 pay_text = {}
 pay_text[1] = _([[Benito seems pleased upon your return to hear that the mission was successful. "Excellent," she says. "It's kind of an annoying detour, I know, but I appreciate that your help very much. I'll try to have a better mission for you next time, eh?" You both grin and exchange some pleasantries before parting ways.]])
 
-misn_rwrd = _("%s credits")
-    
 npc_name = _("Benito")
 npc_desc = _("Benito is shuffling around papers and overall appearing a bit stressed. Perhaps you should see what is the matter.")
 
@@ -88,7 +86,7 @@ function accept ()
 
       misn.setTitle( misn_title[level]:format( missys:name() ) )
       marker = misn.markerAdd( missys, "high" )
-      misn.setReward( misn_rwrd:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
 
       pirate_ships_left = 0
       job_done = false

--- a/dat/missions/flf/flf_diversion.lua
+++ b/dat/missions/flf/flf_diversion.lua
@@ -36,7 +36,6 @@ require "missions/flf/flf_common.lua"
 
 -- localization stuff
 misn_title  = _("FLF: Diversion in %s")
-misn_reward = _("%s credits")
 
 success_text = {}
 success_text[1] = _("You receive a transmission from an FLF officer saying that the operation has completed, and you can now return to the base.")
@@ -76,7 +75,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( missys:name() ) )
    misn.setDesc( misn_desc:format( missys:name() ) )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 

--- a/dat/missions/flf/flf_rogue.lua
+++ b/dat/missions/flf/flf_rogue.lua
@@ -36,7 +36,6 @@ require "fleethelper.lua"
 require "missions/flf/flf_common.lua"
 
 misn_title  = _("FLF: Rogue %s in %s")
-misn_reward = _("%s credits")
 
 text = {}
 text[1] = _("You are thanked for eliminating the traitorous scum and handed a credit chip with the agreed-upon payment.")
@@ -103,7 +102,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( misn_level[level], missys:name() ) )
    misn.setDesc( desc )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 

--- a/dat/missions/neutral/diy-nerds.lua
+++ b/dat/missions/neutral/diy-nerds.lua
@@ -23,6 +23,7 @@
       AUTHOR: thilo <thilo@thiloernst.de>
    --]]
 
+require "numstring.lua"
 
 
 -- Bar information, describes how the NPC appears in the bar
@@ -30,7 +31,7 @@ bar_desc = _("You see a bunch of guys and gals, excitedly whispering over some p
 
 -- Mission details.
 misn_title = _("DIY Nerds") 
-misn_reward = _("20,000 credits")
+misn_reward = creditstring(20000) -- 20K
 misn_desc = _("Cart some nerds to their contest, and back.")
 
 title = {}

--- a/dat/missions/neutral/nebu_satellite.lua
+++ b/dat/missions/neutral/nebu_satellite.lua
@@ -35,7 +35,6 @@ require "missions/neutral/common.lua"
 bar_desc = _("A bunch of scientists seem to be chattering nervously among themselves.")
 mtitle = {}
 mtitle[1] = _("Nebula Satellite")
-misn_reward = _("%s credits")
 mdesc = {}
 mdesc[1] = _("Go to the %s system to launch the probe.")
 mdesc[2] = _("Drop off the scientists at %s in the %s system.")
@@ -103,7 +102,7 @@ function accept ()
 
    -- Set up mission information
    misn.setTitle( mtitle[1] )
-   misn.setReward( string.format( misn_reward, numstring(credits) ) )
+   misn.setReward( creditstring(credits) )
    misn.setDesc( string.format( mdesc[1], satellite_sys:name() ) )
    misn_marker = misn.markerAdd( satellite_sys, "low" )
 

--- a/dat/missions/neutral/patrol.lua
+++ b/dat/missions/neutral/patrol.lua
@@ -63,7 +63,6 @@ abandon_text[1] = _("You are sent a message informing you that landing in the mi
 
 -- Mission details
 misn_title  = _("Patrol of the %s System")
-misn_reward = _("%s credits")
 misn_desc   = _("Patrol specified points in the %s system, eliminating any hostiles you encounter.")
 
 -- Messages
@@ -159,7 +158,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( missys:name() ) )
    misn.setDesc( misn_desc:format( missys:name() ) )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 

--- a/dat/missions/neutral/pirbounty_dead.lua
+++ b/dat/missions/neutral/pirbounty_dead.lua
@@ -95,7 +95,6 @@ misn_title[2] = _("Small Dead or Alive Bounty in %s")
 misn_title[3] = _("Moderate Dead or Alive Bounty in %s")
 misn_title[4] = _("High Dead or Alive Bounty in %s")
 misn_title[5] = _("Dangerous Dead or Alive Bounty in %s")
-misn_reward = _("%s credits")
 misn_desc   = _("The pirate known as %s was recently seen in the %s system. %s authorities want this pirate dead or alive.")
 
 -- Messages
@@ -161,7 +160,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title[level]:format( missys:name() ) )
    misn.setDesc( misn_desc:format( name, missys:name(), paying_faction:name() ) )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 

--- a/dat/missions/neutral/race1.lua
+++ b/dat/missions/neutral/race1.lua
@@ -58,7 +58,6 @@ NPCname = _("A laid back person")
 NPCdesc = _("You see a laid back person, who appears to be one of the locals, looking around the bar.")
 
 misndesc = _("You're participating in a race!")
-misnreward = _("%s credits")
 
 OSDtitle = _("Racing Skills 1")
 OSD = {}
@@ -100,7 +99,7 @@ function accept ()
       misn.accept()
       OSD[4] = string.format(OSD[4], curplanet:name())
       misn.setDesc(misndesc)
-      misn.setReward(misnreward:format(numstring(credits)))
+      misn.setReward(creditstring(credits))
       misn.osdCreate(OSDtitle, OSD)
       tk.msg(title[2], string.format(text[2], curplanet:name(), curplanet:name()))
       hook.takeoff("takeoff")

--- a/dat/missions/neutral/race2.lua
+++ b/dat/missions/neutral/race2.lua
@@ -70,7 +70,6 @@ NPCname = _("A laid back person")
 NPCdesc = _("You see a laid back person, who appears to be one of the locals, looking around the bar, apparently in search of a suitable pilot.")
 
 misndesc = _("You're participating in another race!")
-misnreward = _("%s credits")
 
 OSDtitle = _("Racing Skills 2")
 OSD = {}
@@ -124,7 +123,7 @@ function accept ()
          credits = credits_hard
          tk.msg(title[6], text[6])
       end
-      misn.setReward(misnreward:format(numstring(credits)))
+      misn.setReward(creditstring(credits))
       hook.takeoff("takeoff")
       else
       tk.msg(refusetitle, refusetext)

--- a/dat/missions/neutral/seek_n_destroy.lua
+++ b/dat/missions/neutral/seek_n_destroy.lua
@@ -155,7 +155,6 @@ bar_desc = _("This person might be an outlaw, a pirate, or even worse, a bounty 
 
 -- Mission details
 misn_title  = _("Seek And Destroy Mission, starting in %s")
-misn_reward = _("%s credits")
 misn_desc   = _("The %s pilot known as %s is wanted dead or alive by %s authorities. He was last seen in the %s system.")
 
 function create ()
@@ -226,7 +225,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( mysys[1]:name() ) )
    misn.setDesc( misn_desc:format( target_faction:name(), name, paying_faction:name(), mysys[1]:name() ) )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( mysys[1], "computer" )
 
    -- Store the table

--- a/dat/missions/neutral/sightseeing.lua
+++ b/dat/missions/neutral/sightseeing.lua
@@ -72,7 +72,6 @@ pay_s_nolux_text[3] = _("Most of the passengers enjoyed your tour, but one parti
 
 -- Mission details
 misn_title  = _("Sightseeing in the %s System")
-misn_reward = _("%s credits")
 misn_desc   = _("Several passengers wish to go off-world and go on a sightseeing tour. Navigate to specified attractions in the %s system.")
 
 -- Messages
@@ -152,7 +151,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( missys:name() ) )
    misn.setDesc( misn_desc:format( missys:name() ) )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 
@@ -161,7 +160,7 @@ function accept ()
    if player.pilot():ship():class() ~= "Luxury Yacht" then
       if tk.yesno( nolux_title, nolux_text:format( numstring(credits_nolux) ) ) then
          nolux_known = true
-         misn.setReward( misn_reward:format( numstring( credits_nolux ) ) )
+         misn.setReward( creditstring( credits_nolux ) )
       else
          misn.finish()
       end

--- a/dat/missions/pirate/empbounty_dead.lua
+++ b/dat/missions/pirate/empbounty_dead.lua
@@ -57,7 +57,6 @@ misn_title[3] = _("PIRACY: Moderate Assassination Job in %s")
 misn_title[4] = _("PIRACY: Big Assassination Job in %s")
 misn_title[5] = _("PIRACY: Dangerous Assassination Job in %s")
 misn_title[6] = _("PIRACY: Highly Dangerous Assassination Job in %s")
-misn_reward = _("%s credits")
 misn_desc   = _("A meddlesome %s pilot was recently seen in the %s system. Local crime lords want this pilot dead.")
 desc_illegal_warning = _("WARNING: This mission is illegal and will get you in trouble with the authorities!")
 
@@ -151,7 +150,7 @@ function create ()
       misn.setDesc( misn_desc:format( target_faction, missys:name() ) .. "\n\n" .. desc_illegal_warning )
    end
 
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 

--- a/dat/missions/pirate/patrol.lua
+++ b/dat/missions/pirate/patrol.lua
@@ -51,7 +51,6 @@ abandon_text[1] = _("You are sent a message informing you that landing in the mi
 
 -- Mission details
 misn_title  = _("Patrol of the %s System")
-misn_reward = _("%s credits")
 misn_desc   = _("A local crime boss has offered a job to patrol the %s system in an effort to keep outsiders from discovering this Pirate stronghold. You will be tasked with checking various points and eliminating any outsiders along the way.")
 
 -- Messages

--- a/dat/missions/pirate/pir_clan_cargo.lua
+++ b/dat/missions/pirate/pir_clan_cargo.lua
@@ -30,7 +30,6 @@ require "portrait.lua"
 
 bar_desc = _("You see a pirate lord raving about something. A significant crowd has gathered around.")
 misn_title = _("Clans trade")
-misn_reward = _("%s credits")
 misn_desc = _("Deliver some boxes to the pirate clan of %s, in the %s system.")
 title = {}
 title[1] = _("Spaceport Bar")
@@ -80,7 +79,7 @@ function accept ()
    -- Mission details
    reward = rnd.rnd(10,20) * 100000 -- Hey, this mission is probably hell, after all.
    misn.setTitle(misn_title)
-   misn.setReward( string.format(misn_reward, numstring(reward)) )
+   misn.setReward( creditstring(reward) )
    misn.setDesc( string.format(misn_desc,dest:name(),sys:name()))
 
    -- Flavour text and mini-briefing

--- a/dat/missions/proteron/dissbounty_dead.lua
+++ b/dat/missions/proteron/dissbounty_dead.lua
@@ -76,7 +76,6 @@ share_text[5] = _([["Ha ha ha, looks like I beat you to it this time, eh? Well, 
 
 -- Mission details
 misn_title  = _("PD: Dead or Alive Bounty in %s")
-misn_reward = _("%s credits")
 misn_desc   = _("A political dissident was recently seen in the %s system. %s authorities want this dissident dead or alive.")
 
 -- Messages
@@ -126,7 +125,7 @@ function create ()
    -- Set mission details
    misn.setTitle( misn_title:format( missys:name() ) )
    misn.setDesc( misn_desc:format( missys:name(), paying_faction:name() ) )
-   misn.setReward( misn_reward:format( numstring( credits ) ) )
+   misn.setReward( creditstring( credits ) )
    marker = misn.markerAdd( missys, "computer" )
 end
 

--- a/dat/missions/shark/sh00_ancestorkill.lua
+++ b/dat/missions/shark/sh00_ancestorkill.lua
@@ -70,7 +70,6 @@ text[4] = _([[As you step on the ground, Arnold Smith greets you. "That was a gr
 
 -- Mission details
 misn_title = _("A Shark Bites")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards needs you to demonstrate to Baron Sauterfeldt the capabilities of Nexus designs.")
 
 -- NPC
@@ -126,7 +125,7 @@ function accept()
       osd_msg[3] = osd_msg[3]:format(mispla:name())
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh01_corvette.lua
+++ b/dat/missions/shark/sh01_corvette.lua
@@ -66,7 +66,6 @@ text[4] = _([[Your mission failed.]])
 
 -- Mission details
 misn_title = _("Sharkman is back")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards wants you to fake a loss against a Lancelot while piloting a Destroyer class ship.")
 
 -- NPC
@@ -118,7 +117,7 @@ function accept()
       osd_msg[2] = osd_msg[2]:format(paypla:name(), paysys:name())
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward/2)))
+      misn.setReward(creditstring(reward/2))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh02_tapping.lua
+++ b/dat/missions/shark/sh02_tapping.lua
@@ -69,7 +69,6 @@ text[4] = _([[You approach the agent and obtain the package without issue. Befor
 
 -- Mission details
 misn_title = _("Unfair Competition")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards is in competition with House Sirius.")
 
 -- NPC
@@ -116,7 +115,7 @@ function accept()
       osd_msg[2] = osd_msg[2]:format(pplname, psyname)
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh03_hailing.lua
+++ b/dat/missions/shark/sh03_hailing.lua
@@ -57,7 +57,6 @@ text[4] = _([[The captain of the Hawking answers you. When you say that you have
 
 -- Mission details
 misn_title = _("Invitation")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards asks you to help initiate a secret meeting")
 
 -- NPC
@@ -103,7 +102,7 @@ function accept()
       osd_msg[2] = osd_msg[2]:format(pplname, psyname)
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh04_meeting.lua
+++ b/dat/missions/shark/sh04_meeting.lua
@@ -62,7 +62,6 @@ text[5] = _([[Suddenly, a Za'lek drone starts attacking you! As you wonder what 
 
 -- Mission details
 misn_title = _("The Meeting")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards asks you to take part in a secret meeting")
 
 -- NPC
@@ -109,7 +108,7 @@ function accept()
       osd_msg[2] = osd_msg[2]:format(paypla:name(), paysys:name())
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh05_flf.lua
+++ b/dat/missions/shark/sh05_flf.lua
@@ -67,7 +67,6 @@ text[5] = _([[The FLF officers are clearly ready for battle, but after subduing 
 
 -- Mission details
 misn_title = _("The FLF Contact")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards is looking to strike a better deal with the FLF.")
 
 -- NPC
@@ -106,7 +105,7 @@ function accept()
       tk.msg(title[2], text[2]:format(nextsys:name()))
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh06_arandon.lua
+++ b/dat/missions/shark/sh06_arandon.lua
@@ -60,7 +60,6 @@ text[6] = _([["Mm. It looks like the others have not arrived yet." Smith says. "
 
 -- Mission details
 misn_title = _("A Journey To %s")
-misn_reward = _("%s credits")
 misn_desc = _("You are to transport Arnold Smith to %s so that he can talk about a deal.")
 
 -- NPC
@@ -105,7 +104,7 @@ function accept()
       osd_msg[2] = osd_msg[2]:format(paypla:name(), paysys:name())
 
       misn.setTitle(misn_title:format(missys:name()))
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc:format(missys:name()))
       osd = misn.osdCreate(osd_title:format(missys:name()), osd_msg)
       misn.osdActive(1)

--- a/dat/missions/shark/sh07_pirates.lua
+++ b/dat/missions/shark/sh07_pirates.lua
@@ -65,7 +65,6 @@ text[5] = _([[Smith awaits your arrival at the spaceport. When you exit your shi
 
 -- Mission details
 misn_title = _("The Last Detail")
-misn_reward = _("%s credits")
 misn_desc = _("Nexus Shipyards has tasked you with killing four pirates.")
 
 -- NPC
@@ -142,7 +141,7 @@ function accept()
       osd_msg[2] = osd_msg[2]:format(pplname,psyname)
 
       misn.setTitle(misn_title)
-      misn.setReward(misn_reward:format(numstring(reward)))
+      misn.setReward(creditstring(reward))
       misn.setDesc(misn_desc)
       osd = misn.osdCreate(osd_title, osd_msg)
       misn.osdActive(1)

--- a/dat/missions/sirius/achack/achack01.lua
+++ b/dat/missions/sirius/achack/achack01.lua
@@ -20,6 +20,7 @@
 --]]
 
 require "missions/sirius/common.lua"
+require "numstring.lua"
 
 
 title1 = _("A Sirian with a grudge")
@@ -52,7 +53,7 @@ osd_msg[2] = _("Find your target on %s and kill her")
 osd_msg["__save"] = true
 
 misn_desc = _([[A Sirian man named Harja has hired you to dispatch a "dangerous criminal" who supposedly committed some kind of crime against him.]])
-misn_reward = _("400,000 credits")
+misn_reward = creditstring(400000) -- 400K
 
 log_text = _([[A Sirian man named Harja hired you to kill a Sirius military officer, claiming that she was a "dangerous criminal". Rather than carrying out the mission, you told her about the plot, and she rewarded you by paying half what Harja would have paid for her death.]])
 

--- a/dat/missions/sirius/achack/achack02.lua
+++ b/dat/missions/sirius/achack/achack02.lua
@@ -27,6 +27,7 @@ require "fleethelper.lua"
 require "selectiveclear.lua"
 require "proximity.lua"
 require "missions/sirius/common.lua"
+require "numstring.lua"
 
 
 title1 = _("An unexpected reunion")
@@ -96,7 +97,7 @@ osd_final = {_("Land on Sroolu to get your reward")}
 osd_final["__save"] = true
 
 misn_desc = _("Joanne needs you to escort her ship and fight off mercenaries sent to kill her.")
-misn_reward = _("750,000 credits")
+misn_reward = creditstring(750000) -- 750K
 
 log_text = _([[Joanne, the Serra military officer who Harja tried to hire you to assassinate, enlisted you to aid her against would-be assassins. Along the way, she explained that Harja was a classmate of hers in the High Academy. According to her, Harja had hacked into the academy's main computer to change all of her grades to perfect scores in an attempt to sabotage her by making her look like a cheater.]])
 

--- a/dat/missions/sirius/achack/achack03.lua
+++ b/dat/missions/sirius/achack/achack03.lua
@@ -23,6 +23,7 @@
 require "fleethelper.lua"
 require "proximity.lua"
 require "missions/sirius/common.lua"
+require "numstring.lua"
 
 
 title1 = _("Talking to Joanne")
@@ -85,7 +86,7 @@ osd_msg[3] = _("Return to Joanne on %s (%s)")
 osd_msg["__save"] = true
 
 misn_desc = _("Joanne wants you to find Harja and interrogate him about his motives.")
-misn_reward = _("1,000,000 credits")
+misn_reward = creditstring(1000000) -- 1M
 
 log_text = _([[Joanne hired you to interrogate Harja about his motives for trying to assassinate her. He was unwilling to talk to you, but when you backed him into a corner, Harja claimed that it was Joanne who hacked the High Acadamy's main computer to change her scores in an attempt to frame him. He swore "on Sirichana" that he wasn't responsible for the hack. Joanne took this oath seriously, saying that he wouldn't "abuse his Sirian beliefs". She said that she may need your help again soon.]])
 

--- a/dat/missions/sirius/achack/achack04.lua
+++ b/dat/missions/sirius/achack/achack04.lua
@@ -23,6 +23,7 @@ require "fleethelper.lua"
 require "proximity.lua"
 require "enum.lua"
 require "missions/sirius/common.lua"
+require "numstring.lua"
 
 
 title1 = _("You have mail")
@@ -100,7 +101,7 @@ osd_msg["__save"] = true
 
 misn_desc = _("Joanne has contacted you. She wants to meet you on %s (%s).")
 misn_desc2 = _("Joanne wants you to find Harja and convince him to meet her in person.")
-misn_reward = _("1,500,000 credits")
+misn_reward = creditstring(1500000) -- 1.5M
 
 log_text = _([[You were hired by Joanne to deliver an invitation to Harja to talk with her. He agreed on the condition that you first deal with associates of his that were coming after him. When Joanne and Harja met, they came to an agreement that neither of them were responsible for the hack of the High Academy main computer which was the source of their feud. Joanne said that she will probably call for you again when she's figured out how to proceed.]])
 

--- a/dat/missions/sirius/heretic/heretic0.lua
+++ b/dat/missions/sirius/heretic/heretic0.lua
@@ -48,7 +48,6 @@ npc_name = _("A Scrappy Man")
 bar_desc = _("You see a rougher looking man sitting at the bar and guzzling a brownish ale.")
 misn_desc = _("You are to deliver a shipment to %s in the %s system for a strange man you met at a bar, avoiding Sirius ships.")
 misn_title = _("The Gauntlet")
-misn_reward = _("%s credits")
 
 log_text = _([[You helped a rough-looking man deliver an illegal shipment. After you completed the delivery, another man told you that there may be another mission opportunity and that you should meet some commander in the bar on Margot if you're interested.]])
 
@@ -64,7 +63,7 @@ function create()
       misn.finish(false)
    end
    --set the mission stuff
-   misn.setReward(misn_reward:format(numstring(reward)))
+   misn.setReward(creditstring(reward))
    misn.setTitle(misn_title)
    misn.setNPC(npc_name, "sirius/unique/strangeman")
    misn.setDesc(bar_desc)

--- a/dat/missions/sirius/heretic/heretic1.lua
+++ b/dat/missions/sirius/heretic/heretic1.lua
@@ -48,7 +48,6 @@ misn_title = _("The Return")
 npc_name = _("A Tall Man")
 bar_desc = _("A tall man sitting at a table littered with papers.")
 misn_desc = _("Shaman of Nasin has hired you to deliver the message to %s in the %s system.")
-misn_reward = _("%s credits")
 osd = {}
 osd[1] = _("Fly to %s in the %s system and deliver the message")
 
@@ -64,7 +63,7 @@ function create()
    targetasset, targetsystem = planet.get("The Wringer")
    --set the mission stuff
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward:format(numstring(reward)))
+   misn.setReward(creditstring(reward))
    misn.setNPC(npc_name, "sirius/unique/shaman")
    misn.setDesc(bar_desc)
 

--- a/dat/missions/sirius/heretic/heretic2.lua
+++ b/dat/missions/sirius/heretic/heretic2.lua
@@ -48,7 +48,6 @@ bar_desc = _("This man leans against the bar while looking right at you.")
 chronic_failure = _([[Draga's face goes red with fury when he sees you. For a moment you start to worry he might beat you into a pulp for abandoning your mission, but he moves along, fuming. You breathe a sigh of release; you may have angered Nasin, but at least you're still alive.]])
 out_sys_failure_msg = _([[As you abandon your mission, you receive a message from Draga saying that Nasin has no need for deserters. You hope you made the right decision.]])
 misn_desc = _("You have been hired once again by Nasin, this time to destroy a Sirius patrol that has entered %s.")
-misn_reward = _("%s credits")
 
 log_text = _([[You eliminated a Sirian patrol for Draga, high commander of Nasin's operations. He said that Nasin will have another mission for you if you meet him in the bar on The Wringer again.]])
 
@@ -71,7 +70,7 @@ function create()
    deathcount = 0
    --set the mission stuff
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward:format(numstring(reward)))
+   misn.setReward(creditstring(reward))
    misn.setNPC(npc_name, "sirius/unique/draga")
    misn.setDesc(bar_desc)
 

--- a/dat/missions/sirius/heretic/heretic3.lua
+++ b/dat/missions/sirius/heretic/heretic3.lua
@@ -51,7 +51,6 @@ p_landing = _([[As you land, Draga sees you. He seems just about ready to kill y
 oos_failure = _([[You receive a scathing angry message from Draga chastising you for abandoning your mission. You put it behind you. There's no turning back now.]])
 misn_desc = _([[A Sirius assault fleet has just jumped into %s. You are to assist Nasin in destroying this fleet.]])
 time_to_come_home = _([[You receive a frantic message from Draga. "%s! This is worse than we ever thought. We need you back at the base! Stat!"]])
-misn_reward = _("%s credits")
 
 log_text = _([[You helped Draga in an attempt to protect Nasin from the Sirius military. Draga ordered you to get your ship ready for another battle and meet him at the bar.]])
 
@@ -69,7 +68,7 @@ function create()
    if not misn.claim(homesys) then
       misn.finish(false)
    end
-   misn.setReward( misn_reward:format( numstring( reward ) ) )
+   misn.setReward( creditstring( reward ) )
    misn.setTitle( misn_title )
    misn.setNPC(npc_name, "sirius/unique/draga")
    misn.setDesc(bar_desc)

--- a/dat/missions/sirius/heretic/heretic4.lua
+++ b/dat/missions/sirius/heretic/heretic4.lua
@@ -51,7 +51,6 @@ misn_title = _("The Egress")
 npc_name = _("Draga")
 bar_desc = _("Draga is running around, helping the few Nasin in the bar to get stuff together and get out.")
 misn_desc = _("Assist the Nasin refugees by flying to %s in %s, and unloading them there.")
-misn_reward = _("%s credits")
 
 log_text = _([[You helped rescue as many Nasin as your ship could hold to Ulios. Draga was killed by a Sirian soldier as he attempted to rescue his people. When you made it to Ulios, a man named Jimmy gave you a credit chip and said that he "will be forever in your debt".]])
 
@@ -86,7 +85,7 @@ function accept()
    free_cargo = player.pilot():cargoFree()
    people_carried =  (16 * free_cargo) + 7 --average weight per person is 62kg. one ton / 62 is 16. added the +7 for ships with 0 cargo.
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward:format(numstring(reward)))
+   misn.setReward(creditstring(reward))
    misn.setDesc(misn_desc:format( targetasset:name(), targetsys:name()))
    misn.osdCreate(misn_title,osd)
    refugees = misn.cargoAdd("Refugees",free_cargo)

--- a/dat/missions/sirius/srs_ferry.lua
+++ b/dat/missions/sirius/srs_ferry.lua
@@ -42,7 +42,6 @@ require "numstring.lua"
 
 misn_title = _("SR: %s pilgrimage transport for %s-class citizen")
 misn_desc = _("%s in the %s system requests transport to %s.")
-misn_reward = _("%s credits")
 
 dest_planet_name = "Mutris"
 dest_sys_name = "Aesir"
@@ -244,7 +243,7 @@ function create()
     misn.markerAdd(destsys, "computer")
     misn.setTitle( string.format(misn_title, ferrytime[print_speed], prank[rank]) )
     misn.setDesc(title_p1:format( ferrytime[print_speed], destplanet:name(), prank[rank]) .. title_p2:format(numjumps, traveldist, (timelimit - time.get()):str()))
-    misn.setReward(misn_reward:format(numstring(reward)))
+    misn.setReward(creditstring(reward))
 
     -- Set up passenger details so player cannot keep trying to get a better outcome
     destpicky = rnd.rnd(1,4)

--- a/dat/missions/soromid/comingout/srm_comingout2.lua
+++ b/dat/missions/soromid/comingout/srm_comingout2.lua
@@ -57,7 +57,6 @@ landtext = _([[As you dock you can barely stop Chelsea from jumping out of your 
 
 misn_title = _("Coming of Age")
 misn_desc = _("Chelsea needs you to take her to %s so she can buy her first ship and kick off her piloting career.")
-misn_reward = _("%s credits")
 
 npc_name = _("Chelsea")
 npc_desc = _("She seems to just be sitting by idly. It's been a while; maybe you should say hi?")
@@ -96,7 +95,7 @@ function accept ()
 
       misn.setTitle( misn_title )
       misn.setDesc( misn_desc:format( misplanet:name() ) )
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
       marker = misn.markerAdd( missys, "low" )
 
       osd_desc[1] = osd_desc[1]:format( missys:name(), misplanet:name() )

--- a/dat/missions/soromid/comingout/srm_comingout3.lua
+++ b/dat/missions/soromid/comingout/srm_comingout3.lua
@@ -66,7 +66,6 @@ text[6] = _([[You successfully land and dock alongside Chelsea and she approache
 
 misn_title = _("A Friend's Aid")
 misn_desc = _("Chelsea needs you to escort her to %s.")
-misn_reward = _("%s credits")
 
 npc_name = _("Chelsea")
 npc_desc = _("You see Chelsea looking contemplative.")
@@ -113,7 +112,7 @@ function accept ()
 
       misn.setTitle( misn_title )
       misn.setDesc( misn_desc:format( misplanet:name() ) )
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
       marker = misn.markerAdd( missys, "low" )
 
       osd_desc[1] = osd_desc[1]:format( misplanet:name(), missys:name() )

--- a/dat/missions/soromid/comingout/srm_comingout5.lua
+++ b/dat/missions/soromid/comingout/srm_comingout5.lua
@@ -58,7 +58,6 @@ text[6] = _([[As you dock, you can't help but notice the foul smell of garbage a
 
 misn_title = _("Waste Collector")
 misn_desc = _("Chelsea needs an escort to %s so they can get rid of the garbage now filling their ship.")
-misn_reward = _("%s credits")
 
 npc_name = _("Chelsea")
 npc_desc = _("Chelsea seems like they're stressed. Maybe you should see how they're doing?")
@@ -96,7 +95,7 @@ function accept ()
 
       misn.setTitle( misn_title )
       misn.setDesc( misn_desc:format( misplanet:name() ) )
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
       marker = misn.markerAdd( missys, "low" )
 
       osd_desc[1] = osd_desc[1]:format( misplanet:name(), missys:name() )

--- a/dat/missions/soromid/comingout/srm_comingout6.lua
+++ b/dat/missions/soromid/comingout/srm_comingout6.lua
@@ -61,7 +61,6 @@ text[5] = _([[Chelsea pops up on your viewscreen and grins. "We did it!" they sa
 
 misn_title = _("Moving Up")
 misn_desc = _("Chelsea needs you help them kill a wanted pirate in %s.")
-misn_reward = _("%s credits")
 
 npc_name = _("Chelsea")
 npc_desc = _("Oh, it's Chelsea! You feel an urge to say hello.")
@@ -116,7 +115,7 @@ function accept ()
 
       misn.setTitle( misn_title )
       misn.setDesc( misn_desc:format( missys:name() ) )
-      misn.setReward( misn_reward:format( numstring( credits ) ) )
+      misn.setReward( creditstring( credits ) )
       marker = misn.markerAdd( missys, "high" )
 
       hook.enter( "enter" )

--- a/dat/missions/trader/anxiousmerchant.lua
+++ b/dat/missions/trader/anxiousmerchant.lua
@@ -42,7 +42,6 @@ bar_desc = _("You see a merchant at the bar in a clear state of anxiety.")
 
 --- Missions details
 misn_title = _("Anxious Merchant")
-misn_reward = _("%s credits")
 
 -- OSD
 osd_title = _("Help the Merchant")
@@ -131,7 +130,7 @@ function accept()
 
    -- mission details
    misn.setTitle(misn_title)
-   misn.setReward(misn_reward:format(numstring(payment)))
+   misn.setReward(creditstring(payment))
    misn.setDesc(misn_desc:format(dest_planet:name()))
    marker = misn.markerAdd(dest_sys, "low") -- destination
    cargo_ID = misn.cargoAdd(cargo, cargo_size) -- adds cargo

--- a/dat/missions/zalek/zlk_test.lua
+++ b/dat/missions/zalek/zlk_test.lua
@@ -28,7 +28,6 @@ require "scripts/numstring.lua"
 
 misn_title = _("ZT test of %s")
 misn_desc = _("A Za'lek research team needs you to travel to %s in %s using an engine in order to test it.")
-misn_reward = _("%s credits")
 
 title = _([[ZT: go to %s in the %s system
 Jumps: %d
@@ -127,7 +126,7 @@ function create()
    misn.setTitle( misn_title:format( typeOfEng ))
    misn.markerAdd(destsys, "computer")
    misn.setDesc(title:format(destplanet:name(), destsys:name(), numjumps, traveldist ))
-   misn.setReward(misn_reward:format(numstring(reward)))
+   misn.setReward(creditstring(reward))
 
 end
 

--- a/po/de.po
+++ b/po/de.po
@@ -12623,10 +12623,6 @@ msgstr "Dimitri"
 msgid "You notice Lt. Commander Dimitri at one of the booths."
 msgstr "Die siehst Korvettenkapitän Dimitri an einem der Stände."
 
-#: dat/missions/empire/collective/ec02.lua:37
-msgid "700,000 credits"
-msgstr "700.000 Credits"
-
 #: dat/missions/empire/collective/ec02.lua:39
 #, lua-format
 msgid "Land on %s in the %s system to monitor Collective communications"
@@ -14318,14 +14314,6 @@ msgstr ""
 #: dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua:38
 msgid "Soromid Long Distance Recruitment"
 msgstr "Soromidlangstreckenrekrutierung"
-
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo2.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo3.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo4.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo5.lua:34
-msgid "500,000 credits"
-msgstr "500.000 Credits"
 
 #: dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua:35
 msgid ""
@@ -19581,10 +19569,6 @@ msgstr ""
 #: dat/missions/neutral/diy-nerds.lua:32
 msgid "DIY Nerds"
 msgstr "Bastelnerds"
-
-#: dat/missions/neutral/diy-nerds.lua:33
-msgid "20,000 credits"
-msgstr "20.000 Credits"
 
 #: dat/missions/neutral/diy-nerds.lua:34
 msgid "Cart some nerds to their contest, and back."
@@ -30479,10 +30463,6 @@ msgstr ""
 "Kriminelle“ zu erledigen, die angeblich irgendein Verbrechen gegen ihn "
 "begangen haben soll."
 
-#: dat/missions/sirius/achack/achack01.lua:55
-msgid "400,000 credits"
-msgstr "400.000 Credits"
-
 #: dat/missions/sirius/achack/achack01.lua:57
 msgid ""
 "A Sirian man named Harja hired you to kill a Sirius military officer, "
@@ -30930,10 +30910,6 @@ msgstr ""
 "Joanne braucht dich, um ihr Schiff zu begleiten und die Söldner abzuwehren, "
 "die geschickt wurden, um sie zu töten."
 
-#: dat/missions/sirius/achack/achack02.lua:99
-msgid "750,000 credits"
-msgstr "750.000 Credits"
-
 #: dat/missions/sirius/achack/achack02.lua:101
 msgid ""
 "Joanne, the Serra military officer who Harja tried to hire you to "
@@ -31377,10 +31353,6 @@ msgstr "Kehre zu Joanne auf %s (%s) zurück"
 msgid "Joanne wants you to find Harja and interrogate him about his motives."
 msgstr ""
 "Joanne will, dass du Harja findest und ihn über seine Motive ausfragst."
-
-#: dat/missions/sirius/achack/achack03.lua:88
-msgid "1,000,000 credits"
-msgstr "1.000.000 Credits"
 
 #: dat/missions/sirius/achack/achack03.lua:90
 msgid ""
@@ -31904,10 +31876,6 @@ msgid "Joanne wants you to find Harja and convince him to meet her in person."
 msgstr ""
 "Joanne möchte, dass du Harja findest und ihn überzeugst, sie persönlich zu "
 "treffen."
-
-#: dat/missions/sirius/achack/achack04.lua:103
-msgid "1,500,000 credits"
-msgstr "1.500.000 Credits"
 
 #: dat/missions/sirius/achack/achack04.lua:105
 msgid ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -10459,11 +10459,6 @@ msgstr ""
 msgid "You notice Lt. Commander Dimitri at one of the booths."
 msgstr ""
 
-#: dat/missions/empire/collective/ec02.lua:37
-#, fuzzy
-msgid "700,000 credits"
-msgstr "%sクレジット"
-
 #: dat/missions/empire/collective/ec02.lua:39
 #, lua-format
 msgid "Land on %s in the %s system to monitor Collective communications"
@@ -11865,15 +11860,6 @@ msgstr ""
 #: dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua:38
 msgid "Soromid Long Distance Recruitment"
 msgstr ""
-
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo2.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo3.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo4.lua:34
-#: dat/missions/empire/longdistanceshipping/emp_longdistancecargo5.lua:34
-#, fuzzy
-msgid "500,000 credits"
-msgstr "%sクレジット"
 
 #: dat/missions/empire/longdistanceshipping/emp_longdistancecargo1.lua:35
 msgid ""
@@ -15910,11 +15896,6 @@ msgstr ""
 #: dat/missions/neutral/diy-nerds.lua:32
 msgid "DIY Nerds"
 msgstr ""
-
-#: dat/missions/neutral/diy-nerds.lua:33
-#, fuzzy
-msgid "20,000 credits"
-msgstr "%sクレジット"
 
 #: dat/missions/neutral/diy-nerds.lua:34
 msgid "Cart some nerds to their contest, and back."
@@ -24412,11 +24393,6 @@ msgid ""
 "who supposedly committed some kind of crime against him."
 msgstr ""
 
-#: dat/missions/sirius/achack/achack01.lua:55
-#, fuzzy
-msgid "400,000 credits"
-msgstr "%sクレジット"
-
 #: dat/missions/sirius/achack/achack01.lua:57
 msgid ""
 "A Sirian man named Harja hired you to kill a Sirius military officer, "
@@ -24706,11 +24682,6 @@ msgid ""
 "her."
 msgstr ""
 
-#: dat/missions/sirius/achack/achack02.lua:99
-#, fuzzy
-msgid "750,000 credits"
-msgstr "%sクレジット"
-
 #: dat/missions/sirius/achack/achack02.lua:101
 msgid ""
 "Joanne, the Serra military officer who Harja tried to hire you to "
@@ -24987,11 +24958,6 @@ msgstr ""
 #: dat/missions/sirius/achack/achack03.lua:87
 msgid "Joanne wants you to find Harja and interrogate him about his motives."
 msgstr ""
-
-#: dat/missions/sirius/achack/achack03.lua:88
-#, fuzzy
-msgid "1,000,000 credits"
-msgstr "%sクレジット"
 
 #: dat/missions/sirius/achack/achack03.lua:90
 msgid ""
@@ -25334,11 +25300,6 @@ msgstr ""
 #: dat/missions/sirius/achack/achack04.lua:102
 msgid "Joanne wants you to find Harja and convince him to meet her in person."
 msgstr ""
-
-#: dat/missions/sirius/achack/achack04.lua:103
-#, fuzzy
-msgid "1,500,000 credits"
-msgstr "%sクレジット"
 
 #: dat/missions/sirius/achack/achack04.lua:105
 msgid ""


### PR DESCRIPTION
This covers the absolute easiest case of #1189, in which the entire translatable string is a number of credits. (When we want to refer to a number of credits within a sentence, it's not clear whether we can get away with using creditstring() or we'll have to translate the entire sentence using ngettext().)