### PR TITLE
Go clean on warnings (more build configurations, and in map_overlay.c since it's settled down a bit).

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('naev', 'c',
    version : '0.8.0-beta.4',
    default_options : [
-      'warning_level=1',
+      'warning_level=2',
       'optimization=g',
       'c_std=gnu11',
       'werror=false'

--- a/src/gui.c
+++ b/src/gui.c
@@ -129,10 +129,10 @@ typedef struct MapOverlay_ {
    int boundLeft;
 } MapOverlay;
 static MapOverlay map_overlay = {
-  boundTop: 0,
-  boundRight: 0,
-  boundBottom: 0,
-  boundLeft: 0,
+  .boundTop = 0,
+  .boundRight = 0,
+  .boundBottom = 0,
+  .boundLeft = 0,
 };
 int map_overlay_height(void)
 {

--- a/src/gui.c
+++ b/src/gui.c
@@ -1477,7 +1477,6 @@ void gui_renderPlayer( double res, int overlay )
    } else {
       x = 0.;
       y = 0.;
-      r = 3.;
       r = MIN(SCREEN_W,SCREEN_H)*0.008;
    }
 

--- a/src/map.c
+++ b/src/map.c
@@ -1580,6 +1580,7 @@ void map_updateFactionPresence( const unsigned int wid, const char *name, const 
    if ( hasPresence == 0 )
       nsnprintf( buf, sizeof( buf ), _( "None" ) );
 
+   (void) l;
    window_modifyText( wid, name, buf );
 }
 

--- a/src/map_overlay.c
+++ b/src/map_overlay.c
@@ -331,7 +331,7 @@ static void ovr_init_position( float *px, float *py, float res, float x, float y
       ovr_refresh_compute_overlap( &ox, &oy, res, cx, cy, w, h, pos, mo, moo, items, self, 1, pixbuf, object_weight, text_weight );
       val = pow2(ox)+pow2(oy);
       /* Keep best. */
-      if (val < best) {
+      if (i == 0 || val < best) {
          bx = tx[i];
          by = ty[i];
          best = val;

--- a/src/map_system.c
+++ b/src/map_system.c
@@ -740,6 +740,7 @@ static void map_system_array_update( unsigned int wid, char* str ) {
    }
    else
       WARN( _("Unexpected call to map_system_array_update\n") );
+   (void) i;
 }
 
 static void map_system_array_rmouse( unsigned int wid, char* widget_name )

--- a/src/nlua.c
+++ b/src/nlua.c
@@ -385,7 +385,7 @@ static char* nlua_packfileLoaderTryFile( size_t *bufsize, const char *filename )
 static int nlua_packfileLoader( lua_State* L )
 {
    const char *filename;
-   char filename_ext[PATH_MAX];
+   char filename_ext[NDATA_PATH_MAX];
    char *buf;
    size_t bufsize;
    int envtab;

--- a/src/options.c
+++ b/src/options.c
@@ -351,6 +351,7 @@ static void opt_gameplay( unsigned int wid )
    y -= 40;
 
 
+   (void) y;
    x = 20 + cw + 20;
    y  = by;
    cw += 80;

--- a/src/shiplog.c
+++ b/src/shiplog.c
@@ -552,8 +552,8 @@ void shiplog_listLogsOfType( const char *type, int *nlogs, char ***logsOut, int 
    ntime_t t = ntime_get();
 
    n = !!includeAll;
-   logs = realloc(*logsOut, sizeof(char**) * n);
-   logid = realloc(*logIDs, sizeof(int*) * n);
+   logs = realloc(*logsOut, sizeof(char*) * n);
+   logid = realloc(*logIDs, sizeof(int) * n);
    if ( includeAll ) {
       logs[0] = strdup( _("All") );
       logid[0] = LOG_ID_ALL;


### PR DESCRIPTION
Changes are non-functional outside nlua.c and shiplog.c. All are tested.
The update to meson.build should make it harder for crap to sneak in going forward. (I think Autotools builds are still a bit stricter; we'll have to synchronize at some point.)