### PR TITLE
Consider hidden jumps when selecting a victim planet in pir_ship_stealing.lua.

### DIFF
--- a/dat/missions/pirate/pir_ship_stealing.lua
+++ b/dat/missions/pirate/pir_ship_stealing.lua
@@ -186,8 +186,7 @@ function random_planet()
             end
          end 
          return false
-      end
-   )
+      end, nil, true )
 
    if #planets > 0 then
       return planets[rnd.rnd(1,#planets)]


### PR DESCRIPTION
Presumption is that hidden jumps near Pirate systems are Pirate routes. (pirate/empbounty_dead.lua makes a similar assumption.)