### PR TITLE
Modified colors for indicating pilots, planets, etc.

### DIFF
--- a/src/colour.c
+++ b/src/colour.c
@@ -76,13 +76,11 @@ const glColour cBlackHilight  =  { .r = 0.0, .g = 0.0, .b = 0.0, .a = 0.4 }; /**
 /* toolkit */
 const glColour cHilight       =  { .r = 0.1, .g = 0.9, .b = 0.1, .a = 0.6 }; /**< Hilight colour */
 /* objects */
-const glColour cInert         =  { .r = 0.6, .g = 0.6, .b = 0.6, .a = 1.  }; /**< Inert object colour */
-const glColour cMapInert      =  { .r = 0.4, .g = 0.4, .b = 0.4, .a = 1. }; /**< Inert object map screen text colour */
-const glColour cNeutral       =  { .r = 0.9, .g = 1.0, .b = 0.3, .a = 1.  }; /**< Neutral object colour */
-const glColour cMapNeutral    =  { .r = 0.2, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Neutral object map screen text colour */
-const glColour cFriend        =  { .r = 0.0, .g = 0.8, .b = 0.0, .a = 1.  }; /**< Friend object colour */
-const glColour cHostile       =  { .r = 0.9, .g = 0.2, .b = 0.2, .a = 1.  }; /**< Hostile object colour */
-const glColour cRestricted    =  { .r = 1.0, .g = 0.6, .b = 0.0, .a = 1.  }; /**< Restricted object colour. */
+const glColour cInert         =  cQPaleGrey; /**< Inert object colour */
+const glColour cNeutral       =  cQSand; /**< Neutral object colour */
+const glColour cFriend        =  cQTeal; /**< Friend object colour */
+const glColour cHostile       =  cQPurple; /**< Hostile object colour */
+const glColour cRestricted    =  cQOlive; /**< Restricted object colour. */
 const glColour cDRestricted   =  { .r = 0.7, .g = 0.3, .b = 0.0, .a = 1.  }; /**< Restricted object colour. Darkened for use on white. */
 /* radar */
 const glColour cRadar_player  =  { .r = 0.4, .g = 0.8, .b = 0.4, .a = 1.  }; /**< Player colour on radar. */

--- a/src/colour.c
+++ b/src/colour.c
@@ -76,11 +76,11 @@ const glColour cBlackHilight  =  { .r = 0.0, .g = 0.0, .b = 0.0, .a = 0.4 }; /**
 /* toolkit */
 const glColour cHilight       =  { .r = 0.1, .g = 0.9, .b = 0.1, .a = 0.6 }; /**< Hilight colour */
 /* objects */
-const glColour cInert         =  cQPaleGrey; /**< Inert object colour */
-const glColour cNeutral       =  cQSand; /**< Neutral object colour */
-const glColour cFriend        =  cQTeal; /**< Friend object colour */
-const glColour cHostile       =  cQPurple; /**< Hostile object colour */
-const glColour cRestricted    =  cQOlive; /**< Restricted object colour. */
+const glColour cInert         =  { .r=221./255., .g=221./255., .b=221./255., .a=1. }; /**< Inert object colour */
+const glColour cNeutral       =  { .r=221./255., .g=204./255., .b=119./255., .a=1. }; /**< Neutral object colour */
+const glColour cFriend        =  {  .r=68./255., .g=170./255., .b=153./255., .a=1. }; /**< Friend object colour */
+const glColour cHostile       =  { .r=170./255.,  .g=68./255., .b=153./255., .a=1. }; /**< Hostile object colour */
+const glColour cRestricted    =  { .r=153./255., .g=153./255.,  .b=51./255., .a=1. }; /**< Restricted object colour. */
 const glColour cDRestricted   =  { .r = 0.7, .g = 0.3, .b = 0.0, .a = 1.  }; /**< Restricted object colour. Darkened for use on white. */
 /* radar */
 const glColour cRadar_player  =  { .r = 0.4, .g = 0.8, .b = 0.4, .a = 1.  }; /**< Player colour on radar. */

--- a/src/colour.h
+++ b/src/colour.h
@@ -70,9 +70,7 @@ extern const glColour cBlackHilight;
 extern const glColour cHilight;
 /* objects */
 extern const glColour cInert;
-extern const glColour cMapInert;
 extern const glColour cNeutral;
-extern const glColour cMapNeutral;
 extern const glColour cFriend;
 extern const glColour cHostile;
 extern const glColour cRestricted;

--- a/src/font.c
+++ b/src/font.c
@@ -1296,11 +1296,11 @@ static const glColour* gl_fontGetColour( uint32_t ch )
       case 'p': col = &cFontPurple; break;
       case 'n': col = &cFontGrey; break;
       /* Fancy states. */
-      case 'F': col = &cFontGreen; break; /**< Friendly */
-      case 'H': col = &cFontRed; break; /**< Hostile */
-      case 'N': col = &cFontYellow; break; /**< Neutral */
-      case 'I': col = &cFontGrey; break; /**< Inert */
-      case 'R': col = &cFontOrange; break; /**< Restricted */
+      case 'F': col = &cFriend; break; /**< Friendly */
+      case 'H': col = &cHostile; break; /**< Hostile */
+      case 'N': col = &cNeutral; break; /**< Neutral */
+      case 'I': col = &cInert; break; /**< Inert */
+      case 'R': col = &cRestricted; break; /**< Restricted */
       case 'C': col = &cFontGreen; break; /**< Console */
       case '0': col = NULL; break;
       default:

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -1305,7 +1305,7 @@ const glColour* pilot_getColour( const Pilot* p )
 {
    const glColour *col;
 
-   if (pilot_inRangePilot(player.p, p, NULL) == -1) col = &cMapNeutral;
+   if (pilot_inRangePilot(player.p, p, NULL) == -1) col = &cNeutral;
    else if (pilot_isDisabled(p) || pilot_isFlag(p,PILOT_DEAD)) col = &cInert;
    else if (pilot_isFriendly(p)) col = &cFriend;
    else if (pilot_isHostile(p)) col = &cHostile;


### PR DESCRIPTION
This replaces the "friend", "hostile", "neutral", "inert", and "restricted" colors with colors from the muted colors set. It's not perfect, but combined with the symbols on planets and in other similar places, it seems to be an improvement. Colors were chosen to maximize contrast between neutral, hostile, and friendly (since distinguishing pilots' coloring can't be replaced by any sort of symbol).

🕷️