### PR TITLE
fix crash in sh00

### DIFF
--- a/dat/missions/shark/sh00_ancestorkill.lua
+++ b/dat/missions/shark/sh00_ancestorkill.lua
@@ -189,7 +189,7 @@ function enter()
       pilot.toggleSpawn(false)
 
       -- spawns the bad guy
-      badboy = pilot.add( "Pirate Ancestor", nil, 0 )[1]
+      badboy = pilot.add( "Pirate Ancestor", nil, system.get("Raelid") )[1]
       badboy:rename(piratename)
       badboy:setHostile()
       badboy:setVisplayer()


### PR DESCRIPTION
This `0` was there for 5 years without any reason.
A recent change on `nlua_pilot.c` made it crash. A nice lua error (or warning) would have been better. According to git blame, it could be linked to the commit https://github.com/naev/naev/commit/bc78f71ab94e12eb547247248ac61e3d38dfd91e by @nloewen , but I didn't take the time to be sure.