### PR TITLE
Removed SOUND_SPEED_PLAY_LIMIT.

### DIFF
--- a/src/sound.h
+++ b/src/sound.h
@@ -8,9 +8,6 @@
 #  define SOUND_H
 
 
-#define SOUND_SPEED_PLAY_LIMIT      4.0 /**< Speed modifier at which sounds do not play. */
-
-
 extern int sound_disabled;
 
 

--- a/src/sound_openal.c
+++ b/src/sound_openal.c
@@ -842,10 +842,6 @@ static ALuint sound_al_getSource (void)
 static int al_playVoice( alVoice *v, alSound *s,
       ALfloat px, ALfloat py, ALfloat vx, ALfloat vy, ALint relative )
 {
-   /* Must be below the limit. */
-   if (sound_speed > SOUND_SPEED_PLAY_LIMIT)
-      return 0;
-
    /* Set up the source and buffer. */
    v->u.al.source = sound_al_getSource();
    if (v->u.al.source == 0)

--- a/src/sound_sdlmix.c
+++ b/src/sound_sdlmix.c
@@ -157,9 +157,6 @@ void sound_mix_exit (void)
  */
 int sound_mix_play( alVoice *v, alSound *s )
 {
-   if (sound_speed > SOUND_SPEED_PLAY_LIMIT)
-      return 0;
-
    v->u.mix.channel = Mix_PlayChannel( -1, s->u.mix.buf, 0 );
    if (v->u.mix.channel >= 0)
       Mix_Volume( v->u.mix.channel, sound_mixVolume );
@@ -242,9 +239,6 @@ int sound_mix_playPos( alVoice *v, alSound *s,
 {
    (void) vx;
    (void) vy;
-
-   if (sound_speed > SOUND_SPEED_PLAY_LIMIT)
-      return 0;
 
    /* Get the channel. */
    v->u.mix.channel = Mix_PlayChannel( -1, s->u.mix.buf, 0 );


### PR DESCRIPTION
This thing seems to be wholly unnecessary and makes the game seem buggy. I did some testing following Dvaered and FLF pilots in Frontier space, and hearing a bit of battle sounds at high speed wasn't a problem at all. (In fact, OpenAL makes sounds quieter as they get faster, so under OpenAL it ended up being silent at the real high time compression levels I was experiencing. But even under SDL_Mixer, where that wasn't happening, it just wasn't a problem.)

🕵️