### PR TITLE
Update code to handle CLRF line endings if installed on Windows.

### DIFF
--- a/dat/missions/zalek/neburesearch/neburesearch_00.lua
+++ b/dat/missions/zalek/neburesearch/neburesearch_00.lua
@@ -1,4 +1,5 @@
 --[[
+<?xml version='1.0' encoding='utf8'?>
 <mission name="Novice Nebula Research">
  <flags>
   <unique />

--- a/dat/missions/zalek/neburesearch/neburesearch_01.lua
+++ b/dat/missions/zalek/neburesearch/neburesearch_01.lua
@@ -1,4 +1,5 @@
 --[[
+<?xml version='1.0' encoding='utf8'?>
 <mission name="Advanced Nebula Research">
  <flags>
   <unique />

--- a/dat/missions/zalek/neburesearch/neburesearch_04.lua
+++ b/dat/missions/zalek/neburesearch/neburesearch_04.lua
@@ -1,4 +1,5 @@
 --[[
+<?xml version='1.0' encoding='utf8'?>
 <mission name="Shielding Prototype Funding">
  <flags>
   <unique />

--- a/src/event.c
+++ b/src/event.c
@@ -569,7 +569,7 @@ static int event_parseFile( const char* file )
    xmlNodePtr node;
    xmlDocPtr doc;
    char *filebuf;
-   const char *pos;
+   const char *pos, *start_pos;
    EventData *temp;
 
 #ifdef DEBUGGING
@@ -595,14 +595,15 @@ static int event_parseFile( const char* file )
    }
 
    /* Separate XML header and Lua. */
+   start_pos = nstrnstr( filebuf, "<?xml ", bufsize );
    pos = nstrnstr( filebuf, "--]]", bufsize );
-   if (pos == NULL) {
+   if (pos == NULL || start_pos == NULL) {
       WARN(_("Event file '%s' has missing XML header!"), file);
       return -1;
    }
 
    /* Parse the header. */
-   doc = xmlParseMemory( &filebuf[5], pos-filebuf-5 );
+   doc = xmlParseMemory( start_pos, pos-start_pos );
    if (doc == NULL) {
       WARN(_("Unable to parse document XML header for Event '%s'"), file);
       return -1;

--- a/src/intro.c
+++ b/src/intro.c
@@ -105,8 +105,12 @@ static int intro_load( const char *text )
          cur_line = rest_of_file;
          rest_of_file = strchr(cur_line, '\n');
 	 /* If there's a next line, split the string and point rest_of_file to it. */
-         if (rest_of_file != NULL)
+         if (rest_of_file != NULL) {
+	    /* Check for CRLF endings -- if present, zero both parts. */
+            if (rest_of_file > cur_line && *(rest_of_file-1) == '\r')
+               *(rest_of_file-1) = '\0';
             *rest_of_file++ = '\0';
+	 }
 	 /* Translate if plain text (not empty, not a directive). */
 	 if (cur_line[0] != '\0' && cur_line[0] != '[')
             cur_line = _(cur_line);

--- a/src/mission.c
+++ b/src/mission.c
@@ -912,7 +912,7 @@ static int mission_parseFile( const char* file )
    xmlNodePtr node;
    size_t bufsize;
    char *filebuf;
-   const char *pos;
+   const char *pos, *start_pos;
    MissionData *temp;
 
 #ifdef DEBUGGING
@@ -938,14 +938,15 @@ static int mission_parseFile( const char* file )
    }
 
    /* Separate XML header and Lua. */
+   start_pos = nstrnstr( filebuf, "<?xml ", bufsize );
    pos = nstrnstr( filebuf, "--]]", bufsize );
-   if (pos == NULL) {
+   if (pos == NULL || start_pos == NULL) {
       WARN(_("Mission file '%s' has missing XML header!"), file);
       return -1;
    }
 
    /* Parse the header. */
-   doc = xmlParseMemory( &filebuf[5], pos-filebuf-5 );
+   doc = xmlParseMemory( start_pos, pos-start_pos);
    if (doc == NULL) {
       WARN(_("Unable to parse document XML header for Mission '%s'"), file);
       return -1;

--- a/src/options.c
+++ b/src/options.c
@@ -12,11 +12,9 @@
 #include "options.h"
 
 #include "naev.h"
-
 #include "nstring.h"
-
+#include <ctype.h>
 #include "SDL.h"
-
 #include "log.h"
 #include "input.h"
 #include "toolkit.h"
@@ -200,8 +198,7 @@ static char** lang_list( int *n )
    size_t fs;
    char *buf;
    char **ls;
-   int j;
-   size_t i;
+   size_t i, j;
 
    /* Default English only. */
    ls = malloc( sizeof(char*)*128 );
@@ -215,10 +212,10 @@ static char** lang_list( int *n )
       return ls;
    j = 0;
    for (i=0; i<fs; i++) {
-      if ((buf[i] != '\n') && (buf[i] != '\0'))
+      if (!isspace(buf[i]) && (buf[i] != '\0'))
          continue;
       buf[i] = '\0';
-      if (*n < 128)
+      if (*n < 128 && i > j)
          ls[(*n)++] = strdup( &buf[j] );
       j=i+1;
    }


### PR DESCRIPTION
This doesn't extend to using the OS's native line-ending mode with conf.lua.
That's probably worth doing to make it more user-friendly, but I haven't seen evidence we have to do it.