### PR TITLE
fuzzy pilots are not identified as enemies

### DIFF
--- a/src/pilot.c
+++ b/src/pilot.c
@@ -277,6 +277,10 @@ static int pilot_validEnemy( const Pilot* p, const Pilot* target )
    if (!pilot_validTarget( p, target ))
       return 0;
 
+   /* Must not be fuzzy. */
+   if (pilot_inRangePilot( p, target, NULL ) != 1)
+      return 0;
+
    /* He's ok. */
    return 1;
 }


### PR DESCRIPTION
The AI used to identify pilots as enemies even if they were fuzzily detected.
I'm pretty sure it's not the desired behaviour (fuzzy pilots are not red neither green in order to hide many information including their faction)
That doesn't change very much in-game, except that it's slightly easier to navigate unnoticed with a stealth ship.