### PR TITLE
a try at making PRINTF_FORMAT less error-prone

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -347,7 +347,7 @@ case "$host" in
 esac
 
 # global
-GLOBAL_CFLAGS="-include \"\$(top_builddir)/src/config.h\" -include \"\$(top_builddir)/src/attributes.h\" -I\"\$(top_srcdir)/src\" -DPKGDATADIR=\\\"\$(pkgdatadir)\\\" -W -Wall -Wextra -Wunused -Wshadow -Wpointer-arith -Wmissing-prototypes -Winline -Wcast-align -Wmissing-declarations -Wredundant-decls -Wcast-align -Wformat -Wformat-security"
+GLOBAL_CFLAGS="-include \"\$(top_builddir)/src/config.h\" -I\"\$(top_srcdir)/src\" -DPKGDATADIR=\\\"\$(pkgdatadir)\\\" -W -Wall -Wextra -Wunused -Wshadow -Wpointer-arith -Wmissing-prototypes -Winline -Wcast-align -Wmissing-declarations -Wredundant-decls -Wcast-align -Wformat -Wformat-security"
 GLOBAL_LIBS=
 
 AS_IF([test "x$enable_debug" != "xno"], [

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -40,13 +40,6 @@
    #define FORMAT( ... )
 #endif
 
-/* @todo We should declare the fmt argument nonnull, but we have to rip out some null checks first. */
-#ifdef __MINGW_PRINTF_FORMAT
-   #define PRINTF_FORMAT( i, j ) FORMAT( __MINGW_PRINTF_FORMAT, i, j) /*NONNULL( i )*/
-#else
-   #define PRINTF_FORMAT( i, j ) FORMAT( printf, i, j) /*NONNULL( i )*/
-#endif
-
 // User defined diagnosis
 #if __has_attribute( diagnose_if )
    #define WARN_IF( c, m ) __attribute__( ( diagnose_if( c, m, "warning" ) ) )

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -8,7 +8,7 @@
 #  define DIALOGUE_H
 
 
-#include "attributes.h"
+#include "nstring.h"
 
 
 /*

--- a/src/font.h
+++ b/src/font.h
@@ -8,7 +8,7 @@
 #  define FONT_H
 
 
-#include "attributes.h"
+#include "nstring.h"
 #include "opengl.h"
 
 

--- a/src/land.h
+++ b/src/land.h
@@ -8,8 +8,8 @@
 #  define LAND_H
 
 
-#include "attributes.h"
 #include "conf.h"
+#include "nstring.h"
 #include "space.h"
 
 

--- a/src/log.h
+++ b/src/log.h
@@ -12,8 +12,8 @@
 #include <stdio.h>
 #include <signal.h>
 
-#include "attributes.h"
 #include "gettext.h"
+#include "nstring.h"
 
 #if defined ENABLE_NLS && ENABLE_NLS
 #define _(String) gettext(String)

--- a/src/nstring.h
+++ b/src/nstring.h
@@ -7,12 +7,25 @@
 #  define NSTRING_H
 
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "attributes.h"
 #include "ncompat.h"
 
+#ifdef __MINGW_PRINTF_FORMAT
+   #define BUILTIN_PRINTF_FORMAT __MINGW_PRINTF_FORMAT
+#else
+   #define BUILTIN_PRINTF_FORMAT printf
+#endif
+
+/**
+ * @brief A function which passes on a format string to vsnprintf or the like should have PRINTF_FORMAT( i, j )
+ *        in front of its prototype, where i is the 1-based index of the format-string argument and j is the
+ *        1-based index where the formatted items (if any) start.
+ * @todo We should declare the fmt argument nonnull, but we have to rip out some null checks first. */
+#define PRINTF_FORMAT( i, j ) FORMAT( BUILTIN_PRINTF_FORMAT, i, j) /*NONNULL( i )*/
 
 const char *nstrnstr( const char *haystack, const char *needle, size_t size );
 #if HAS_POSIX && defined(_GNU_SOURCE)

--- a/src/player.h
+++ b/src/player.h
@@ -7,7 +7,7 @@
 #  define PLAYER_H
 
 
-#include "attributes.h"
+#include "nstring.h"
 #include "pilot.h"
 
 /** Player flag enum. */

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -7,7 +7,7 @@
 
 /* Note: these utilities are from cutetf8, which also provides u8_escape and u8_escape_wchar.
  * Those are nice, but removed pending an audit of how they use Windows format strings. */
-#include "attributes.h"
+#include "nstring.h"
 
 extern int locale_is_utf8;
 


### PR DESCRIPTION
The last PR left a weird situation where PRINTF_FORMAT( fmt_arg_index, va_list_index ) could go wrong if you included "attributes.h" before <stdio.h>.
I never found a perfect answer, but this seems OK: (1) put it with nsnprintf in in nstring.h, (2) nstring.h includes stdio.h, (3) we stop having Autotools builds pre-include "attributes.h" because I don't think it makes sense. (This was never set up for Meson.)