### PR TITLE
Hilighting a missing Ship License with Color

### DIFF
--- a/src/land.c
+++ b/src/land.c
@@ -827,10 +827,10 @@ void land_updateMainTab (void)
    /* Else create it. */
    else {
       /* Refuel button. */
-      credits2str( cred, o->price, 2 );
+      credits2str( cred, o->price, 0 );
       nsnprintf( buf, sizeof(buf), _("Buy Local Map (%s)"), cred );
       window_addButtonKey( land_windows[0], -20, 20 + (LAND_BUTTON_HEIGHT + 20),
-            LAND_BUTTON_WIDTH,LAND_BUTTON_HEIGHT, "btnMap",
+            LAND_BUTTON_WIDTH, LAND_BUTTON_HEIGHT, "btnMap",
             buf, spaceport_buyMap, SDLK_b );
    }
 

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -196,7 +196,7 @@ void shipyard_update( unsigned int wid, char* str )
    (void)str;
    int i;
    Ship* ship;
-   char buf[PATH_MAX], buf2[ECON_CRED_STRLEN], buf3[ECON_CRED_STRLEN];
+   char buf[PATH_MAX], buf2[ECON_CRED_STRLEN], buf3[ECON_CRED_STRLEN], buf_license[PATH_MAX];
 
    i = toolkit_getImageArrayPos( wid, "iarShipyard" );
 
@@ -247,6 +247,14 @@ void shipyard_update( unsigned int wid, char* str )
    price2str( buf2, ship_buyPrice(ship), player.p->credits, 2 );
    credits2str( buf3, player.p->credits, 2 );
 
+   if (ship->license == NULL)
+      strncpy( buf_license, _("None"), sizeof(buf_license)-1 );
+   else if (player_hasLicense( ship->license ))
+      strncpy( buf_license, _(ship->license), sizeof(buf_license)-1 );
+   else
+      nsnprintf( buf_license, sizeof(buf_license), "#r%s#0", _(ship->license) );
+   buf_license[ sizeof(buf_license)-1 ] = '\0';
+
    nsnprintf( buf, PATH_MAX,
          _("%s\n"
          "%s\n"
@@ -291,7 +299,7 @@ void shipyard_update( unsigned int wid, char* str )
          ship->fuel_consumption,
          buf2,
          buf3,
-         (ship->license != NULL) ? _(ship->license) : _("None") );
+         buf_license );
    window_modifyText( wid,  "txtDDesc", buf );
 
    if (!shipyard_canBuy( ship->name, land_planet ))


### PR DESCRIPTION
Issue: For the Light, Medium and Heavy Combat Vehicle Licenses, though I did not own them, their text was not in Red.
At least the Button was set to not enabled. Or enabled, with a message explaining the license was needed.

The button prohibiting purchasing was working as intended. The Red text indicating a missing license is what appeared to be missing.

I also reduced the decimal precision on the Local Map, to 0. Which makes oversized button fonts render nicely, but might affect any forks that charge 3.45 for local maps.

This is how the application behaves now:
![License_Color](https://user-images.githubusercontent.com/76220444/103410288-ae552700-4b38-11eb-85a4-b17fd6600c5f.PNG)
