### PR TITLE
Refactor gui_osd.c so we can re-wrap the text. Fixes visual truncation after switching GUIs.

### DIFF
--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -42,10 +42,10 @@ typedef struct OSD_s {
 
 
 /*
- * OSD linked list.
+ * OSD array.
  */
 static unsigned int osd_idgen = 0; /**< ID generator for OSD. */
-static OSD_t *osd_list        = NULL; /**< Linked list for OSD. */
+static OSD_t *osd_list        = NULL; /**< Array (array.h) for OSD. */
 
 
 /*

--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -155,13 +155,16 @@ unsigned int osd_create( const char *title, int nitems, const char **items, int 
 
 /**
  * @brief Calculates the word-wrapped osd->items from osd->msg.
- *        osd->items must be freshly initialized.
  */
 void osd_wordwrap( OSD_t* osd )
 {
    int i, n, l, s, w, t;
    char *chunk;
    for (i=0; i<array_size(osd->items); i++) {
+      for (l=0; l<array_size(osd->items[i]); l++)
+         free(osd->items[i][l]);
+      array_resize( &osd->items[i], 0 );
+
       l = strlen(osd->msg[i]); /* Message length. */
       n = 0; /* Text position. */
       t = 0; /* Tabbed? */
@@ -348,7 +351,9 @@ int osd_getActive( unsigned int osd )
  */
 int osd_setup( int x, int y, int w, int h )
 {
+   int i, must_rewrap;
    /* Set offsets. */
+   must_rewrap = (osd_w != w) && (osd_list != NULL);
    osd_x = x;
    osd_y = y;
    osd_w = w;
@@ -358,6 +363,10 @@ int osd_setup( int x, int y, int w, int h )
    /* Calculate some font things. */
    osd_tabLen = gl_printWidthRaw( &gl_smallFont, "   " );
    osd_hyphenLen = gl_printWidthRaw( &gl_smallFont, "- " );
+
+   if (must_rewrap)
+      for (i=0; i<array_size(osd_list); i++)
+         osd_wordwrap( &osd_list[i] );
    osd_calcDimensions();
 
    return 0;

--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -151,7 +151,7 @@ unsigned int osd_create( const char *title, int nitems, const char **items, int 
       while (n < l) {
          /* Test if tabbed. */
          if (n==0) {
-            if (items[i][n] == '\t') {
+            if (osd->msg[i][n] == '\t') {
                t = 1;
                w = osd_w - osd_tabLen;
             }
@@ -162,7 +162,7 @@ unsigned int osd_create( const char *title, int nitems, const char **items, int 
          }
 
          /* Get text size. */
-         s = gl_printWidthForText( &gl_smallFont, &items[i][n], w );
+         s = gl_printWidthForText( &gl_smallFont, &osd->msg[i][n], w );
 
          if (n==0 && t==1)
             w -= osd_hyphenLen;
@@ -171,20 +171,20 @@ unsigned int osd_create( const char *title, int nitems, const char **items, int 
          if (n==0) {
             if (t==1) {
                chunk = malloc(s+4);
-               nsnprintf( chunk, s+4, "   %s", &items[i][n+1] );
+               nsnprintf( chunk, s+4, "   %s", &osd->msg[i][n+1] );
             }
             else {
                chunk = malloc(s+3);
-               nsnprintf( chunk, s+3, "- %s", &items[i][n] );
+               nsnprintf( chunk, s+3, "- %s", &osd->msg[i][n] );
             }
          }
          else if (t==1) {
             chunk = malloc(s+4);
-            nsnprintf( chunk, s+4, "   %s", &items[i][n] );
+            nsnprintf( chunk, s+4, "   %s", &osd->msg[i][n] );
          }
          else {
             chunk = malloc(s+1);
-            nsnprintf( chunk, s+1, "%s", &items[i][n] );
+            nsnprintf( chunk, s+1, "%s", &osd->msg[i][n] );
          }
          array_push_back( &osd->items[i], chunk );
 


### PR DESCRIPTION
(Repro: Start in "brushed" with sufficiently long OSD text, switch to any other GUI.)
PR diff looks complicated, but the commits shouldn't.