### PR TITLE
Return default map overlay bounds to the entire screen.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -118,9 +118,9 @@ static double gui_viewport_h = 0.; /**< GUI Viewport height. */
  * Map overlay
  */
 MapOverlay map_overlay = {
-  boundTop: 46,
+  boundTop: 0,
   boundRight: 0,
-  boundBottom: 46,
+  boundBottom: 0,
   boundLeft: 0,
 };
 int map_overlay_height(void)


### PR DESCRIPTION
More space makes it much easier to see the stuff within. More work is still needed for #1449, but this is a step in the right direction.