### PR TITLE
Removed puke-green coloring of imagearray selections.

### DIFF
--- a/src/tk/widget/imagearray.c
+++ b/src/tk/widget/imagearray.c
@@ -199,21 +199,9 @@ static void iar_render( Widget* iar, double bx, double by )
 
          fontcolour = cFontWhite;
          /* Draw background. */
-         if (iar->dat.iar.images[pos].bg.a > 0.) {
-            if (is_selected) {
-               toolkit_drawRect( xcurs + 2.,
-                     ycurs + 2.,
-                     w - 5., h - 5., &cDarkGreen, NULL );
-            } else {
-               toolkit_drawRect( xcurs + 2.,
-                     ycurs + 2.,
-                     w - 5., h - 5., &iar->dat.iar.images[pos].bg, NULL );
-            }
-         } else if (is_selected) {
-            toolkit_drawRect( xcurs + 2.,
-                  ycurs + 2.,
-                  w - 5., h - 5., &cDarkGreen, NULL );
-         }
+         toolkit_drawRect( xcurs + 2.,
+               ycurs + 2.,
+               w - 5., h - 5., &iar->dat.iar.images[pos].bg, NULL );
 
          /* image */
          if (iar->dat.iar.images[pos].image != NULL)


### PR DESCRIPTION
Looks much better, and seems redundant; the white outline is perfectly sufficient and allows the background color to still be seen.

![Screenshot at 2020-12-04 19-56-05](https://user-images.githubusercontent.com/2217995/101228790-25e38380-366b-11eb-951f-2b6c617dd2c8.png)

🕷️