### PR TITLE
fix wrong usage of inRangePilot

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1976,8 +1976,8 @@ void player_targetHostile (void)
 
       /* Must be hostile. */
       if (pilot_isHostile(pilot_stack[i])) {
-         inRange = pilot_inRangePilot(pilot_stack[i], player.p, &td);
-         if (tp == PLAYER_ID || (inRange == 1 && td < d)) {
+         inRange = pilot_inRangePilot(player.p, pilot_stack[i], &td);
+         if (tp == PLAYER_ID || ((inRange == 1) && (td < d))) {
             d  = td;
             tp = pilot_stack[i]->id;
          }


### PR DESCRIPTION
In function to target nearest enemy, we used to check inRange in the wrong order