### PR TITLE
dialogue_getSize should not try to translate the title

### DIFF
--- a/src/dialogue.c
+++ b/src/dialogue.c
@@ -167,7 +167,7 @@ static glFont* dialogue_getSize( const char* title,
    int i, titlelen, msglen;
 
    /* Get title length. */
-   titlelen = gl_printWidthRaw( &gl_defFont, _(title) );
+   titlelen = gl_printWidthRaw( &gl_defFont, title );
    msglen = gl_printWidthRaw( &gl_smallFont, msg );
 
    /* Try widths from 300 to 800 in 50 px increments.


### PR DESCRIPTION
Tthat responsibility has been fully assigned to the caller. (Fixes a bug where a dialogue with empty title would want to be 3000px wide because gettext translates "" to the translation metadata.)