### PR TITLE
Font shader update

### DIFF
--- a/dat/glsl/font.frag
+++ b/dat/glsl/font.frag
@@ -4,6 +4,7 @@ uniform sampler2D sampler;
 in vec2 tex_coord_out;
 out vec4 color_out;
 
+// How thick to render glyphs; 0 is very thick, 1 is very thin
 const float glyph_center   = 0.5;
 
 void main(void) {
@@ -14,8 +15,11 @@ void main(void) {
    */
 
    /* Distance field rendering. */
+   // dist is a value between 0 and 1 with 0.5 on the edge and 1 inside it.
    float dist = texture(sampler, tex_coord_out).r;
+   // fwidth computes the absolute value of the x and y derivatives
    float width = fwidth(dist);
+   // smoothstep maps values below 0.5 to 0 and above 0.5 to 1, with a smooth transition at 0.5.
    float alpha = smoothstep(glyph_center-width, glyph_center+width, dist);
    color_out = vec4(color.rgb, alpha*color.a);
 

--- a/dat/glsl/font_outline.frag
+++ b/dat/glsl/font_outline.frag
@@ -5,16 +5,21 @@ uniform sampler2D sampler;
 in vec2 tex_coord_out;
 out vec4 color_out;
 
+// How thick to render glyphs; 0 is very thick, 1 is very thin
 const float glyph_center   = 0.5;
-const float outline_center = 0.55;
+// between 0 and glyph_center is a thick outline, above glyph_center is no outline
+const float outline_center = 0.1;
 
 void main(void) {
+   // dist is a value between 0 and 1 with 0.5 on the edge and 1 inside it.
    float dist = texture(sampler, tex_coord_out).r;
+   // fwidth computes the absolute value of the x and y derivatives
    float width = fwidth(dist);
+   // smoothstep maps values below 0.5 to 0 and above 0.5 to 1, with a smooth transition at 0.5.
    float alpha = smoothstep(glyph_center-width, glyph_center+width, dist);
    float beta = smoothstep(outline_center-width, outline_center+width, dist);
-   vec3 rgb = mix(outline_color.rgb, color.rgb, beta);
-   color_out = vec4(rgb, alpha*color.a);
+   vec3 rgb = mix(outline_color.rgb, color.rgb, alpha);
+   color_out = vec4(rgb, beta*color.a);
 
 #include "colorblind.glsl"
 }

--- a/src/distance_field.c
+++ b/src/distance_field.c
@@ -131,3 +131,41 @@ make_distance_mapb( unsigned char *img,
 
     return out;
 }
+
+
+float*
+make_distance_mapbf( unsigned char *img,
+                    unsigned int width, unsigned int height )
+{
+    double * data    = (double *) calloc( width * height, sizeof(double) );
+    float *out       = (float *) malloc( width * height * sizeof(float) );
+    unsigned int i;
+
+    // find minimum and maximum values
+    double img_min = DBL_MAX;
+    double img_max = DBL_MIN;
+
+    for( i=0; i<width*height; ++i)
+    {
+        double v = img[i];
+        data[i] = v;
+        if (v > img_max)
+            img_max = v;
+        if (v < img_min)
+            img_min = v;
+    }
+
+    // Map values from 0 - 255 to 0.0 - 1.0
+    for( i=0; i<width*height; ++i)
+        data[i] = (img[i]-img_min)/img_max;
+
+    data = make_distance_mapd(data, width, height);
+
+    // lower to float
+    for( i=0; i<width*height; ++i)
+        out[i] = (float)(1-data[i]);
+
+    free( data );
+
+    return out;
+}

--- a/src/distance_field.h
+++ b/src/distance_field.h
@@ -7,5 +7,8 @@ make_distance_mapd( double *data, unsigned int width, unsigned int height );
 unsigned char *
 make_distance_mapb( unsigned char *img,
                     unsigned int width, unsigned int height );
+float*
+make_distance_mapbf( unsigned char *img,
+                    unsigned int width, unsigned int height );
 
 #endif /* DISTANCE_FIELD_H */

--- a/src/font.c
+++ b/src/font.c
@@ -36,7 +36,7 @@
 /* TODO figure out how much border is theoretically necessary to avoid bleed
  * from adjacent characters. */
 #define FONT_DISTANCE_FIELD_BORDER 5 /**< Border of the distance field. */
-#define FONT_DISTANCE_FIELD_SIZE   64 /**< Size to render the fonts at. */
+#define FONT_DISTANCE_FIELD_SIZE   (64-FONT_DISTANCE_FIELD_BORDER*2) /**< Size to render the fonts at. */
 #define HASH_LUT_SIZE 512 /**< Size of glyph look up table. */
 #define DEFAULT_TEXTURE_SIZE 1024 /**< Default size of texture caches for glyphs. */
 #define MAX_ROWS 64 /**< Max number of rows per texture cache. */
@@ -1557,7 +1557,7 @@ static int gl_fontstashAddFallback( glFontStash* stsh, const char *fname )
    if (FT_IS_SCALABLE(face)) {
       if (FT_Set_Char_Size( face,
                0, /* Same as width. */
-               (FONT_DISTANCE_FIELD_SIZE-FONT_DISTANCE_FIELD_BORDER*2) * 64,
+               FONT_DISTANCE_FIELD_SIZE * 64,
                96, /* Create at 96 DPI */
                96)) /* Create at 96 DPI */
          WARN(_("FT_Set_Char_Size failed."));

--- a/src/font.c
+++ b/src/font.c
@@ -88,6 +88,7 @@ typedef struct glFontGlyph_s {
  */
 typedef struct font_char_s {
    GLubyte *data; /**< Data of the character. */
+   GLfloat *dataf; /**< Float data of the character. */
    int w; /**< Width. */
    int h; /**< Height. */
    int off_x; /**< X offset when rendering. */
@@ -273,8 +274,12 @@ static int gl_fontAddGlyphTex( glFontStash *stsh, font_char_t *ch, glFontGlyph *
    /* Upload data. */
    glBindTexture( GL_TEXTURE_2D, tex->id );
    glPixelStorei(GL_UNPACK_ALIGNMENT,1);
-   glTexSubImage2D( GL_TEXTURE_2D, 0, gr->x, gr->y, ch->w, ch->h,
-         GL_RED, GL_UNSIGNED_BYTE, ch->data );
+   if (ch->dataf != NULL)
+      glTexSubImage2D( GL_TEXTURE_2D, 0, gr->x, gr->y, ch->w, ch->h,
+            GL_RED, GL_FLOAT, ch->dataf );
+   else
+      glTexSubImage2D( GL_TEXTURE_2D, 0, gr->x, gr->y, ch->w, ch->h,
+            GL_RED, GL_UNSIGNED_BYTE, ch->data );
 
    /* Check for error. */
    gl_checkErr();
@@ -1102,6 +1107,8 @@ static int font_makeChar( glFontStash *stsh, font_char_t *c, uint32_t ch )
       h = bitmap.rows;
 
       /* Store data. */
+      c->data = NULL;
+      c->dataf = NULL;
       if (bitmap.buffer == NULL) {
          /* Space characters tend to have no buffer. */
          b = 0;
@@ -1120,7 +1127,7 @@ static int font_makeChar( glFontStash *stsh, font_char_t *c, uint32_t ch )
             for (u=0; u<w; u++)
                buffer[ (b+v)*rw+(b+u) ] = bitmap.buffer[ v*w+u ];
          /* Compute signed fdistance field with buffered glyph. */
-         c->data = make_distance_mapb( buffer, rw, rh );
+         c->dataf = make_distance_mapbf( buffer, rw, rh );
          free( buffer );
       }
       c->w     = rw;

--- a/src/font.c
+++ b/src/font.c
@@ -33,7 +33,9 @@
 #include "utf8.h"
 
 
-#define FONT_DISTANCE_FIELD_BORDER  2 /**< Border of the distance field. */
+/* TODO figure out how much border is theoretically necessary to avoid bleed
+ * from adjacent characters. */
+#define FONT_DISTANCE_FIELD_BORDER  5 /**< Border of the distance field. */
 #define FONT_DISTANCE_FIELD_SIZE   64 /**< Size to render the fonts at. */
 #define HASH_LUT_SIZE 512 /**< Size of glyph look up table. */
 #define DEFAULT_TEXTURE_SIZE 1024 /**< Default size of texture caches for glyphs. */

--- a/src/font.c
+++ b/src/font.c
@@ -35,7 +35,7 @@
 
 /* TODO figure out how much border is theoretically necessary to avoid bleed
  * from adjacent characters. */
-#define FONT_DISTANCE_FIELD_BORDER  5 /**< Border of the distance field. */
+#define FONT_DISTANCE_FIELD_BORDER 5 /**< Border of the distance field. */
 #define FONT_DISTANCE_FIELD_SIZE   64 /**< Size to render the fonts at. */
 #define HASH_LUT_SIZE 512 /**< Size of glyph look up table. */
 #define DEFAULT_TEXTURE_SIZE 1024 /**< Default size of texture caches for glyphs. */
@@ -1135,7 +1135,7 @@ static int font_makeChar( glFontStash *stsh, font_char_t *c, uint32_t ch )
       c->w     = rw;
       c->h     = rh;
       c->off_x = slot->bitmap_left-b;
-      c->off_y = slot->bitmap_top -b;
+      c->off_y = slot->bitmap_top +b;
       c->adv_x = (GLfloat)slot->advance.x / 64.;
       c->adv_y = (GLfloat)slot->advance.y / 64.;
 


### PR DESCRIPTION
I did some algebra to figure out what fraction of a square one would expect to fall within the glyph/outline thresholds of a distance field, based on the value and directional derivatives.
It's not what we had.

EDIT: Then @bobbens fixed a whole lot of stuff, and the need for this mostly evaporated.
It still seems to achieve a crispness/smoothness tradeoff, which is likely also achievable by replacing smoothstep() and less change than we have here.

Probably we close this without merging. BUT here are updated comparisons.

![land-master](https://user-images.githubusercontent.com/1224111/102958589-4012c380-44ab-11eb-9e48-57a9de16df81.png)
![land-merged](https://user-images.githubusercontent.com/1224111/102958590-4012c380-44ab-11eb-8b32-16d032ae738e.png)
![load-master](https://user-images.githubusercontent.com/1224111/102958591-40ab5a00-44ab-11eb-97a8-463bd62cd1e7.png)
![load-merged](https://user-images.githubusercontent.com/1224111/102958593-4143f080-44ab-11eb-8c72-bba2dc154742.png)
![map-master](https://user-images.githubusercontent.com/1224111/102958594-4143f080-44ab-11eb-8fa2-abdd1721f21d.png)
![map-merged](https://user-images.githubusercontent.com/1224111/102958595-41dc8700-44ab-11eb-98a8-2e59268c0aa5.png)
![menu-master](https://user-images.githubusercontent.com/1224111/102958596-42751d80-44ab-11eb-90cb-cbc2e5ad1331.png)
![menu-merged](https://user-images.githubusercontent.com/1224111/102958597-42751d80-44ab-11eb-81db-4b9c2175bc44.png)
