### PR TITLE
Fix where 2fa.txt is saved.. Whoops!

### DIFF
--- a/utils/ci/steam/2fa/get_2fa.py
+++ b/utils/ci/steam/2fa/get_2fa.py
@@ -7,8 +7,7 @@
 # Written by Jack Greiner (ProjectSynchro on Github: https://github.com/ProjectSynchro/)
 #
 # This script should be run after querying for a Steam Guard code (attempting to login)
-# The 2FA code will be saved to a file called "2fa.txt" in the "extras/steam/2fa/" directory
-# is a bit dirty in it's current state, but does what it's supposed to.
+# The 2FA code will be saved to a file called "2fa.txt" in the same directory as this python script is run
 #
 
 import imaplib
@@ -21,7 +20,7 @@ password = os.environ['TFA_PASS']
 imap_url = os.environ['TFA_IMAP']
 
 # Create file to store the 2FA code in
-file = open("2fa.txt", "w")
+file = open(os.path.join(os.path.dirname(__file__), "2fa.txt"), "w")
 
 # try to create IMAP connection and login
 connection = imaplib.IMAP4_SSL(imap_url)

--- a/utils/ci/steam/2fa/get_2fa.py
+++ b/utils/ci/steam/2fa/get_2fa.py
@@ -7,7 +7,7 @@
 # Written by Jack Greiner (ProjectSynchro on Github: https://github.com/ProjectSynchro/)
 #
 # This script should be run after querying for a Steam Guard code (attempting to login)
-# The 2FA code will be saved to a file called "2fa.txt" in the same directory as this python script is run
+# The 2FA code will be saved to a file called "2fa.txt" in the same directory as this python script is located.
 #
 
 import imaplib


### PR DESCRIPTION
Last one I swear..

The following build failure is caused by the location in which the 2fa file was being saved:
https://github.com/naev/naev/actions/runs/375608131

This rectifies that, by saving the 2fa file in the same path as the 2fa script, which is where SteamDeploy.sh expects it to be.