### PR TITLE
Translate the intro/credits text.

### DIFF
--- a/po/POTFILES_COMBINED.in
+++ b/po/POTFILES_COMBINED.in
@@ -2549,3 +2549,4 @@ dat/ssys/zintar.xml
 dat/ssys/zylex.xml
 dat/start.xml
 dat/tech.xml
+po/credits.pot

--- a/utils/update-po.sh
+++ b/utils/update-po.sh
@@ -32,3 +32,13 @@ cat "$TMPFILE" | LC_ALL=C sort | tee -a "$ROOT/po/POTFILES_COMBINED.in" > "$ROOT
 echo "po/xml.pot" >> "$ROOT/po/POTFILES.in"
 
 rm "$TMPFILE" # clean-up
+
+# Pull strings from the "intro" and "AUTHORS" files (inputs to credit rolls) into "credits.pot".
+echo "po/credits.pot" >> "$ROOT/po/POTFILES_COMBINED.in"
+awk '# Loop over lines, and when we get plain text (not a "[...]" line),
+   /^[^[[]/ {
+      # Escape any quotation marks...
+      gsub(/"/, "\\\"");
+      # And print a msgid/msgstr pair with the filename and line number.
+      print "#: " FILENAME ":" NR "\nmsgid \"" $0 "\"\nmsgstr \"\"\n";
+   }' dat/intro dat/AUTHORS > "$ROOT/po/credits.pot"


### PR DESCRIPTION
The solution here is a little hair-raising. Suggestions welcome.
The overall strategy is:

- Keep the intro and AUTHORS file in their plain-text format. (Especially AUTHORS.)
- Emit a pot file that collects the lines of text. I'm not aware of a tool that does this, so I shelled out to awk, which does everything.
- Have intro.c cut the source text at line boundaries while collecting its "intro_lines", so that each line can be an input string to gettext() when we should do that. The C string crunching gets pretty subtle, so comment as nicely as I can...

I can't tell you how tempting it is to replace these sequences with Lua scripts (which call _) and some sort of thin player on the C side. But that would likely cause a lot of problems, too.