### PR TITLE
Pilot stops attacking if out of sensor range

### DIFF
--- a/dat/ai/include/atk_bomber.lua
+++ b/dat/ai/include/atk_bomber.lua
@@ -17,6 +17,9 @@ function atk_bomber ()
    ai.hostile(target) -- Mark as hostile
    ai.settarget(target)
 
+   -- See if the enemy is still seeable
+   if not _atk_check_seeable() then return end
+
    -- Get stats about enemy
    local dist  = ai.dist( target ) -- get distance
    local range = ai.getweaprange(3, 0)

--- a/dat/ai/include/atk_capital.lua
+++ b/dat/ai/include/atk_capital.lua
@@ -15,6 +15,9 @@ function atk_capital ()
    ai.hostile(target) -- Mark as hostile
    ai.settarget(target)
 
+   -- See if the enemy is still seeable
+   if not _atk_check_seeable() then return end
+
    -- Get stats about enemy
    local dist  = ai.dist( target ) -- get distance
    local range = ai.getweaprange(3)

--- a/dat/ai/include/atk_corvette.lua
+++ b/dat/ai/include/atk_corvette.lua
@@ -15,6 +15,9 @@ function atk_corvette ()
    ai.hostile(target) -- Mark as hostile
    ai.settarget(target)
 
+   -- See if the enemy is still seeable
+   if not _atk_check_seeable() then return end
+
    -- Get stats about enemy
    local dist  = ai.dist( target ) -- get distance
    local range = ai.getweaprange(3, 0)

--- a/dat/ai/include/atk_drone.lua
+++ b/dat/ai/include/atk_drone.lua
@@ -82,6 +82,9 @@ function atk_drone ()
    ai.hostile(target) -- Mark as hostile
    ai.settarget(target)
 
+   -- See if the enemy is still seeable
+   if not _atk_check_seeable() then return end
+
    -- Get stats about enemy
    local dist  = ai.dist( target ) -- get distance
    local range = ai.getweaprange(3, 0)  -- get my weapon range (?)

--- a/dat/ai/include/atk_fighter.lua
+++ b/dat/ai/include/atk_fighter.lua
@@ -55,6 +55,9 @@ function atk_fighter ()
    ai.hostile(target) -- Mark as hostile
    ai.settarget(target)
 
+   -- See if the enemy is still seeable
+   if not _atk_check_seeable() then return end
+
    -- Get stats about enemy
    local dist  = ai.dist( target ) -- get distance
    local range = ai.getweaprange(3, 0)

--- a/dat/ai/include/atk_generic.lua
+++ b/dat/ai/include/atk_generic.lua
@@ -76,6 +76,9 @@ function atk_generic ()
    ai.hostile(target) -- Mark as hostile
    ai.settarget(target)
 
+   -- See if the enemy is still seeable
+   if not _atk_check_seeable() then return end
+
    -- Get stats about enemy
    local dist  = ai.dist( target ) -- get distance
    local range = ai.getweaprange( 3 )


### PR DESCRIPTION
At the beginning of the attack function (and of it's subtask zigzag, I don't think there are others) one tests if the target is still in sensor range.
If not, the task is popped and a goto task is pushed to the last place where the target was seen.
As suggested by @onpon4, Pilots under manual control are not affected, in order not to impact the missions.

This is not totally clean as theoretically, the AI should not be the one who decides if the target is out of sensor range, but well, it's simple and it works...