### PR TITLE
Fix format-security warning on Windows code path.

### DIFF
--- a/src/nfile.c
+++ b/src/nfile.c
@@ -294,7 +294,7 @@ const char *_nfile_dirname( const char *path )
       return path;
 
    /* New dirname. */
-   nsnprintf( dirname_buf, MIN(sizeof(dirname_buf), (size_t)(i+1)),  path );
+   strncpy( dirname_buf, path, MIN(sizeof(dirname_buf)-1, (size_t)i) );
    return dirname_buf;
 #else
 #error "Functionality not implemented for your OS."


### PR DESCRIPTION
(All those users whose install paths contain "%s" can breathe a sigh of relief.)