### PR TITLE
[For 0.9] Introduce typed versions of xmlr_attr. Use them. Everything hurts less now.

### DIFF
--- a/src/commodity.c
+++ b/src/commodity.c
@@ -322,7 +322,7 @@ static int commodity_parse( Commodity *temp, xmlNodePtr parent )
       if (xml_isNode(node, "planet_modifier")) {
          newdict = malloc(sizeof(CommodityModifier));
          newdict->next = temp->planet_modifier;
-         newdict->name = xml_nodeProp(node,(xmlChar*)"type");
+         xmlr_attr_strd(node, "type", newdict->name);
          newdict->value = xml_getFloat(node);
          temp->planet_modifier = newdict;
          continue;
@@ -330,7 +330,7 @@ static int commodity_parse( Commodity *temp, xmlNodePtr parent )
       if (xml_isNode(node, "faction_modifier")) {
          newdict = malloc(sizeof(CommodityModifier));
          newdict->next = temp->faction_modifier;
-         newdict->name = xml_nodeProp(node, (xmlChar*)"type");
+         xmlr_attr_strd(node, "type", newdict->name);
          newdict->value = xml_getFloat(node);
          temp->faction_modifier = newdict;
       }

--- a/src/damagetype.c
+++ b/src/damagetype.c
@@ -69,8 +69,7 @@ static int DTYPE_parse( DTYPE *temp, const xmlNodePtr parent )
    /* Clear data. */
    memset( temp, 0, sizeof(DTYPE) );
 
-   /* Get the name (mallocs). */
-   temp->name = xml_nodeProp(parent,"name");
+   xmlr_attr_strd( parent, "name", temp->name );
 
    /* Extract the data. */
    node = parent->xmlChildrenNode;
@@ -80,7 +79,7 @@ static int DTYPE_parse( DTYPE *temp, const xmlNodePtr parent )
       if (xml_isNode(node, "shield")) {
          temp->sdam = xml_getFloat(node);
 
-         xmlr_attr(node, "stat", stat);
+         xmlr_attr_strd( node, "stat", stat );
          if (stat != NULL) {
             temp->soffset = ss_offsetFromType( ss_typeFromName(stat) );
             free(stat);
@@ -91,7 +90,7 @@ static int DTYPE_parse( DTYPE *temp, const xmlNodePtr parent )
       else if (xml_isNode(node, "armour")) {
          temp->adam = xml_getFloat(node);
 
-         xmlr_attr(node, "stat", stat);
+         xmlr_attr_strd( node, "stat", stat );
          if (stat != NULL) {
             temp->aoffset = ss_offsetFromType( ss_typeFromName(stat) );
             free(stat);

--- a/src/economy.c
+++ b/src/economy.c
@@ -1013,7 +1013,6 @@ void economy_clearSinglePlanet(Planet *p)
 int economy_sysLoad( xmlNodePtr parent )
 {
    xmlNodePtr node, cur, nodeAsset, nodeCommodity;
-   //StarSystem *sys;
    char *str;
    Planet *planet;
    int i;
@@ -1028,19 +1027,17 @@ int economy_sysLoad( xmlNodePtr parent )
          cur = node->xmlChildrenNode;
          do {
             if (xml_isNode(cur, "system")) {
-               xmlr_attr(cur,"name",str);
-               //sys = system_get(str);
-               free(str);
+               /* Ignore "name" attribute. */
                nodeAsset = cur->xmlChildrenNode;
                do{
                   if (xml_isNode(nodeAsset, "planet")) {
-                     xmlr_attr(nodeAsset,"name",str);
+                     xmlr_attr_strd(nodeAsset,"name",str);
                      planet = planet_get(str);
                      free(str);
                      nodeCommodity = nodeAsset->xmlChildrenNode;
                      do{
                         if (xml_isNode(nodeCommodity, "commodity")) {
-                           xmlr_attr(nodeCommodity,"name",str);
+                           xmlr_attr_strd(nodeCommodity,"name",str);
                            cp = NULL;
                            for (i=0; i<planet->ncommodities; i++) {
                               if ( (strcmp(str,planet->commodities[i]->name) == 0) ) {
@@ -1050,33 +1047,17 @@ int economy_sysLoad( xmlNodePtr parent )
                            }
                            free(str);
                            if ( cp != NULL ) {
-                              xmlr_attr(nodeCommodity,"sum",str);
-                              if (str) {
-                                 cp->sum = atof(str);
-                                 free(str);
-                              }
-                              xmlr_attr(nodeCommodity,"sum2",str);
-                              if (str) {
-                                 cp->sum2 = atof(str);
-                                 free(str);
-                              }
-                              xmlr_attr(nodeCommodity,"cnt",str);
-                              if (str) {
-                                 cp->cnt = atoi(str);
-                                 free(str);
-                              }
-                              xmlr_attr(nodeCommodity,"time",str);
-                              if (str) {
-                                 cp->updateTime = atoll(str);
-                                 free(str);
-                              }
+                              xmlr_attr_float(nodeCommodity,"sum",cp->sum);
+                              xmlr_attr_float(nodeCommodity,"sum2",cp->sum2);
+                              xmlr_attr_int(nodeCommodity,"cnt",cp->cnt);
+                              xmlr_attr_long(nodeCommodity,"time",cp->updateTime);
                            }
                         }
                      } while (xml_nextNode(nodeCommodity));
                   }
                } while (xml_nextNode(nodeAsset));
             } else if (xml_isNode(cur, "lastPurchase")) {
-               xmlr_attr(cur, "name", str);
+               xmlr_attr_strd(cur, "name", str);
                if (str) {
                   c=commodity_get(str);
                   c->lastPurchasePrice=xml_getLong(cur);

--- a/src/event.c
+++ b/src/event.c
@@ -446,7 +446,7 @@ static int event_parseXML( EventData *temp, const xmlNodePtr parent )
    memset( temp, 0, sizeof(EventData) );
 
    /* get the name */
-   temp->name = xml_nodeProp(parent, "name");
+   xmlr_attr_strd(parent, "name", temp->name);
    if (temp->name == NULL)
       WARN(_("Event in %s has invalid or no name"), EVENT_DATA_PATH);
 
@@ -863,7 +863,7 @@ static int events_parseActive( xmlNodePtr parent )
       if (!xml_isNode(node,"event"))
          continue;
 
-      xmlr_attr(node,"name",buf);
+      xmlr_attr_strd(node,"name",buf);
       if (buf==NULL) {
          WARN(_("Event has missing 'name' attribute, skipping."));
          continue;
@@ -875,13 +875,7 @@ static int events_parseActive( xmlNodePtr parent )
          continue;
       }
       free(buf);
-      xmlr_attr(node,"id",buf);
-      if (buf==NULL) {
-         WARN(_("Event with data '%s' has missing 'id' attribute, skipping."), event_dataName(data));
-         continue;
-      }
-      id = atoi(buf);
-      free(buf);
+      xmlr_attr_uint(node,"id",id);
       if (id==0) {
          WARN(_("Event with data '%s' has invalid 'id' attribute, skipping."), event_dataName(data));
          continue;

--- a/src/faction.c
+++ b/src/faction.c
@@ -1263,23 +1263,9 @@ static int faction_parse( Faction* temp, xmlNodePtr parent )
             /* Initialize in case a colour channel is absent. */
             col = calloc( 1, sizeof(glColour) );
 
-            xmlr_attr(node,"r",ctmp);
-            if (ctmp != NULL) {
-               col->r = atof(ctmp);
-               free(ctmp);
-            }
-
-            xmlr_attr(node,"g",ctmp);
-            if (ctmp != NULL) {
-               col->g = atof(ctmp);
-               free(ctmp);
-            }
-
-            xmlr_attr(node,"b",ctmp);
-            if (ctmp != NULL) {
-               col->b = atof(ctmp);
-               free(ctmp);
-            }
+            xmlr_attr_float(node,"r",col->r);
+            xmlr_attr_float(node,"g",col->g);
+            xmlr_attr_float(node,"b",col->b);
 
             col->a = 1.;
             temp->colour = col;
@@ -1682,11 +1668,10 @@ int pfaction_load( xmlNodePtr parent )
          cur = node->xmlChildrenNode;
          do {
             if (xml_isNode(cur,"faction")) {
-               xmlr_attr(cur, "name", str);
+               xmlr_attr_strd(cur, "name", str);
                faction = faction_get(str);
 
                if (faction != -1) { /* Faction is valid. */
-
                   sub = cur->xmlChildrenNode;
                   do {
                      if (xml_isNode(sub,"standing")) {

--- a/src/hook.c
+++ b/src/hook.c
@@ -1286,7 +1286,7 @@ static int hook_parse( xmlNodePtr base )
          is_date  = 0;
 
          /* Handle the type. */
-         xmlr_attr(node, "type", stype);
+         xmlr_attr_strd(node, "type", stype);
          /* Default to mission for old saves. */
          if (stype == NULL)
             type = HOOK_TYPE_MISN;

--- a/src/load.c
+++ b/src/load.c
@@ -126,7 +126,7 @@ static int load_load( nsave_t *save, const char *path )
 
       if (xml_isNode(parent, "player")) {
          /* Get name. */
-         xmlr_attr(parent, "name", save->name);
+         xmlr_attr_strd(parent, "name", save->name);
          /* Parse rest. */
          node = parent->xmlChildrenNode;
          do {
@@ -151,8 +151,8 @@ static int load_load( nsave_t *save, const char *path )
 
             /* Ship info. */
             if (xml_isNode(node, "ship")) {
-               xmlr_attr(node, "name", save->shipname);
-               xmlr_attr(node, "model", save->shipmodel);
+               xmlr_attr_strd(node, "name", save->shipname);
+               xmlr_attr_strd(node, "model", save->shipmodel);
                continue;
             }
          } while (xml_nextNode(node));

--- a/src/news.c
+++ b/src/news.c
@@ -646,7 +646,7 @@ int news_loadArticles( xmlNodePtr parent )
  */
 static int news_parseArticle( xmlNodePtr parent )
 {
-   char *ntitle, *ndesc, *title, *desc, *faction, *tag;
+   char *ntitle, *ndesc, *title, *desc, *faction;
    char *buff;
    ntime_t date, date_to_rm;
    xmlNodePtr node;
@@ -656,7 +656,7 @@ static int news_parseArticle( xmlNodePtr parent )
    node = parent->xmlChildrenNode;
 
 #define NEWS_READ(elem, s) \
-xmlr_attr(node, s, elem); \
+xmlr_attr_strd(node, s, elem); \
 if (elem == NULL) { WARN(_("Event is missing '%s', skipping."), s); goto cleanup; }
 
    do {
@@ -670,7 +670,6 @@ if (elem == NULL) { WARN(_("Event is missing '%s', skipping."), s); goto cleanup
       title   = NULL;
       desc    = NULL;
       faction = NULL;
-      tag     = NULL;
 
       NEWS_READ(title, "title");
       NEWS_READ(desc, "desc");
@@ -693,13 +692,11 @@ if (elem == NULL) { WARN(_("Event is missing '%s', skipping."), s); goto cleanup
       ntitle = get_fromclean(title);
       ndesc  = get_fromclean(desc);
 
-      /* Optional. */
-      xmlr_attr(node, "tag", tag);
 
       /* make the article*/
       n_article = new_article(ntitle, ndesc, faction, date, date_to_rm);
-      if (tag != NULL)
-         n_article->tag = strdup(tag);
+      /* Read optional tag. */
+      xmlr_attr_strd(node, "tag", n_article->tag);
 
 cleanup:
       free(ntitle);
@@ -707,7 +704,6 @@ cleanup:
       free(title);
       free(desc);
       free(faction);
-      free(tag);
    } while (xml_nextNode(node));
 #undef NEWS_READ
 

--- a/src/nlua_var.c
+++ b/src/nlua_var.c
@@ -157,8 +157,8 @@ int var_load( xmlNodePtr parent )
 
          do {
             if (xml_isNode(cur,"var")) {
-               xmlr_attr(cur,"name",var.name);
-               xmlr_attr(cur,"type",str);
+               xmlr_attr_strd(cur,"name",var.name);
+               xmlr_attr_strd(cur,"type",str);
                if (strcmp(str,"nil")==0)
                   var.type = MISN_VAR_NIL;
                else if (strcmp(str,"num")==0) {

--- a/src/nxml.c
+++ b/src/nxml.c
@@ -35,25 +35,14 @@ glTexture* xml_parseTexture( xmlNodePtr node,
    char *buf, filename[PATH_MAX];
    glTexture *tex;
 
+   xmlr_attr_atoi_neg1(node, "sx", sx );
+   xmlr_attr_atoi_neg1(node, "sy", sy );
+
    /*
     * Safe defaults.
     */
-   sx = defsx;
-   sy = defsy;
-
-   /* Read x sprites. */
-   xmlr_attr(node, "sx", buf );
-   if (buf != NULL) {
-      sx = atoi(buf);
-      free(buf);
-   }
-
-   /* Read y sprites. */
-   xmlr_attr(node, "sy", buf );
-   if (buf != NULL) {
-      sy = atoi(buf);
-      free(buf);
-   }
+   if (sx == -1) sx = defsx;
+   if (sy == -1) sy = defsy;
 
    /* Get graphic to load. */
    buf = xml_get( node );

--- a/src/nxml.h
+++ b/src/nxml.h
@@ -46,9 +46,6 @@
 #define xml_nextNode(n)     \
    ((n!=NULL) && ((n = n->next) != NULL))
 
-/* gets the property s of node n. WARNING: MALLOCS! */
-#define xml_nodeProp(n,s)     (char*)xmlGetProp(n,(xmlChar*)s)
-
 /* get data different ways */
 #define xml_raw(n)            ((char*)(n)->children->content)
 #define xml_get(n)            (((n)->children == NULL) ? NULL : (char*)(n)->children->content)
@@ -90,8 +87,19 @@
          WARN("Node '%s' already loaded and being replaced from '%s' to '%s'", \
                s, str, xml_raw(n) ); } \
       str = ((xml_get(n) == NULL) ? NULL : strdup(xml_raw(n))); continue; }}
+/** DEPRECATED synonym for xmlr_attr_strd. (This one just isn't explicit about being a malloc.)
+ * It's still used by old code that needs to be reviewed or deleted for other reasons. */
 #define xmlr_attr(n,s,a) \
-   a = xml_nodeProp(n,s)
+   a = (char*)xmlGetProp(n,(xmlChar*)s)
+#define xmlr_attr_int(n,s,a)     do {xmlr_attr(n,s,char*T); a = T==NULL ? 0 : strtol(  T, NULL, 10); free(T);} while(0)
+#define xmlr_attr_int(n,s,a)     do {xmlr_attr(n,s,char*T); a = T==NULL ? 0 : strtol(  T, NULL, 10); free(T);} while(0)
+#define xmlr_attr_uint(n,s,a)    do {xmlr_attr(n,s,char*T); a = T==NULL ? 0 : strtoul( T, NULL, 10); free(T);} while(0)
+#define xmlr_attr_long(n,s,a)    do {xmlr_attr(n,s,char*T); a = T==NULL ? 0 : strtoll( T, NULL, 10); free(T);} while(0)
+#define xmlr_attr_ulong(n,s,a)   do {xmlr_attr(n,s,char*T); a = T==NULL ? 0 : strtoull(T, NULL, 10); free(T);} while(0)
+#define xmlr_attr_float(n,s,a)   do {xmlr_attr(n,s,char*T); a = T==NULL ? 0 :     atof(T          ); free(T);} while(0)
+#define xmlr_attr_strd(n,s,a)    xmlr_attr(n,s,a)
+/** DEPRECATED common pattern for optional ints (actually of type int) */
+#define xmlr_attr_atoi_neg1(n,s,a) do {xmlr_attr(n,s,char*T); a = T==NULL ? -1 : atoi(T); free(T);} while(0)
 
 /*
  * writer crap

--- a/src/nxml_lua.c
+++ b/src/nxml_lua.c
@@ -355,10 +355,10 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
    do {
       if (xml_isNode(node,"data")) {
          /* Get general info. */
-         xmlr_attr(node,"name",name);
-         xmlr_attr(node,"type",type);
+         xmlr_attr_strd(node,"name",name);
+         xmlr_attr_strd(node,"type",type);
          /* Check to see if key is a number. */
-         xmlr_attr(node,"keynum",num);
+         xmlr_attr_strd(node,"keynum",num);
          if (num != NULL) {
             lua_pushnumber(L, atof(name));
             free(num);
@@ -366,7 +366,7 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
          else if ( name != NULL )
             lua_pushstring(L, name);
          else {
-            xmlr_attr( node, "name_base64", name );
+            xmlr_attr_strd( node, "name_base64", name );
             data = base64_decode_cstr( &len, name );
             lua_pushlstring( L, data, len );
             free( data );
@@ -375,7 +375,7 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
          /* handle data types */
          /* Recursive tables. */
          if (strcmp(type,"table")==0) {
-            xmlr_attr(node,"name",buf);
+            xmlr_attr_strd(node,"name",buf);
             /* Create new table. */
             lua_newtable(L);
             /* Save data. */
@@ -419,7 +419,7 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
          }
          else if (strcmp(type,JUMP_METATABLE)==0) {
             ss = system_get(xml_get(node));
-            system_get(xmlr_attr(node,"dest",buf));
+            xmlr_attr_strd(node,"dest",buf);
             dest = system_get( buf );
             if ((ss != NULL) && (dest != NULL)) {
                lj.srcid = ss->id;
@@ -428,6 +428,7 @@ static int nxml_unpersistDataNode( lua_State *L, xmlNodePtr parent )
             }
             else
                WARN(_("Failed to load nonexistent jump from '%s' to '%s'"), xml_get(node), buf);
+            free(buf);
          }
          else if (strcmp(type,COMMODITY_METATABLE)==0)
             lua_pushcommodity(L,commodity_get(xml_get(node)));

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -1155,7 +1155,7 @@ static void outfit_parseSBolt( Outfit* temp, const xmlNodePtr parent )
       xmlr_float(node,"track",temp->u.blt.track);
       xmlr_float(node,"swivel",temp->u.blt.swivel);
       if (xml_isNode(node,"range")) {
-         buf = xml_nodeProp(node,"blowup");
+         xmlr_attr_strd(node,"blowup",buf);
          if (buf != NULL) {
             if (strcmp(buf,"armour")==0)
                outfit_setProp(temp, OUTFIT_PROP_WEAP_BLOWUP_SHIELD);
@@ -1176,7 +1176,7 @@ static void outfit_parseSBolt( Outfit* temp, const xmlNodePtr parent )
          temp->u.blt.gfx_space = xml_parseTexture( node,
                OUTFIT_GFX_PATH"space/%s.png", 6, 6,
                OPENGL_TEX_MAPTRANS | OPENGL_TEX_MIPMAPS );
-         xmlr_attr(node, "spin", buf);
+         xmlr_attr_strd(node, "spin", buf);
          if (buf != NULL) {
             outfit_setProp( temp, OUTFIT_PROP_WEAP_SPIN );
             temp->u.blt.spin = atof( buf );
@@ -1316,7 +1316,6 @@ static void outfit_parseSBeam( Outfit* temp, const xmlNodePtr parent )
    int l;
    xmlNodePtr node;
    double C, area;
-   char *prop;
 
    /* Defaults. */
    temp->u.bem.spfx_armour = -1;
@@ -1336,11 +1335,7 @@ static void outfit_parseSBeam( Outfit* temp, const xmlNodePtr parent )
       xmlr_float(node,"heatup",temp->u.bem.heatup);
 
       if (xml_isNode(node, "duration")) {
-         prop = xml_nodeProp(node, "min");
-         if (prop != NULL) {
-            temp->u.bem.min_duration = atof(prop);
-            free(prop);
-         }
+         xmlr_attr_float(node, "min", temp->u.bem.min_duration);
          temp->u.bem.duration = xml_getFloat(node);
          continue;
       }
@@ -1510,7 +1505,7 @@ static void outfit_parseSAmmo( Outfit* temp, const xmlNodePtr parent )
       xml_onlyNodes(node);
       /* Basic */
       if (xml_isNode(node,"duration")) {
-         buf = xml_nodeProp(node,"blowup");
+         xmlr_attr_strd(node,"blowup",buf);
          if (buf != NULL) {
             if (strcmp(buf,"armour")==0)
                outfit_setProp(temp, OUTFIT_PROP_WEAP_BLOWUP_SHIELD);
@@ -1534,12 +1529,9 @@ static void outfit_parseSAmmo( Outfit* temp, const xmlNodePtr parent )
          temp->u.amm.gfx_space = xml_parseTexture( node,
                OUTFIT_GFX_PATH"space/%s.png", 6, 6,
                OPENGL_TEX_MAPTRANS | OPENGL_TEX_MIPMAPS );
-         xmlr_attr(node, "spin", buf);
-         if (buf != NULL) {
+         xmlr_attr_float(node, "spin", temp->u.amm.spin);
+         if (temp->u.amm.spin != 0)
             outfit_setProp( temp, OUTFIT_PROP_WEAP_SPIN );
-            temp->u.amm.spin = atof( buf );
-            free(buf);
-         }
          /* Load the collision polygon. */
          buf = xml_get(node);
          outfit_loadPLG( temp, buf, 0 );
@@ -1628,18 +1620,13 @@ static void outfit_parseSMod( Outfit* temp, const xmlNodePtr parent )
 {
    int i;
    xmlNodePtr node;
-   char *buf;
    ShipStatList *ll;
    node = parent->children;
 
    do { /* load all the data */
       xml_onlyNodes(node);
       if (xml_isNode(node,"active")) {
-         xmlr_attr(node, "cooldown", buf);
-         if (buf != NULL) {
-            temp->u.mod.cooldown = atof( buf );
-            free(buf);
-         }
+         xmlr_attr_float(node, "cooldown", temp->u.mod.cooldown);
          temp->u.mod.active   = 1;
          temp->u.mod.duration = xml_getFloat(node);
 
@@ -1926,8 +1913,9 @@ static void outfit_parseSMap( Outfit *temp, const xmlNodePtr parent )
       xml_onlyNodes(node);
 
       if (xml_isNode(node,"sys")) {
-         buf = xml_nodeProp(node,"name");
-         if ((buf != NULL) && ((sys = system_get(buf)) != NULL)) {
+         xmlr_attr_strd(node,"name",buf);
+         sys = system_get(buf);
+         if (sys != NULL) {
             free(buf);
             array_grow( &temp->u.map->systems ) = sys;
 
@@ -1955,8 +1943,10 @@ static void outfit_parseSMap( Outfit *temp, const xmlNodePtr parent )
                   WARN(_("Outfit '%s' has unknown node '%s'"),temp->name, cur->name);
             } while (xml_nextNode(cur));
          }
-         else
+         else {
             WARN(_("Map '%s' has invalid system '%s'"), temp->name, buf);
+            free(buf);
+         }
       }
       else if (xml_isNode(node,"short_desc")) {
          temp->desc_short = malloc( OUTFIT_SHORTDESC_MAX );
@@ -2139,7 +2129,7 @@ static int outfit_parse( Outfit* temp, const char* file )
    /* Clear data. */
    memset( temp, 0, sizeof(Outfit) );
 
-   temp->name = xml_nodeProp(parent,"name"); /* already mallocs */
+   xmlr_attr_strd(parent,"name",temp->name);
    if (temp->name == NULL)
       WARN(_("Outfit in %s has invalid or no name"), OUTFIT_DATA_PATH);
 
@@ -2204,7 +2194,7 @@ static int outfit_parse( Outfit* temp, const char* file )
                   WARN(_("Outfit '%s' has unknown slot type '%s'."), temp->name, cprop);
 
                /* Property. */
-               xmlr_attr( cur, "prop", prop );
+               xmlr_attr_strd( cur, "prop", prop );
                if (prop != NULL)
                   temp->slot.spid = sp_get( prop );
                free( prop );
@@ -2238,14 +2228,14 @@ static int outfit_parse( Outfit* temp, const char* file )
       if (xml_isNode(node,"specific")) { /* has to be processed separately */
 
          /* get the type */
-         prop = xml_nodeProp(node,"type");
+         xmlr_attr_strd(node, "type", prop);
          if (prop == NULL)
             ERR(_("Outfit '%s' element 'specific' missing property 'type'"),temp->name);
          temp->type = outfit_strToOutfitType(prop);
          free(prop);
 
          /* is secondary weapon? */
-         prop = xml_nodeProp(node,"secondary");
+         xmlr_attr_strd(node, "secondary", prop);
          if (prop != NULL) {
             if ((int)atoi(prop))
                outfit_setProp(temp, OUTFIT_PROP_WEAP_SECONDARY);
@@ -2253,16 +2243,14 @@ static int outfit_parse( Outfit* temp, const char* file )
          }
 
          /* Check for manually-defined group. */
-         prop = xml_nodeProp(node, "group");
-         if (prop != NULL) {
-            group = atoi(prop);
+         xmlr_attr_atoi_neg1(node, "group", group);
+         if (group != -1) {
             if (group > PILOT_WEAPON_SETS || group < 1) {
                WARN(_("Outfit '%s' has group '%d', should be in the 1-%d range"),
                      temp->name, group, PILOT_WEAPON_SETS);
             }
 
             temp->group = CLAMP(0, 9, group - 1);
-            free(prop);
          }
 
          /*
@@ -2461,7 +2449,7 @@ int outfit_mapParse (void)
          continue;
       }
 
-      n = xml_nodeProp( node,"name" );
+      xmlr_attr_strd( node, "name", n );
       o = outfit_get( n );
       free(n);
       if (!outfit_isMap(o)) { /* If its not a map, we don't care. */

--- a/src/player.c
+++ b/src/player.c
@@ -3263,7 +3263,7 @@ Planet* player_load( xmlNodePtr parent )
  */
 static Planet* player_parse( xmlNodePtr parent )
 {
-   char *planet, *found, *str;
+   char *planet, *found;
    unsigned int services;
    Planet *pnt;
    xmlNodePtr node, cur;
@@ -3277,7 +3277,7 @@ static Planet* player_parse( xmlNodePtr parent )
    int cycles, periods, seconds, time_set;
    double rem;
 
-   xmlr_attr(parent,"name",player.name);
+   xmlr_attr_strd(parent, "name", player.name);
 
    /* Make sure player.p is NULL. */
    player.p = NULL;
@@ -3359,12 +3359,8 @@ static Planet* player_parse( xmlNodePtr parent )
                   continue;
                }
 
-               xmlr_attr( cur, "quantity", str );
-               if (str != NULL) {
-                  q = atof(str);
-                  free(str);
-               }
-               else {
+               xmlr_attr_float( cur, "quantity", q );
+               if (q == 0) {
                   WARN(_("Outfit '%s' was saved without quantity!"), o->name);
                   continue;
                }
@@ -3593,7 +3589,7 @@ static int player_parseEscorts( xmlNodePtr parent )
 
    do {
       if (xml_isNode(node,"escort")) {
-         xmlr_attr( node, "type", buf );
+         xmlr_attr_strd( node, "type", buf );
          if (strcmp(buf,"bay")==0)
             type = ESCORT_TYPE_BAY;
          else {
@@ -3666,7 +3662,7 @@ static void player_parseShipSlot( xmlNodePtr node, Pilot *ship, PilotOutfitSlot 
       return;
 
    /* See if has ammo. */
-   xmlr_attr(node,"ammo",buf);
+   xmlr_attr_strd(node,"ammo",buf);
    if (buf == NULL)
       return;
 
@@ -3677,16 +3673,9 @@ static void player_parseShipSlot( xmlNodePtr node, Pilot *ship, PilotOutfitSlot 
       return;
 
    /* See if has quantity. */
-   xmlr_attr(node,"quantity",buf);
-   if (buf == NULL)
-      return;
-
-   /* Get quantity. */
-   q = atoi(buf);
-   free(buf);
-
-   /* Add ammo. */
-   pilot_addAmmo( ship, slot, ammo, q );
+   xmlr_attr_int(node,"quantity",q);
+   if (q > 0)
+      pilot_addAmmo( ship, slot, ammo, q );
 }
 
 
@@ -3699,7 +3688,7 @@ static void player_parseShipSlot( xmlNodePtr node, Pilot *ship, PilotOutfitSlot 
  */
 static int player_parseShip( xmlNodePtr parent, int is_player )
 {
-   char *name, *model, *q, *id;
+   char *name, *model;
    int i, n;
    int fuel;
    Ship *ship_parsed;
@@ -3712,10 +3701,10 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
    Commodity *com;
    PilotFlags flags;
    unsigned int pid;
-   int autoweap, level, weapid, active_set, aim_lines;
+   int autoweap, level, weapid, active_set, aim_lines, in_range, weap_type;
 
-   xmlr_attr(parent,"name",name);
-   xmlr_attr(parent,"model",model);
+   xmlr_attr_strd( parent, "name", name );
+   xmlr_attr_strd( parent, "model", model );
 
    /* Safe defaults. */
    pilot_clearFlagsRaw( flags );
@@ -3770,12 +3759,7 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          cur = node->xmlChildrenNode;
          do { /* load each outfit */
             if (xml_isNode(cur,"outfit")) {
-               xmlr_attr(cur,"slot",q);
-               n = -1;
-               if (q != NULL) {
-                  n = atoi(q);
-                  free(q);
-               }
+               xmlr_attr_atoi_neg1( cur, "slot", n );
                if ((n<0) || (n >= ship->outfit_nstructure)) {
                   name = xml_get(cur);
                   o = outfit_get(name);
@@ -3791,12 +3775,7 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          cur = node->xmlChildrenNode;
          do { /* load each outfit */
             if (xml_isNode(cur,"outfit")) {
-               xmlr_attr(cur,"slot",q);
-               n = -1;
-               if (q != NULL) {
-                  n = atoi(q);
-                  free(q);
-               }
+               xmlr_attr_atoi_neg1( cur, "slot", n );
                if ((n<0) || (n >= ship->outfit_nutility)) {
                   WARN(_("Outfit slot out of range, not adding."));
                   continue;
@@ -3809,12 +3788,7 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          cur = node->xmlChildrenNode;
          do { /* load each outfit */
             if (xml_isNode(cur,"outfit")) {
-               xmlr_attr(cur,"slot",q);
-               n = -1;
-               if (q != NULL) {
-                  n = atoi(q);
-                  free(q);
-               }
+               xmlr_attr_atoi_neg1( cur, "slot", n );
                if ((n<0) || (n >= ship->outfit_nweapon)) {
                   WARN(_("Outfit slot out of range, not adding."));
                   continue;
@@ -3827,13 +3801,8 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          cur = node->xmlChildrenNode;
          do {
             if (xml_isNode(cur, "commodity")) {
-               xmlr_attr(cur, "quantity", q);
-               xmlr_attr(cur, "id", id);
-               quantity = atoi(q);
-               i = (id == NULL) ? 0 : atoi(id);
-               free(q);
-               if (id != NULL)
-                  free(id);
+               xmlr_attr_int( cur, "quantity", quantity );
+               xmlr_attr_int( cur, "id", i );
 
                /* Get the commodity. */
                com = commodity_get(xml_get(cur));
@@ -3893,29 +3862,13 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          continue;
 
       /* Check for autoweap. */
-      xmlr_attr(node,"autoweap",id);
-      if (id != NULL) {
-         autoweap = atoi(id);
-         free(id);
-      }
+      xmlr_attr_int( node, "autoweap", autoweap );
 
       /* Load the last weaponset the player used on this ship. */
-      xmlr_attr(node,"active_set",id);
-      if (id != NULL) {
-         active_set = atoi(id);
-         free(id);
-      }
-      else {
-         /* set active_set to invalid. will be dealt with later */
-         active_set = -1;
-      }
+      xmlr_attr_atoi_neg1( node, "active_set", active_set );
 
       /* Check for aim_lines. */
-      xmlr_attr(node, "aim_lines", id);
-      if (id != NULL) {
-         aim_lines = atoi(id);
-         free(id);
-      }
+      xmlr_attr_int( node, "aim_lines", aim_lines );
 
       /* Parse weapon sets. */
       cur = node->xmlChildrenNode;
@@ -3928,13 +3881,11 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          }
 
          /* Get id. */
-         xmlr_attr(cur,"id",id);
-         if (id == NULL) {
+         xmlr_attr_atoi_neg1(cur,"id",i);
+         if (i == -1) {
             WARN(_("Player ship '%s' missing 'id' tag for weapon set."),ship->name);
             continue;
          }
-         i = atoi(id);
-         free(id);
          if ((i < 0) || (i >= PILOT_WEAPON_SETS)) {
             WARN(_("Player ship '%s' has invalid weapon set id '%d' [max %d]."),
                   ship->name, i, PILOT_WEAPON_SETS-1 );
@@ -3942,25 +3893,20 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
          }
 
          /* Set inrange mode. */
-         xmlr_attr(cur,"inrange",id);
-         if (id == NULL)
-            pilot_weapSetInrange( ship, i, WEAPSET_INRANGE_PLAYER_DEF );
-         else {
-            pilot_weapSetInrange( ship, i, atoi(id) );
-            free(id);
-         }
+         xmlr_attr_int( cur, "inrange", in_range );
+         if (in_range > 0)
+            pilot_weapSetInrange( ship, i, in_range );
 
          if (autoweap) /* Autoweap handles everything except inrange. */
             continue;
 
          /* Set type mode. */
-         xmlr_attr(cur,"type",id);
-         if (id == NULL) {
+         xmlr_attr_atoi_neg1( cur, "type", weap_type );
+         if (weap_type == -1) {
             WARN(_("Player ship '%s' missing 'type' tag for weapon set."),ship->name);
             continue;
          }
-         pilot_weapSetType( ship, i, atoi(id) );
-         free(id);
+         pilot_weapSetType( ship, i, weap_type );
 
          /* Parse individual weapons. */
          ccur = cur->xmlChildrenNode;
@@ -3976,13 +3922,11 @@ static int player_parseShip( xmlNodePtr parent, int is_player )
             }
 
             /* Get level. */
-            xmlr_attr(ccur,"level",id);
-            if (id == NULL) {
+            xmlr_attr_atoi_neg1( ccur, "level", level);
+            if (level == -1) {
                WARN(_("Player ship '%s' missing 'level' tag for weapon set weapon."), ship->name);
                continue;
             }
-            level = atoi(id);
-            free(id);
             weapid = xml_getInt(ccur);
             if ((weapid < 0) || (weapid >= ship->noutfits)) {
                WARN(_("Player ship '%s' has invalid weapon id %d [max %d]."),

--- a/src/ship.c
+++ b/src/ship.c
@@ -677,7 +677,7 @@ static int ship_parseSlot( Ship *temp, ShipOutfitSlot *slot, OutfitSlotType type
    Outfit *o;
 
    /* Parse size. */
-   xmlr_attr( node, "size", buf );
+   xmlr_attr_strd( node, "size", buf );
    if (buf != NULL)
       base_size = outfit_toSlotSize( buf );
    else {
@@ -706,34 +706,16 @@ static int ship_parseSlot( Ship *temp, ShipOutfitSlot *slot, OutfitSlotType type
 
    /* Get mount point for weapons. */
    if (type == OUTFIT_SLOT_WEAPON) {
-      xmlr_attr(node,"x",buf);
-      if (buf!=NULL) {
-         slot->mount.x = atof(buf);
-         free(buf);
-      }
-      else
-         WARN(_("Ship '%s' missing 'x' element of 'weapon' slot."),temp->name);
-      xmlr_attr(node,"y",buf);
-      if (buf!=NULL) {
-         slot->mount.y = atof(buf);
-         /* Since we measure in pixels, we have to modify it so it
-          *  doesn't get corrected by the ortho correction. */
-         slot->mount.y *= M_SQRT2;
-         free(buf);
-      }
-      else
-         WARN(_("Ship '%s' missing 'y' element of 'weapon' slot."),temp->name);
-      xmlr_attr(node,"h",buf);
-      if (buf!=NULL) {
-         slot->mount.h = atof(buf);
-         free(buf);
-      }
-      else
-         WARN(_("Ship '%s' missing 'h' element of 'weapon' slot."),temp->name);
+      xmlr_attr_float( node, "x", slot->mount.x );
+      xmlr_attr_float( node, "y", slot->mount.y );
+      /* Since we measure in pixels, we have to modify it so it
+       *  doesn't get corrected by the ortho correction. */
+      slot->mount.y *= M_SQRT2;
+      xmlr_attr_float( node, "h", slot->mount.h );
    }
 
    /* Parse property. */
-   xmlr_attr( node, "prop", buf );
+   xmlr_attr_strd( node, "prop", buf );
    if (buf != NULL) {
       slot->slot.spid = sp_get( buf );
       slot->exclusive = sp_exclusive( slot->slot.spid );
@@ -742,22 +724,14 @@ static int ship_parseSlot( Ship *temp, ShipOutfitSlot *slot, OutfitSlotType type
    }
    //TODO: consider inserting those two parse blocks below inside the parse block above
 
-   /* Parse exclusive flag. */
-   xmlr_attr( node, "exclusive", buf );
-   if (buf != NULL) {
-      slot->exclusive = atoi( buf );
-      free( buf );
-   }
+   /* Parse exclusive flag, default false. */
+   xmlr_attr_int( node, "exclusive", slot->exclusive );
    //TODO: decide if exclusive should even belong in ShipOutfitSlot, remove this hack, and fix slot->exclusive to slot->slot.exclusive in it's two previous occurrences, meaning three lines above and 12 lines above
    /* hack */
    slot->slot.exclusive=slot->exclusive;
 
-   /* Parse required flag. */
-   xmlr_attr( node, "required", buf );
-   if (buf != NULL) {
-      slot->required  = atoi( buf );
-      free( buf );
-   }
+   /* Parse required flag, default false. */
+   xmlr_attr_int( node, "required", slot->required );
 
    /* Parse default outfit. */
    buf = xml_get(node);
@@ -791,9 +765,9 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    int i;
    xmlNodePtr cur, node;
    int sx, sy;
-   char *stmp, *buf;
+   char *buf;
    char str[PATH_MAX];
-   int l, m, h, engine;
+   int l, m, h, noengine;
    ShipStatList *ll;
 
    /* Clear memory. */
@@ -803,7 +777,7 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
    ss_statsInit( &temp->stats_array );
 
    /* Get name. */
-   xmlr_attr(parent,"name",temp->name);
+   xmlr_attr_strd( parent, "name", temp->name );
    if (temp->name == NULL)
       WARN( _("Ship in %s has invalid or no name"), SHIP_DATA_PATH );
 
@@ -834,31 +808,17 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
          }
 
          /* Get sprite size. */
-         xmlr_attr(node, "sx", stmp );
-         if (stmp != NULL) {
-            sx = atoi(stmp);
-            free(stmp);
-         }
-         else
+         xmlr_attr_atoi_neg1( node, "sx", sx );
+         if (sx == -1)
             sx = 8;
-         xmlr_attr(node, "sy", stmp );
-         if (stmp != NULL) {
-            sy = atoi(stmp);
-            free(stmp);
-         }
-         else
+         xmlr_attr_atoi_neg1( node, "sy", sy );
+         if (sy == -1)
             sy = 8;
 
-         xmlr_attr(node, "noengine", stmp );
-         if (stmp != NULL) {
-            engine = 0;
-            free(stmp);
-         }
-         else
-            engine = 1;
+         xmlr_attr_int(node, "noengine", noengine );
 
          /* Load the graphics. */
-         ship_loadGFX( temp, buf, sx, sy, engine );
+         ship_loadGFX( temp, buf, sx, sy, !noengine );
 
          /* Load the polygon. */
          ship_loadPLG( temp, buf );
@@ -884,19 +844,11 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
          nsnprintf( str, PATH_MAX, GFX_PATH"%s", buf );
 
          /* Get sprite size. */
-         xmlr_attr(node, "sx", stmp );
-         if (stmp != NULL) {
-            sx = atoi(stmp);
-            free(stmp);
-         }
-         else
+         xmlr_attr_atoi_neg1( node, "sx", sx );
+         if (sx == -1)
             sx = 8;
-         xmlr_attr(node, "sy", stmp );
-         if (stmp != NULL) {
-            sy = atoi(stmp);
-            free(stmp);
-         }
-         else
+         xmlr_attr_atoi_neg1( node, "sy", sy );
+         if (sy == -1)
             sy = 8;
 
          /* Load the graphics. */
@@ -916,19 +868,11 @@ static int ship_parse( Ship *temp, xmlNodePtr parent )
          nsnprintf( str, PATH_MAX, GFX_PATH"%s", buf );
 
          /* Get sprite size. */
-         xmlr_attr(node, "sx", stmp );
-         if (stmp != NULL) {
-            sx = atoi(stmp);
-            free(stmp);
-         }
-         else
+         xmlr_attr_atoi_neg1( node, "sx", sx );
+         if (sx == -1)
             sx = 8;
-         xmlr_attr(node, "sy", stmp );
-         if (stmp != NULL) {
-            sy = atoi(stmp);
-            free(stmp);
-         }
-         else
+         xmlr_attr_atoi_neg1( node, "sy", sy );
+         if (sy == -1)
             sy = 8;
 
          /* Load the graphics. */

--- a/src/shiplog.c
+++ b/src/shiplog.c
@@ -411,7 +411,6 @@ int shiplog_load( xmlNodePtr parent )
 {
    xmlNodePtr node, cur;
    ShipLogEntry *e;
-   char *str;
    int id,i;
    shiplog_clear();
 
@@ -421,14 +420,7 @@ int shiplog_load( xmlNodePtr parent )
          cur = node->xmlChildrenNode;
          do {
             if (xml_isNode(cur, "entry")) {
-               xmlr_attr(cur, "id", str);
-               if (str) {
-                  id = atoi(str);
-                  free(str);
-               } else {
-                  id = 0;
-                  WARN(_("Warning - no ID in shipLog entry\n"));
-               }
+               xmlr_attr_int(cur, "id", id);
                /* check this ID isn't already present */
                for ( i=0; i<shipLog->nlogs; i++ ) {
                   if ( shipLog->idList[i] == id )
@@ -443,29 +435,13 @@ int shiplog_load( xmlNodePtr parent )
                   shipLog->idstrList = realloc( shipLog->idstrList, sizeof(char*) * shipLog->nlogs);
                   shipLog->maxLen = realloc( shipLog->maxLen, sizeof(int) * shipLog->nlogs);
                   shipLog->idList[shipLog->nlogs-1] = id;
-                  shipLog->removeAfter[shipLog->nlogs-1] = 0;
-                  shipLog->idstrList[shipLog->nlogs-1] = NULL;
-                  shipLog->maxLen[shipLog->nlogs-1] = 0;
-                  xmlr_attr(cur, "t", str);
-                  if (str) {
-                     shipLog->typeList[shipLog->nlogs-1] = str;
-                  } else {
+                  xmlr_attr_strd( cur, "t", shipLog->typeList[shipLog->nlogs-1] );
+                  xmlr_attr_long( cur, "r", shipLog->removeAfter[shipLog->nlogs-1] );
+                  xmlr_attr_strd( cur, "s", shipLog->idstrList[shipLog->nlogs-1] );
+                  xmlr_attr_int( cur, "m", shipLog->maxLen[shipLog->nlogs-1] );
+                  if (shipLog->typeList[shipLog->nlogs-1] == NULL) {
                      shipLog->typeList[shipLog->nlogs-1] = strdup("No type");
                      WARN(_("No ID in shipLog entry"));
-                  }
-                  xmlr_attr(cur, "r", str);
-                  if (str) {
-                     shipLog->removeAfter[shipLog->nlogs-1] = atoll(str);
-                     free(str);
-                  }
-                  xmlr_attr(cur, "s", str);
-                  if (str) {
-                     shipLog->idstrList[shipLog->nlogs-1] = str;
-                  }
-                  xmlr_attr(cur, "m", str);
-                  if (str) {
-                     shipLog->maxLen[shipLog->nlogs-1] = atoi(str);
-                     free(str);
                   }
                   shipLog->nameList[shipLog->nlogs-1] = strdup(xml_raw(cur));
                }
@@ -479,20 +455,8 @@ int shiplog_load( xmlNodePtr parent )
                   shipLog->tail->next = e;
                shipLog->tail = e;
 
-               xmlr_attr(cur, "id", str);
-               if (str) {
-                  e->id = atoi(str);
-                  free(str);
-               } else {
-                  WARN(_("Warning - no ID for shipLog entry"));
-               }
-               xmlr_attr(cur, "t", str);
-               if (str) {
-                  e->time = atol(str);
-                  free(str);
-               } else {
-                  WARN(_("Warning - no time for shipLog entry"));
-               }
+               xmlr_attr_int( cur, "id", e->id );
+               xmlr_attr_long( cur, "t", e->time );
                e->msg = strdup(xml_raw(cur));
             }
          } while (xml_nextNode(cur));

--- a/src/slots.c
+++ b/src/slots.c
@@ -97,7 +97,7 @@ int sp_load (void)
 
       sp    = &array_grow( &sp_array );
       memset( sp, 0, sizeof(SlotProperty_t) );
-      xmlr_attr( node, "name", sp->name );
+      xmlr_attr_strd( node, "name", sp->name );
       cur   = node->xmlChildrenNode;
       do {
          xml_onlyNodes(cur);

--- a/src/spfx.c
+++ b/src/spfx.c
@@ -136,8 +136,7 @@ static int spfx_base_parse( SPFX_Base *temp, const xmlNodePtr parent )
    /* Clear data. */
    memset( temp, 0, sizeof(SPFX_Base) );
 
-   /* Get the name (mallocs). */
-   temp->name = xml_nodeProp(parent,"name");
+   xmlr_attr_strd( parent, "name", temp->name );
 
    /* Extract the data. */
    node = parent->xmlChildrenNode;

--- a/src/start.c
+++ b/src/start.c
@@ -92,7 +92,7 @@ int start_load (void)
             xmlr_strd( cur, "event",   start_data.event );
 
             if (xml_isNode(cur,"ship")) {
-               xmlr_attr( cur, "name",    start_data.shipname );
+               xmlr_attr_strd( cur, "name",    start_data.shipname );
                xmlr_strd( cur, "ship",    start_data.ship );
             }
             else if (xml_isNode(cur, "system")) {

--- a/src/tech.c
+++ b/src/tech.c
@@ -156,8 +156,7 @@ int tech_load (void)
       if (!xml_isNode(node, XML_TECH_TAG))
          continue;
 
-      /* Must avoid warning by checking explicit NULL. */
-      xmlr_attr( node, "name", buf );
+      xmlr_attr_strd( node, "name", buf );
       if (buf == NULL)
          continue;
 
@@ -316,7 +315,7 @@ static int tech_parseNode( tech_group_t *tech, xmlNodePtr parent )
    memset( tech, 0, sizeof(tech_group_t) );
 
    /* Get name. */
-   xmlr_attr( parent, "name", tech->name);
+   xmlr_attr_strd( parent, "name", tech->name );
    if (tech->name == NULL) {
       WARN(_("tech node does not have 'name' attribute"));
       return 1;
@@ -349,7 +348,7 @@ static int tech_parseNodeData( tech_group_t *tech, xmlNodePtr parent )
          }
 
          /* Try to find hard-coded type. */
-         buf = xml_nodeProp( node, "type" );
+         xmlr_attr_strd( node, "type", buf );
          if (buf == NULL) {
             ret = 1;
             if (ret)
@@ -360,40 +359,31 @@ static int tech_parseNodeData( tech_group_t *tech, xmlNodePtr parent )
                ret = tech_addItemShip( tech, name );
             if (ret)
                ret = tech_addItemCommodity( tech, name );
-            if (ret) {
+            if (ret)
                WARN(_("Generic item '%s' not found in tech group '%s'"),
                      name, tech->name );
-               continue;
-            }
          }
          else if (strcmp(buf,"group")==0) {
-            if (!tech_addItemGroup( tech, name )) {
+            if (!tech_addItemGroup( tech, name ))
                WARN(_("Group item '%s' not found in tech group '%s'."),
                      name, tech->name );
-               continue;
-            }
          }
          else if (strcmp(buf,"outfit")==0) {
-            if (!tech_addItemGroup( tech, name )) {
+            if (!tech_addItemGroup( tech, name ))
                WARN(_("Outfit item '%s' not found in tech group '%s'."),
                      name, tech->name );
-               continue;
-            }
          }
          else if (strcmp(buf,"ship")==0) {
-            if (!tech_addItemGroup( tech, name )) {
+            if (!tech_addItemGroup( tech, name ))
                WARN(_("Ship item '%s' not found in tech group '%s'."),
                      name, tech->name );
-               continue;
-            }
          }
          else if (strcmp(buf,"commodity")==0) {
-            if (!tech_addItemGroup( tech, name )) {
+            if (!tech_addItemGroup( tech, name ))
                WARN(_("Commodity item '%s' not found in tech group '%s'."),
                      name, tech->name );
-               continue;
-            }
          }
+         free( buf );
          continue;
       }
       WARN(_("Tech group '%s' has unknown node '%s'."), tech->name, node->name);

--- a/src/unidiff.c
+++ b/src/unidiff.c
@@ -203,7 +203,7 @@ int diff_loadAvailable (void)
 
       diff = &array_grow(&diff_available);
       diff->filename = diff_files[i];
-      xmlr_attr(node, "name", diff->name);
+      xmlr_attr_strd(node, "name", diff->name);
       xmlFreeDoc(doc);
       free(filebuf);
    }
@@ -318,7 +318,7 @@ static int diff_patchSystem( UniDiff_t *diff, xmlNodePtr node )
    /* Set the target. */
    memset(&base, 0, sizeof(UniHunk_t));
    base.target.type = HUNK_TARGET_SYSTEM;
-   xmlr_attr(node,"name",base.target.u.name);
+   xmlr_attr_strd(node,"name",base.target.u.name);
    if (base.target.u.name==NULL) {
       WARN(_("Unidiff '%s' has a system node without a 'name' tag, not applying."), diff->name);
       return -1;
@@ -339,7 +339,7 @@ static int diff_patchSystem( UniDiff_t *diff, xmlNodePtr node )
          hunk.target.u.name = strdup(base.target.u.name);
 
          /* Get the asset to modify. */
-         xmlr_attr(cur,"name",hunk.u.name);
+         xmlr_attr_strd(cur,"name",hunk.u.name);
 
          /* Get the type. */
          if (strcmp(buf,"add")==0)
@@ -371,7 +371,7 @@ static int diff_patchSystem( UniDiff_t *diff, xmlNodePtr node )
          hunk.target.u.name = strdup(base.target.u.name);
 
          /* Get the jump point to modify. */
-         xmlr_attr(cur,"target",hunk.u.name);
+         xmlr_attr_strd(cur,"target",hunk.u.name);
 
          /* Get the type. */
          if (strcmp(buf,"add")==0)
@@ -416,7 +416,7 @@ static int diff_patchTech( UniDiff_t *diff, xmlNodePtr node )
    /* Set the target. */
    memset(&base, 0, sizeof(UniHunk_t));
    base.target.type = HUNK_TARGET_TECH;
-   xmlr_attr(node,"name",base.target.u.name);
+   xmlr_attr_strd(node,"name",base.target.u.name);
    if (base.target.u.name==NULL) {
       WARN(_("Unidiff '%s' has an target node without a 'name' tag"), diff->name);
       return -1;
@@ -486,7 +486,7 @@ static int diff_patchAsset( UniDiff_t *diff, xmlNodePtr node )
    /* Set the target. */
    memset(&base, 0, sizeof(UniHunk_t));
    base.target.type = HUNK_TARGET_ASSET;
-   xmlr_attr(node,"name",base.target.u.name);
+   xmlr_attr_strd(node,"name",base.target.u.name);
    if (base.target.u.name==NULL) {
       WARN(_("Unidiff '%s' has an target node without a 'name' tag"), diff->name);
       return -1;
@@ -540,7 +540,7 @@ static int diff_patchFaction( UniDiff_t *diff, xmlNodePtr node )
    /* Set the target. */
    memset(&base, 0, sizeof(UniHunk_t));
    base.target.type = HUNK_TARGET_FACTION;
-   xmlr_attr(node,"name",base.target.u.name);
+   xmlr_attr_strd(node,"name",base.target.u.name);
    if (base.target.u.name==NULL) {
       WARN(_("Unidiff '%s' has an target node without a 'name' tag"), diff->name);
       return -1;
@@ -595,7 +595,7 @@ static int diff_patchFaction( UniDiff_t *diff, xmlNodePtr node )
          hunk.target.u.name = strdup(base.target.u.name);
 
          /* Get the faction to set the association of. */
-         xmlr_attr(cur,"name",hunk.u.name);
+         xmlr_attr_strd(cur,"name",hunk.u.name);
 
          /* Get the type. */
          if (strcmp(buf,"ally")==0)
@@ -642,7 +642,7 @@ static int diff_patch( xmlNodePtr parent )
    /* Prepare it. */
    diff = diff_newDiff();
    memset(diff, 0, sizeof(UniDiff_t));
-   xmlr_attr(parent,"name",diff->name);
+   xmlr_attr_strd(parent,"name",diff->name);
 
    /* Whether or not we need to update the universe. */
    univ_update = 0;


### PR DESCRIPTION
Why 0.9?
(1) I think I've tested with good coverage, but I haven't checked *everything*.
(2) free(NULL) is valid and this code will do it. I forget where. I'm still operating as if such refactors are for after 0.8 final.
So we can deal with this later; I just wanted to put it out in the open ASAP.

This is a part of #999 - it won't be a pain to implement with this in place.
Future improvements: better macros for reading an attribute with a specified default, the FIXME in system_parseJumpPointDiff, change supported int types to specific things like int64_t. (A serialized data format shouldn't depend on how big the compiler makes an int or long.)