### PR TITLE
docs: fix simple typo, untill -> until

### DIFF
--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -35,7 +35,7 @@ ThreadQueue* vpool_create( void );
  * another job to be done as this could lead to a deadlock. */
 void vpool_enqueue( ThreadQueue* queue, int (*function)(void *), void *data );
 
-/* Run every job in the vpool queue and block untill every job in the queue is
+/* Run every job in the vpool queue and block until every job in the queue is
  * done. It destroys the queue when it's done. */
 void vpool_wait( ThreadQueue* queue );
 


### PR DESCRIPTION
There is a small typo in src/threadpool.h.

Should read `until` rather than `untill`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md