### PR TITLE
More thorough rework of the input widget. Main benefit is that it can't position the cursor inside multibyte characters...

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -497,6 +497,22 @@ static size_t font_limitSize( glFontStash *ft_font, int *width,
  *    @param width Width to match.
  *    @return Number of characters that fit.
  */
+int gl_printWidthForTextLine( const glFont *ft_font, const char *text, int width )
+{
+   glFontStash *stsh = gl_fontGetStash( ft_font );
+   return font_limitSize( stsh, NULL, text, width );
+}
+
+
+/**
+ * @brief Gets the number of characters in text that fit into width,
+ *        assuming your intent is to word-wrap at said width.
+ *
+ *    @param ft_font Font to use.
+ *    @param text Text to check.
+ *    @param width Width to match.
+ *    @return Number of characters that fit.
+ */
 int gl_printWidthForText( const glFont *ft_font, const char *text,
       const int width )
 {

--- a/src/font.h
+++ b/src/font.h
@@ -83,8 +83,8 @@ FORMAT( printf, 7, 8 ) int gl_printText( const glFont *ft_font,
       const glColour* c, const char *fmt, ... );
 
 /* Dimension stuff. */
-int gl_printWidthForText( const glFont *ft_font, const char *text,
-      const int width );
+int gl_printWidthForTextLine( const glFont *ft_font, const char *text, int width );
+int gl_printWidthForText( const glFont *ft_font, const char *text, int width );
 int gl_printWidthRaw( const glFont *ft_font, const char *text );
 FORMAT( printf, 2, 3 )int gl_printWidth( const glFont *ft_font, const char *fmt, ... );
 int gl_printHeightRaw( const glFont *ft_font, const int width, const char *text );

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -514,12 +514,18 @@ static int inp_rangeToWidth( Widget *inp, int start_pos, int end_pos )
  */
 static int inp_rangeFromWidth( Widget *inp, int start_pos, int width )
 {
-   int tw, oneline;
+   int tw, oneline, out;
+   char *str, *eol;
+
+   str = &inp->dat.inp.input[start_pos];
    tw = width>=0 ? width : inp->w-10;
    oneline = width>=0 || inp->dat.inp.oneline;
    if (oneline)
-      return gl_printWidthForTextLine( inp->dat.inp.font, &inp->dat.inp.input[start_pos], tw );
-   return gl_printWidthForText( inp->dat.inp.font, &inp->dat.inp.input[start_pos], tw );
+      out = gl_printWidthForTextLine( inp->dat.inp.font, str, tw );
+   else
+      out = gl_printWidthForText( inp->dat.inp.font, str, tw );
+   eol = strchr( str, '\n' );
+   return eol ? MIN( out, eol-str ) : out;
 }
 
 

--- a/src/tk/widget/input.c
+++ b/src/tk/widget/input.c
@@ -566,6 +566,8 @@ static int inp_rangeToWidth( Widget *inp, int start_pos, int end_pos )
 
 /*
  * @brief Returns the byte-size of the text we can fit within \p width starting at \p start_pos.
+ *        Note: "for convenience" this function accounts for word-wrap if the widget is word-wrapping
+ *        and width==-1; otherwise, it assumes we're measuring the characters within a line.
  *
  *    @param inp Input widget to operate on.
  *    @param start_pos Starting byte position.
@@ -573,9 +575,12 @@ static int inp_rangeToWidth( Widget *inp, int start_pos, int end_pos )
  */
 static int inp_rangeFromWidth( Widget *inp, int start_pos, int width )
 {
-   if (width < 0)
-      width = inp->w - 10;
-   return gl_printWidthForText( inp->dat.inp.font, &inp->dat.inp.input[start_pos], width );
+   int tw, oneline;
+   tw = width>=0 ? width : inp->w-10;
+   oneline = width>=0 || inp->dat.inp.oneline;
+   if (oneline)
+      return gl_printWidthForTextLine( inp->dat.inp.font, &inp->dat.inp.input[start_pos], tw );
+   return gl_printWidthForText( inp->dat.inp.font, &inp->dat.inp.input[start_pos], tw );
 }
 
 


### PR DESCRIPTION
... even if some maniacal tester enters them in the dev-mode multi-line text boxes and uses the up/down arrow keys.
(But if char widths vary enough across lines, the new approach should look better.)
The logic should generally be a little more foolproof/hackable and a little less efficient when clamping and moving up/down lines.

I don't expect 0.8 to need this, because the game itself uses one-line inputs and those basically work fine already.