### PR TITLE
Added a space in "s" and "p" notation (for consistency).

### DIFF
--- a/src/ntime.c
+++ b/src/ntime.c
@@ -215,9 +215,9 @@ void ntime_prettyBuf( char *str, int max, ntime_t t, int d )
    periods = ntime_getPeriods( nt );
    seconds = ntime_getSeconds( nt );
    if ((cycles == 0) && (periods == 0)) /* only seconds */
-      nsnprintf( str, max, _("%04ds"), seconds );
+      nsnprintf( str, max, _("%04d s"), seconds );
    else if ((cycles == 0) || (d==0))
-      nsnprintf( str, max, _("%.*fp"), d, periods + 0.0001 * seconds );
+      nsnprintf( str, max, _("%.*f p"), d, periods + 0.0001 * seconds );
    else /* UST format */
       nsnprintf( str, max, _("UST %d:%.*f"), cycles, d, periods + 0.0001 * seconds );
 }


### PR DESCRIPTION
Doing this as a PR because I know @bobbens expressed uncertainty about doing it this way. It is the correct way to how SI abbreviations in English, though.

🕵️