### PR TITLE
Fix ndata deployment for Steam (on master).

### DIFF
--- a/utils/ci/steam/SteamDeploy.sh
+++ b/utils/ci/steam/SteamDeploy.sh
@@ -66,7 +66,7 @@ tar -Jxf "$TEMPPATH/naev-win64/steam-win64.tar.xz" -C "$STEAMPATH/content/win64"
 mv "$STEAMPATH"/content/win64/naev*.exe "$STEAMPATH/content/win64/naev.exe"
 
 # Move data to deployment location
-tar -Jxf "$TEMPPATH/naev-ndata/steam-ndata.tar.xz" -C "$STEAMPATH/content/ndata"
+tar -Jxf "$TEMPPATH/naev-ndata/steam-ndata.tar.xz" --strip=1 -C "$STEAMPATH/content/ndata"
 
 # Runs STEAMCMD, and builds the app as well as all needed depots.
 


### PR DESCRIPTION
SteamDeploy.sh wasn't expecting a leading directory (in this case source/)
This solves that.