### PR TITLE
"Fix" libxml2/MinGW warnings with Dvaered engineering. (After testing, I don't think they're bugs, and they're noisy enough to hide actual bugs.)

### DIFF
--- a/src/nxml.h
+++ b/src/nxml.h
@@ -9,6 +9,17 @@
 
 #include <errno.h>
 
+#ifdef __MINGW64_VERSION_MAJOR
+   /* HACK: libxml2 assumes in its function declarations that its format
+    * strings are handled by the native (legacy Microsoft) printf-family
+    * functions. Their source even #defines vsnprintf to _vsnprintf for maximum
+    * breakage. However, testing a shows, e.g., xmlw_attr with PRIu64 formats
+    * will still work on a MinGW64 build.
+    * Therefore, we vandalize their (unfixable) diagnostics Dvaered-style.
+    * */
+#  define LIBXML_ATTR_FORMAT( fmt, args )
+#endif
+
 #include "libxml/parser.h"
 #include "libxml/xmlwriter.h"
 


### PR DESCRIPTION
The caveat: that "testing" was under Wine with the DLL coming from my system's mingw-w64-libxml2 package.
Shouldn't matter, but might?
If we add asprintf() later, we can replace the xmlTextWriterWriteFormat* calls with a smarter macro and sidestep all of this crap. That sounds like 0.9 work to me.