### PR TITLE
Some nerfs to the overpowered Quicksilver.

### DIFF
--- a/dat/outfits/modifiers/improved_stabilizer.xml
+++ b/dat/outfits/modifiers/improved_stabilizer.xml
@@ -8,6 +8,7 @@
   <price>135000</price>
   <description>By improving your ship's stabilization systems drastically, this modification will allow you to reach higher speeds while still keeping the ship stable.</description>
   <gfx_store>stabilizer</gfx_store>
+  <limit>improved_stabilizer</limit>
   <cpu>-2</cpu>
  </general>
  <specific type="modification">

--- a/dat/ships/quicksilver.xml
+++ b/dat/ships/quicksilver.xml
@@ -21,7 +21,6 @@
   <cargo>30</cargo>
  </characteristics>
  <slots>
-  <weapon size="small" x="15" y="0" h="5" />
   <weapon size="small" x="-10" y="-3" h="0" />
   <weapon size="small" x="-10" y="3" h="0" />
   <utility size="small" prop="systems" exclusive="1" required="1">Unicorp PT-100 Core System</utility>
@@ -30,7 +29,6 @@
   <utility size="small" />
   <structure size="small" prop="engines" exclusive="1" required="1">Unicorp Hawk 150 Engine</structure>
   <structure size="small" prop="hull" exclusive="1" required="1">Unicorp D-2 Light Plating</structure>
-  <structure size="small" />
   <structure size="small" />
   <structure size="small" />
  </slots>


### PR DESCRIPTION
The Quicksilver had a bit of a problem where it was overpowered enough that it may have sometimes made other ships seem pointless. Most notably, it was reasonably competent in offensive combat, which it shouldn't be, and had barely less cargo capacity potential than the Koala. This fixes that by doing two things: first, it makes the Improved Stabilizer a "one per ship" outfit, and second, it removes one weapon slot and one structural slot. We did some extensive testing and found it to still excel at its purpose (rush cargo). With an Improved Stabilizer and Engine Reroute, it's able to outrun most enemies and confidently shoot down the few that can catch up (typically only the fastest Hyenas).

🕵️