### PR TITLE
Verify widget name before operating upon it. Fixes a bug.

### DIFF
--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -2348,6 +2348,10 @@ void window_setFocus( const unsigned int wid, const char* wgtname )
    Window *wdw;
    Widget *wgt;
 
+   /* If widget name is NULL, we should not proceed */
+   if (wgtname == NULL)
+      return;
+
    /* Get window. */
    wdw = window_wget(wid);
    if (wdw == NULL)


### PR DESCRIPTION
Protecting from a Segfault that was encountered while pressing Left Shift on the Outfits tab while focused on something that possibly shouldn't permit focus. Use Tab to set focus, then press Left Shift.

Here's my hand-written stack trace.
```toolkit.c line 353
if (strcmp(wgt->name, name)==0)
	wgt->name is btnCloseOutfits
	name* is 0x0

called by: window_setFocus( const unsigned int wid, const char* wgtname ) line 2334
	with unmodified wgtname

called by: outfits_regenList( unsigned int wid, char *str ) land_outfits.c line 231
	as window_setFocus( wid, focused );
	where focused is 0x0, set by focused = strdup(window_getFocus(wid));