### PR TITLE
I hate fonts

### DIFF
--- a/dat/glsl/font.frag
+++ b/dat/glsl/font.frag
@@ -8,17 +8,10 @@ out vec4 color_out;
 const float glyph_center   = 0.5;
 
 void main(void) {
-   /* Standard rendering. */
-   /*
-   color_out = color;
-   color_out.a = texture(sampler, tex_coord_out).r;
-   */
-
-   /* Distance field rendering. */
    // dist is a value between 0 and 1 with 0.5 on the edge and 1 inside it.
    float dist = texture(sampler, tex_coord_out).r;
-   // fwidth computes the absolute value of the x and y derivatives
-   float width = fwidth(dist);
+   // fwidth sums the absolute value of the x and y derivatives
+   float width = fwidth(dist)/2;
    // smoothstep maps values below 0.5 to 0 and above 0.5 to 1, with a smooth transition at 0.5.
    float alpha = smoothstep(glyph_center-width, glyph_center+width, dist);
    color_out = vec4(color.rgb, alpha*color.a);

--- a/dat/glsl/font_glow.frag
+++ b/dat/glsl/font_glow.frag
@@ -10,7 +10,7 @@ const float glow_center    = 1.25;
 
 void main(void) {
    float dist = texture(sampler, tex_coord_out).r;
-   float width = fwidth(dist);
+   float width = fwidth(dist)/2;
    float alpha = smoothstep(glyph_center-width, glyph_center+width, dist);
    vec3 rgb = mix(glow_color.rgb, color.rgb, alpha);
    float mu = smoothstep(glyph_center, glow_center, sqrt(dist));

--- a/dat/glsl/font_outline.frag
+++ b/dat/glsl/font_outline.frag
@@ -14,7 +14,7 @@ void main(void) {
    // dist is a value between 0 and 1 with 0.5 on the edge and 1 inside it.
    float dist = texture(sampler, tex_coord_out).r;
    // fwidth computes the absolute value of the x and y derivatives
-   float width = fwidth(dist);
+   float width = fwidth(dist)/2;
    // smoothstep maps values below 0.5 to 0 and above 0.5 to 1, with a smooth transition at 0.5.
    float alpha = smoothstep(glyph_center-width, glyph_center+width, dist);
    float beta = smoothstep(outline_center-width, outline_center+width, dist);

--- a/dat/glsl/font_outline_glow.frag
+++ b/dat/glsl/font_outline_glow.frag
@@ -12,7 +12,7 @@ const float glow_center    = 1.25;
 
 void main(void) {
    float dist = texture(sampler, tex_coord_out).r;
-   float width = fwidth(dist);
+   float width = fwidth(dist)/2;
    float alpha = smoothstep(glyph_center-width, glyph_center+width, dist);
 
    vec3 rgb = mix(glow_color.rgb, color.rgb, alpha);

--- a/src/font.c
+++ b/src/font.c
@@ -164,7 +164,7 @@ static int font_restoreLast      = 0; /**< Restore last colour. */
  */
 static int gl_fontstashAddFallback( glFontStash* stsh, const char *fname, unsigned int h );
 static size_t font_limitSize( glFontStash *stsh, double h,
-      int *width, const char *text, const int max );
+      double* width, const char* text, const int max );
 static const glColour* gl_fontGetColour( uint32_t ch );
 /* Get unicode glyphs from cache. */
 static glFontGlyph* gl_fontGetGlyph( glFontStash *stsh, uint32_t ch );
@@ -462,7 +462,7 @@ void gl_printStore( glFontRestore *restore, const char *text )
  *    @return Number of characters that fit.
  */
 static size_t font_limitSize( glFontStash *stsh, double h,
-      int *width, const char *text, const int max )
+      double* width, const char* text, const int max )
 {
    GLfloat n, scale;
    size_t i;
@@ -499,7 +499,7 @@ static size_t font_limitSize( glFontStash *stsh, double h,
    }
 
    if (width != NULL)
-      (*width) = (int)round(n);
+      *width = n;
    return i;
 }
 
@@ -565,7 +565,7 @@ int gl_printWidthForText( const glFont *ft_font, const char *text,
       /* Save last space. */
       if (text[i] == ' ') {
          lastspace = i;
-         lastwidth = n;
+         lastwidth = (int)round(n);
       }
 
       ch = u8_nextchar( text, &i );
@@ -762,7 +762,8 @@ int gl_printMidRaw(
       const char *text
       )
 {
-   int n, s;
+   double n;
+   int s;
    size_t ret, i;
    uint32_t ch;
 
@@ -1193,7 +1194,7 @@ static void gl_fontRenderStart( const glFontStash* stsh, double h, double x, dou
    }
    gl_uniformAColor(font_shader_color, col, a);
 
-   font_projection_mat = gl_Matrix4_Translate(gl_view_matrix, round(x), round(y), 0);
+   font_projection_mat = gl_Matrix4_Translate(gl_view_matrix, x, y, 0);
    s = h / FONT_DISTANCE_FIELD_SIZE;
    font_projection_mat = gl_Matrix4_Scale(font_projection_mat, s, s, 1 );
 
@@ -1493,13 +1494,6 @@ int gl_fontInit( glFont* font, const char *fname, const unsigned int h, const ch
    stsh->vbo_vert_data = calloc( 8*stsh->mvbo, sizeof(GLshort) );
    stsh->vbo_tex  = gl_vboCreateStatic( sizeof(GLfloat)*8*stsh->mvbo,  stsh->vbo_tex_data );
    stsh->vbo_vert = gl_vboCreateStatic( sizeof(GLshort)*8*stsh->mvbo, stsh->vbo_vert_data );
-
-   /* Initializes ASCII. */
-#if 0
-   for (i=0; i<128; i++)
-      if (isprint(i)) /* Only care about printables. */
-         gl_fontGetGlyph( stsh, i );
-#endif
 
    return 0;
 }


### PR DESCRIPTION
Rather than include screenshots I'm going to let @onpon4 either tear this apart or not.
But if you liked the old rendering at 1:1, you should like this. (But it's still using signed distance fields.)
The most important change is to use the FT character size that would make sense at 1:1 and a FT transformation matrix to render the glyph at the appropriate size. This helps size-dependent features of glyph outlines Do The Right Thing.
I also tweaked the shaders. Rather than introduce complexity, I changed a [-fwidth(dist),fwidth(dist)] interval to [-fwidth(dist)/2,fwidth(dist)/2] so the smooth steps are across a ~1px margin instead of a ~2px margin. This is a major improvement at 1:1.