### PR TITLE
use raw goto when one has lost contact with the target

### DIFF
--- a/dat/ai/include/atk_util.lua
+++ b/dat/ai/include/atk_util.lua
@@ -52,7 +52,7 @@ function _atk_check_seeable()
 
    ai.settarget(self) -- Un-target
    ai.poptask()
-   ai.pushtask("goto", target:pos() )
+   ai.pushtask("__goto_nobrake_raw", target:pos() )
    return false
 end
 


### PR DESCRIPTION
Because there is no need to be very precise, neither to brake