### PR TITLE
Clippy asks if we meant...

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -348,10 +348,11 @@ static int gl_fontAddGlyphTex( glFontStash *stsh, font_char_t *ch, glFontGlyph *
    glyph->tex = tex;
 
    /* Since the VBOs have possibly changed, we have to reset the data. */
-   gl_vboActivateAttribOffset( stsh->vbo_vert, font_shader_vertex,
-         0, 2, GL_SHORT, 0 );
-   gl_vboActivateAttribOffset( stsh->vbo_tex, font_shader_tex_coord,
-         0, 2, GL_FLOAT, 0 );
+   /* TODO: This seems fragile. */
+   gl_vboActivateAttribOffset( stsh->vbo_vert, shaders.font.vertex, 0, 2, GL_SHORT, 0 );
+   gl_vboActivateAttribOffset( stsh->vbo_vert, shaders.font_outline.vertex, 0, 2, GL_SHORT, 0 );
+   gl_vboActivateAttribOffset( stsh->vbo_tex, shaders.font.tex_coord, 0, 2, GL_FLOAT, 0 );
+   gl_vboActivateAttribOffset( stsh->vbo_tex, shaders.font_outline.tex_coord, 0, 2, GL_FLOAT, 0 );
 
    return 0;
 }


### PR DESCRIPTION
(The font_shader_vertex and font_shader_tex_coord globals are only meant to be used mid-render. If we need these steps, do we need them for all font shaders?)