### PR TITLE
Hopefully fix the last of the issues with SteamCMD

### DIFF
--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -274,7 +274,7 @@ jobs:
         run: |
           chmod -R +x dist/staging/naev-steam-deployment
           cp -r dist/staging/naev-steam-deployment/* ${{ github.workspace }}
-          ./SteamDeploy.sh -n -v "dist/staging/naev-version" -t "dist/staging" -o "dist/out"
+          ./SteamDeploy.sh -n -v "${{ github.workspace }}/dist/staging/naev-version" -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
         env:
           STEAMCMD_USER: ${{ secrets.STEAMCMD_USER }}
           STEAMCMD_PASS: ${{ secrets.STEAMCMD_PASS }}

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -274,7 +274,7 @@ jobs:
         run: |
           chmod -R +x dist/staging/naev-steam-deployment
           cp -r dist/staging/naev-steam-deployment/* ${{ github.workspace }}
-          ./SteamDeploy.sh -v "dist/staging/naev-version" -t "dist/staging" -o "dist/out"
+          ./SteamDeploy.sh -v "${{ github.workspace }}/dist/staging/naev-version" -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
         env:
           STEAMCMD_USER: ${{ secrets.STEAMCMD_USER }}
           STEAMCMD_PASS: ${{ secrets.STEAMCMD_PASS }}

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -351,7 +351,7 @@ jobs:
         run: |
           chmod -R +x dist/staging/naev-steam-deployment
           cp -r dist/staging/naev-steam-deployment/* ${{ github.workspace }}
-          ./SteamDeploy.sh -v "dist/staging/naev-version" -t "dist/staging" -o "dist/out"
+          ./SteamDeploy.sh -v "${{ github.workspace }}/dist/staging/naev-version" -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
         env:
           STEAMCMD_USER: ${{ secrets.STEAMCMD_USER }}
           STEAMCMD_PASS: ${{ secrets.STEAMCMD_PASS }}

--- a/utils/ci/steam/SteamDeploy.sh
+++ b/utils/ci/steam/SteamDeploy.sh
@@ -66,11 +66,11 @@ mkdir -p "$STEAMPATH"/content/win64
 mkdir -p "$STEAMPATH"/content/ndata
 
 # Move Depot Scripts to Steam staging area
-cp -r "$SCRIPTROOT"/scripts "$STEAMPATH"
+cp -v -r "$SCRIPTROOT"/scripts "$STEAMPATH"
 
 # Move all build artefacts to deployment locations
 # Move Linux binary and set as executable
-cp "$TEMPPATH"/naev-steamruntime/naev.x64 "$STEAMPATH"/content/lin64
+cp -v "$TEMPPATH"/naev-steamruntime/naev.x64 "$STEAMPATH"/content/lin64
 chmod +x "$STEAMPATH"/content/lin64/naev.x64
           
 # Move macOS bundle to deployment location (Bye Bye for now)
@@ -134,8 +134,8 @@ elif [ "$DRYRUN" == "true" ]; then
             ls -l -R "$STEAMPATH"
         elif [ "$BETA" == "false" ]; then 
             # Move soundtrack stuff to deployment area
-            cp "$TEMPPATH"/naev-steam-soundtrack/*.mp3 "$STEAMPATH/content/soundtrack"
-            cp "$TEMPPATH"/naev-steam-soundtrack/*.png "$STEAMPATH/content/soundtrack"
+            cp -v "$TEMPPATH"/naev-steam-soundtrack/*.mp3 "$STEAMPATH/content/soundtrack"
+            cp -v "$TEMPPATH"/naev-steam-soundtrack/*.png "$STEAMPATH/content/soundtrack"
 
             # Run steam upload with 2fa key
             echo "steamcmd release build"


### PR DESCRIPTION
It appears that steamcmd may require an absolute path to be passed in when referring to app build scripts.

This additionally add some verbose output when files are being copied,

A manual trigger is needed to get this to run.