### PR TITLE
Cleanups

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -249,7 +249,7 @@ static void info_openMain( unsigned int wid )
    } else {
      licenses = malloc(sizeof(char*) * nlicenses);
      for (i=0; i<nlicenses; i++)
-        licenses[i] = strdup(buf[i]);
+        licenses[i] = strdup( _(buf[i]) );
       qsort( licenses, nlicenses, sizeof(char*), strsort );
    }
    window_addText( wid, -20, -40, w-80-200-40-40, 20, 1, "txtList",

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -226,11 +226,12 @@ static int inp_addKey( Widget* inp, uint32_t ch )
       inp->dat.inp.input[ inp->dat.inp.pos++ ] = buf[i];
    assert(inp->dat.inp.input[ inp->dat.inp.byte_max - 1 ] == '\0');
 
-   if (inp->dat.inp.oneline) {
+   while (inp->dat.inp.oneline) {
       /* We can't wrap the text, so we need to scroll it out. */
       n = gl_printWidthRaw( inp->dat.inp.font, inp->dat.inp.input+inp->dat.inp.view );
-      if (n+10 > inp->w)
-         u8_inc( inp->dat.inp.input, &inp->dat.inp.view );
+      if (n+10 <= inp->w)
+         break;
+      u8_inc( inp->dat.inp.input, &inp->dat.inp.view );
    }
 
    return 1;
@@ -451,11 +452,12 @@ static int inp_key( Widget* inp, SDL_Keycode key, SDL_Keymod mod )
             (inp->dat.inp.byte_max - curpos) );
       assert(inp->dat.inp.input[ inp->dat.inp.byte_max - curpos + inp->dat.inp.pos ] == '\0');
 
-      if (inp->dat.inp.oneline && inp->dat.inp.view > 0) {
+      while (inp->dat.inp.oneline && inp->dat.inp.view > 0) {
          n = gl_printWidthRaw( &gl_smallFont,
                inp->dat.inp.input + inp->dat.inp.view - 1 );
-         if (n+10 < inp->w)
-            inp->dat.inp.view += curpos - inp->dat.inp.pos;
+         if (n+10 >= inp->w)
+            break;
+	 inp->dat.inp.view -= (curpos - inp->dat.inp.pos);
       }
 
       if (inp->dat.inp.fptr != NULL)


### PR DESCRIPTION
Test case for the input box changes (explained in commit message): Info, Ship Log, New Entry.
Type "Dear Diary, I continued you in Germ" -- at least with my font settings, it scrolls the "r" in "Dear" out of view but the final "m" still doesn't fit and isn't drawn. That feels very confusing.
Now start backspacing. Starting with the second deletion, it looks like letters are disappearing off both the front and the back. They aren't actually, but we're scrolling the leftmost letters out of view instead of into view.
