### PR TITLE
If a mouse event callback says it handled the event (by returning non…zero), **stop asking widgets to handle the event**.

### DIFF
--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -1560,6 +1560,9 @@ static int toolkit_mouseEvent( Window *w, SDL_Event* event )
       }
       else
          ret |= toolkit_mouseEventWidget( w, wgt, event, x, y, rx, ry );
+
+      if (ret != 0)
+         return ret;
    }
 
    return ret;


### PR DESCRIPTION
Light testing shows good results.
In particular, clicking OK on a shiplog popup doesn't register as also clicking the list underneath.
I suspect this will also avoid an earlier bug involving map_find UI reentrancy (previously addressed with a kludge).
However, this has the potential to affect a lot of stuff. We have to be really sure the linked list of widgets is ordered properly and nothing is going to claim an event falsely.
It also calls the surrounding "ret |=" pattern into question. Shouldn't we just use "ret =" and stop after it goes nonzero? (On most of these branches the effect is the same, as we set ret = 0 and only allow one "ret |=" branch to happen.)
