### PR TITLE
Scalefactor default applies correctly. A few other defaults enabled.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -142,7 +142,7 @@ void conf_setDefaults (void)
    /* GUI. */
    conf.mesg_visible = 5;
    conf.map_overlay_opacity = MAP_OVERLAY_OPACITY_DEFAULT;
-   conf.big_icons = 1;
+   conf.big_icons = BIG_ICONS_DEFAULT;
 
    /* Repeat. */
    conf.repeat_delay = 500;

--- a/src/conf.h
+++ b/src/conf.h
@@ -40,6 +40,7 @@
 #define SHOW_PAUSE_DEFAULT                   1     /**< Whether to display pause status. */
 #define ENGINE_GLOWS_DEFAULT                 1     /**< Whether to display engine glows. */
 #define MINIMIZE_DEFAULT                     1     /**< Whether to minimize on focus loss. */
+#define BIG_ICONS_DEFAULT                    1     /**< Whether to display BIGGER icons. */
 #define FONT_SIZE_CONSOLE_DEFAULT            10    /**< Default console font size. */
 #define FONT_SIZE_INTRO_DEFAULT              18    /**< Default intro font size. */
 #define FONT_SIZE_DEF_DEFAULT                12    /**< Default font size. */

--- a/src/options.c
+++ b/src/options.c
@@ -475,6 +475,7 @@ static void opt_gameplayDefaults( unsigned int wid, char *str )
 
    /* Faders. */
    window_faderValue( wid, "fadAutonav", AUTONAV_RESET_SPEED_DEFAULT );
+   window_faderValue( wid, "fadMapOverlayOpacity", MAP_OVERLAY_OPACITY_DEFAULT );
 
    /* Input boxes. */
    nsnprintf( vmsg, sizeof(vmsg), "%d", INPUT_MESSAGES_DEFAULT );
@@ -1521,9 +1522,10 @@ static void opt_videoDefaults( unsigned int wid, char *str )
    window_checkboxSet( wid, "chkFPS", SHOW_FPS_DEFAULT );
    window_checkboxSet( wid, "chkEngineGlow", ENGINE_GLOWS_DEFAULT );
    window_checkboxSet( wid, "chkMinimize", MINIMIZE_DEFAULT );
+   window_checkboxSet( wid, "chkBigIcons", BIG_ICONS_DEFAULT );
 
    /* Faders. */
-   window_faderValue(  wid, "fadScale", SCALE_FACTOR_DEFAULT );
+   window_faderSetBoundedValue( wid, "fadScale", SCALE_FACTOR_DEFAULT );
 }
 
 /**
@@ -1536,6 +1538,7 @@ static void opt_setScalefactor( unsigned int wid, char *str )
 {
    char buf[32];
    double scale = window_getFaderValue(wid, str);
+   scale = round(scale * 10) / 10;     // Reasonable precision. Clearer value.
    if (FABS(conf.scalefactor-scale) > 1e-4)
       opt_needRestart();
    conf.scalefactor = scale;

--- a/src/tk/widget/fader.h
+++ b/src/tk/widget/fader.h
@@ -35,6 +35,8 @@ void window_addFader( const unsigned int wid,
 /* Misc functions. */
 void window_faderValue( const unsigned int wid,
       char* name, double value );
+void window_faderSetBoundedValue( const unsigned int wid,
+      char* name, double value );
 void window_faderBounds( const unsigned int wid,
       char* name, double min, double max );
 double window_getFaderValue( const unsigned int wid, char* name );


### PR DESCRIPTION
So, Scale factor was changing to 3.0 when I pressed the Set Defaults button under Video.
It turns out that the reason, was the default value being 1.0, while the slider (fader) widget treating 0 through 1 as 1 through 3 in terms of actual applied value.

I tried a different solution, but this final version I believe is more accurate and more readable than my non-disclosed effort.
The problem was, that there has to be equal functionality for Directly setting the value, as with loading from conf,lua or resetting to Defaults. The other two modes are Mouse based selection, and Keyboard based selection.

Have tested that each other Fader still operates as they were intended to,

This commit also adds a rounding of the Scale factor to the nearest Tenth of a value, because something like 1.4879 seems to me to be completely missing the mark of perhaps allowing scaling factors such as 150%, 200%, etc from being selected by the user.