### PR TITLE
MinGW found trouble in nlua_file.c

### DIFF
--- a/src/nlua_file.c
+++ b/src/nlua_file.c
@@ -262,7 +262,7 @@ static int fileL_read( lua_State *L )
       NLUA_ERROR(L, _("file not open!"));
 
    /* Figure out how much to read. */
-   readlen = luaL_optlong(L,2,(long)lf->rw->size);
+   readlen = luaL_optinteger(L,2,SDL_RWsize(lf->rw));
 
    /* Create buffer and read into it. */
    buf = malloc( readlen );


### PR DESCRIPTION
Fun facts I just learned: (1) rw->size is a function pointer. You can call it (passing the rw), but casting its address to long is not so good. (2) luaL_optlong uses a potentially shorter data type (long) than luaL_optinteger (ptrdiff_t).