### PR TITLE
Fix cargo common

### DIFF
--- a/dat/scripts/cargo_common.lua
+++ b/dat/scripts/cargo_common.lua
@@ -198,10 +198,6 @@ function cargo_setDesc( misn_desc, cargo, amount, target, deadline, notes )
    end
 
    if deadline ~= nil then
-      print()
-      print( tostring( deadline   ) )
-      print( tostring( time.get() ) )
-      print( tostring( deadline - time.get() ) )
       table.insert( t, _("Time limit: %s"):format( tostring(deadline - time.get()) ) );
    end
 

--- a/dat/scripts/cargo_common.lua
+++ b/dat/scripts/cargo_common.lua
@@ -198,7 +198,11 @@ function cargo_setDesc( misn_desc, cargo, amount, target, deadline, notes )
    end
 
    if deadline ~= nil then
-      table.insert(t, _("Time limit: %s"):format( deadline - time.get() ) );
+      print()
+      print( tostring( deadline   ) )
+      print( tostring( time.get() ) )
+      print( tostring( deadline - time.get() ) )
+      table.insert( t, _("Time limit: %s"):format( tostring(deadline - time.get()) ) );
    end
 
    misn.setDesc( table.concat(t, "\n" ) );


### PR DESCRIPTION
Solves warning in cargo_common.lua (Issue #1490).
It was simply a matter of adding a tostring() to the argument to format().
