### PR TITLE
Be much more careful about UTF-8 characters vs. bytes in the input widget code.

### DIFF
--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -69,11 +69,12 @@ void window_addInput( const unsigned int wid,
    wgt->focusGain       = inp_focusGain;
    wgt->focusLose       = inp_focusLose;
    wgt->dat.inp.font    = (font != NULL) ? font : &gl_smallFont;
-   wgt->dat.inp.max     = max+1;
+   wgt->dat.inp.char_max= max+1;
+   wgt->dat.inp.byte_max= 4*max+1;
    wgt->dat.inp.oneline = oneline;
    wgt->dat.inp.pos     = 0;
    wgt->dat.inp.view    = 0;
-   wgt->dat.inp.input   = calloc( wgt->dat.inp.max, 4 ); /* Maximum length of a unicode character is 4 bytes. */
+   wgt->dat.inp.input   = calloc( wgt->dat.inp.byte_max, 1 ); /* Maximum length of a unicode character is 4 bytes. */
    wgt->dat.inp.fptr    = NULL;
 
    /* position/size */
@@ -211,7 +212,7 @@ static int inp_addKey( Widget* inp, uint32_t ch )
    }
 
    /* Make sure it's not full. */
-   if (u8_strlen(inp->dat.inp.input) >= (size_t)inp->dat.inp.max-1)
+   if (u8_strlen(inp->dat.inp.input) >= (size_t)inp->dat.inp.char_max-1)
       return 1;
 
    /* Render back to utf8. */
@@ -220,10 +221,10 @@ static int inp_addKey( Widget* inp, uint32_t ch )
    /* Add key. */
    memmove( &inp->dat.inp.input[ inp->dat.inp.pos+len ],
          &inp->dat.inp.input[ inp->dat.inp.pos ],
-         inp->dat.inp.max - inp->dat.inp.pos - 1 - len );
+         inp->dat.inp.byte_max - inp->dat.inp.pos - len );
    for (i=0; i<len; i++)
       inp->dat.inp.input[ inp->dat.inp.pos++ ] = buf[i];
-   inp->dat.inp.input[ inp->dat.inp.max-1 ] = '\0';
+   assert(inp->dat.inp.input[ inp->dat.inp.byte_max - 1 ] == '\0');
 
    if (inp->dat.inp.oneline) {
       /* We can't wrap the text, so we need to scroll it out. */
@@ -283,11 +284,11 @@ static int inp_key( Widget* inp, SDL_Keycode key, SDL_Keymod mod )
             if (mod & KMOD_CTRL) {
                /* We want to position the cursor at the start of the previous or current word. */
                /* Begin by skipping all breakers. */
-               while (inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1]) && inp->dat.inp.pos > 0) {
+               while (inp->dat.inp.pos > 0 && inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1])) {
                   u8_dec( inp->dat.inp.input, &inp->dat.inp.pos );
                }
                /* Now skip until we encounter a breaker (or SOL). */
-               while (!inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1]) && inp->dat.inp.pos > 0) {
+               while (inp->dat.inp.pos > 0 && !inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1])) {
                   u8_dec( inp->dat.inp.input, &inp->dat.inp.pos );
                }
             }
@@ -440,11 +441,11 @@ static int inp_key( Widget* inp, SDL_Keycode key, SDL_Keymod mod )
          if (mod & KMOD_CTRL) {
             /* We want to delete up to the start of the previous or current word. */
             /* Begin by skipping all breakers. */
-            while (inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1]) && inp->dat.inp.pos > 0) {
+            while (inp->dat.inp.pos > 0 && inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1])) {
                u8_dec( inp->dat.inp.input, &inp->dat.inp.pos );
             }
             /* Now skip until we encounter a breaker (or SOL). */
-            while (!inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1]) && inp->dat.inp.pos > 0) {
+            while (inp->dat.inp.pos > 0 && !inp_isBreaker(inp->dat.inp.input[inp->dat.inp.pos-1])) {
                u8_dec( inp->dat.inp.input, &inp->dat.inp.pos );
             }
          }
@@ -455,8 +456,8 @@ static int inp_key( Widget* inp, SDL_Keycode key, SDL_Keymod mod )
       /* Actually delete the chars. */
       memmove( &inp->dat.inp.input[ inp->dat.inp.pos ],
             &inp->dat.inp.input[ curpos ],
-            (inp->dat.inp.max - curpos) );
-      inp->dat.inp.input[ inp->dat.inp.max - curpos + inp->dat.inp.pos ] = '\0';
+            (inp->dat.inp.byte_max - curpos) );
+      assert(inp->dat.inp.input[ inp->dat.inp.byte_max - curpos + inp->dat.inp.pos ] == '\0');
 
       if (inp->dat.inp.oneline && inp->dat.inp.view > 0) {
          n = gl_printWidthRaw( &gl_smallFont,
@@ -497,8 +498,8 @@ static int inp_key( Widget* inp, SDL_Keycode key, SDL_Keymod mod )
       /* Actually delete the chars. */
       memmove( &inp->dat.inp.input[ inp->dat.inp.pos ],
             &inp->dat.inp.input[ curpos ],
-            (inp->dat.inp.max - curpos) );
-      inp->dat.inp.input[ inp->dat.inp.max - curpos + inp->dat.inp.pos ] = '\0';
+            (inp->dat.inp.byte_max - curpos) );
+      assert(inp->dat.inp.input[ inp->dat.inp.byte_max - curpos + inp->dat.inp.pos ] == '\0');
 
       if (inp->dat.inp.fptr != NULL)
          inp->dat.inp.fptr( inp->wdw, inp->name );
@@ -525,14 +526,14 @@ static int inp_key( Widget* inp, SDL_Keycode key, SDL_Keymod mod )
       if (inp->dat.inp.oneline)
          return 0; /* Enter does not work in one-liners. */
       /* Empty. */
-      if ((inp->dat.inp.pos >= inp->dat.inp.max-1))
+      if (u8_strlen(inp->dat.inp.input) >= (size_t)inp->dat.inp.char_max-2)
          return 1;
 
       memmove( &inp->dat.inp.input[ inp->dat.inp.pos+1 ],
             &inp->dat.inp.input[ inp->dat.inp.pos ],
-            inp->dat.inp.max - inp->dat.inp.pos - 2 );
+            inp->dat.inp.byte_max - inp->dat.inp.pos - 1 );
       inp->dat.inp.input[ inp->dat.inp.pos++ ] = '\n';
-      inp->dat.inp.input[ inp->dat.inp.max-1 ] = '\0'; /* Make sure it's NUL terminated. */
+      assert(inp->dat.inp.input[ inp->dat.inp.byte_max-1 ] == '\0');
 
       if (inp->dat.inp.fptr != NULL)
          inp->dat.inp.fptr( inp->wdw, inp->name );
@@ -641,13 +642,13 @@ char* window_setInput( const unsigned int wid, char* name, const char *msg )
 
    /* Set the message. */
    if (msg == NULL) {
-      memset( wgt->dat.inp.input, 0, wgt->dat.inp.max );
+      memset( wgt->dat.inp.input, 0, wgt->dat.inp.byte_max );
       wgt->dat.inp.pos     = 0;
       wgt->dat.inp.view    = 0;
    }
    else {
-      strncpy( wgt->dat.inp.input, msg, wgt->dat.inp.max );
-      wgt->dat.inp.input[ wgt->dat.inp.max-1 ] = '\0';
+      strncpy( wgt->dat.inp.input, msg, wgt->dat.inp.byte_max );
+      wgt->dat.inp.input[ wgt->dat.inp.byte_max-1 ] = '\0';
       wgt->dat.inp.pos = strlen( wgt->dat.inp.input );
    }
 

--- a/src/tk/widget/input.h
+++ b/src/tk/widget/input.h
@@ -18,7 +18,8 @@ typedef struct WidgetInputData_ {
    char *filter; /**< Characters to filter. */
    char *input; /**< Input buffer. */
    int oneline; /**< Is it a one-liner? no '\n' and friends */
-   size_t max; /**< Maximum length. */
+   size_t char_max; /**< Maximum number of code points, including terminal null, in buffer. */
+   size_t byte_max; /**< Byte size of the buffer. */
    size_t view; /**< View position. */
    size_t pos; /**< Cursor position. */
    glFont *font; /**< Font to use. */


### PR DESCRIPTION
Example of how to crash the existing code: use Wayland, set SDL_VIDEODRIVER=wayland, toggle a Japanese keyboard layout, button-mash in the new-game dialog. Of course, surviving multi-byte inputs is only the first step.