### PR TITLE
Add macOS to CI (again) // Cross-compile Windows // Update pre-release and release workflows

### DIFF
--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -108,6 +108,14 @@ jobs:
           name: ${{ matrix.tag }}-${{ github.sha }}-compile-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-buildArtifacts
+          path: |
+            ${{ github.workspace }}/build
+          if-no-files-found: error
+
       - name: Test Install
         run: |
           meson install -C build
@@ -123,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
-      
+
     steps:
       - name: Get Source
         uses: actions/download-artifact@v1

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -143,7 +143,7 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
       - name: Upload AppImage Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
         with:
           name: naev-${{ github.sha }}-AppImageBuild

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -61,7 +61,7 @@ jobs:
           tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
 
       - name: Meson Setup
-        if: ${{ matrix.tag != naev-windows }}
+        if: ${{ matrix.tag != 'naev-windows' }}
         id: setup
         run: |
           meson setup build source \
@@ -75,7 +75,7 @@ jobs:
               -Dforce_fallback_for=SuiteSparse
 
       - name: Cross-compile Meson Setup
-        if: ${{ matrix.tag == naev-windows }}
+        if: ${{ matrix.tag == 'naev-windows' }}
         id: setup
         run: |
           meson setup build source \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -109,7 +109,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.tag }}-${{ github.sha }}-buildArtifacts
           path: |

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -204,7 +204,7 @@ jobs:
           brew update
           brew install \
             intltool \
-            physfs \
+            mercurial --with-custom-python \
             sdl2
 
       - name: Setup Python

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -139,6 +139,8 @@ jobs:
         id: appimageCompile
         run: |
           script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "${{ github.workspace }}/dist"" appImageBuildLog.txt
+          ls -l ${{ github.workspace }}/dist
+          ls -l ${{ github.workspace }}/dist/out
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
@@ -155,7 +157,7 @@ jobs:
         with:
           name: naev-${{ github.sha }}-AppImageBuild
           path: |
-            ${{ github.workspace }}/dist/out/*.AppImage
+            ${{ github.workspace }}/dist/out/*.*
           if-no-files-found: error
 
   "Lua_Documentation":

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -205,16 +205,16 @@ jobs:
         run: |
           brew update
           brew install \
-            binutils \
-            fontconfig \
             intltool \
-            libpng \
-            libvorbis \
-            meson \
-            ninja \
             openal-soft \
-            pkg-config \
             sdl2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install Meson and Ninja via pip
+        run: |
+          pip install meson ninja
 
       - name: Get Source
         uses: actions/download-artifact@v1

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -91,12 +91,12 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v1
+        if: ${{ matrix.tag != 'naev-steamruntime' }}
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.tag }}-${{ github.sha }}-buildArtifacts
           path: |
             ${{ github.workspace }}/build
-          if-no-files-found: error
 
       - name: Test Install
         run: |

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Compile AppImage
         id: appimageCompile
         run: |
-          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "${{ github.workspace }}/dist"" appImageBuildLog.txt
+          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "dist"" appImageBuildLog.txt
           pwd
           ls -l ${{ github.workspace }}/dist
           pwd

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -118,7 +118,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
   "AppImage_Compile_Naev":
-    needs: [Package_Source, Linux_Compile_Naev]
+    needs: [Package_Source, Compile_Naev]
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu2004
-    needs: [Package_Source, Linux_Compile_Naev, Windows_Compile_Naev]
+    needs: [Package_Source, Compile_Naev]
 
     steps:
       - name: Get Source

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -142,12 +142,21 @@ jobs:
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
-      - name: Upload AppImage Artifacts
+      - name: Upload AppImage Compile Log
         uses: actions/upload-artifact@v2
         if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
         with:
+          name: naev-${{ github.sha }}-AppImageBuild-log
+          path: |
+            ${{ github.workspace }}/appImageBuildLog.txt
+
+      - name: Upload AppImage Artifact
+        uses: actions/upload-artifact@v2
+        with:
           name: naev-${{ github.sha }}-AppImageBuild
-          path: ${{ github.workspace }}/*
+          path: |
+            ${{ github.workspace }}/dist/out/*.AppImage
+          if-no-files-found: error
 
   "Lua_Documentation":
     runs-on: ubuntu-latest

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -123,8 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
-      volumes:
-        - /tmp/out:${{ github.workspace }}/VolMount
+      
     steps:
       - name: Get Source
         uses: actions/download-artifact@v1
@@ -140,25 +139,24 @@ jobs:
         id: appimageCompile
         run: |
           mkdir -p /tmp/out
-          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "$DESTDIR"" /tmp/out/appImageBuildLog.txt
-          cp $DESTDIR/out/*.AppImage /tmp/out
+          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "$DESTDIR"" appImageBuildLog.txt
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
       - name: Upload AppImage Compile Log
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
         with:
           name: naev-${{ github.sha }}-AppImageBuild-log
           path: |
-            ${{ github.workspace }}/VolMount/*.txt
+            ${{ github.workspace }}/appImageBuildLog.txt
 
       - name: Upload AppImage Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: naev-${{ github.sha }}-AppImageBuild
           path: |
-            ${{ github.workspace }}/VolMount/*.AppImage
+            ${{ github.workspace }}/dist/out
           if-no-files-found: error
 
   "Lua_Documentation":

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ matrix.tag == 'naev-windows' }}
         id: crossSetup
         run: |
-          chown "$USER":"$USER" -R /github
+          chown "$USER":"$USER" -R /github/home
           winecfg
           meson setup build source \
               --cross-file='source/utils/build/${{ matrix.config }}' \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -142,19 +142,12 @@ jobs:
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
-      - name: Upload AppImage Compile Log
+      - name: Upload AppImage Artifacts
         uses: actions/upload-artifact@v1
         if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
         with:
-          name: naev-${{ github.sha }}-AppImageBuild-log
-          path: ${{ github.workspace }}/appImageBuildLog.txt
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: naev-AppImage-${{ github.sha }}
-          path: "${{ github.workspace }}/dist/out/*.AppImage"
-          if-no-files-found: error
+          name: naev-${{ github.sha }}-AppImageBuild
+          path: ${{ github.workspace }}/*
 
   "Lua_Documentation":
     runs-on: ubuntu-latest

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -204,7 +204,6 @@ jobs:
           brew update
           brew install \
             intltool \
-            mercurial --with-custom-python \
             sdl2
 
       - name: Setup Python
@@ -212,7 +211,7 @@ jobs:
 
       - name: Install Meson and Ninja via pip
         run: |
-          pip install meson ninja
+          pip install mercurial meson ninja
 
       - name: Get Source
         uses: actions/download-artifact@v1

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -78,6 +78,8 @@ jobs:
         if: ${{ matrix.tag == 'naev-windows' }}
         id: crossSetup
         run: |
+          chown "$USER":"$USER" -R /github
+          winecfg
           meson setup build source \
               --cross-file='source/utils/build/${{ matrix.config }}' \
               --buildtype=debug \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cross-compile Meson Setup
         if: ${{ matrix.tag == 'naev-windows' }}
-        id: setup
+        id: crossSetup
         run: |
           meson setup build source \
               --cross-file='source/utils/build/${{ matrix.config }}' \
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload Setup Log
         uses: actions/upload-artifact@v1
-        if: ${{ success() || steps.setup.outcome == 'failure' }}
+        if: ${{ success() || steps.setup.outcome == 'failure' || steps.crossSetup.outcome == 'failure' }}
         with:
           name: ${{ matrix.tag }}-${{ github.sha }}-setup-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -29,7 +29,7 @@ jobs:
           name: naev-dist-${{ github.sha }}
           path: ${{ github.workspace }}/build/meson-dist/*
 
-  "Linux_Compile_Naev":
+  "Compile_Naev":
     needs: "Package_Source"
 
     strategy:
@@ -41,6 +41,9 @@ jobs:
 
           - tag: naev-steamruntime
             config: linux_steamruntime.ini
+
+          - tag: naev-windows
+            config: windows_cross_mxe.ini
 
     runs-on: ubuntu-latest
     container:
@@ -58,10 +61,25 @@ jobs:
           tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
 
       - name: Meson Setup
+        if: ${{ matrix.tag != naev-windows }}
         id: setup
         run: |
           meson setup build source \
               --native-file='source/utils/build/${{ matrix.config }}' \
+              --buildtype=debug \
+              --wrap-mode=forcefallback \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled \
+              -Dforce_fallback_for=SuiteSparse
+
+      - name: Cross-compile Meson Setup
+        if: ${{ matrix.tag == naev-windows }}
+        id: setup
+        run: |
+          meson setup build source \
+              --cross-file='source/utils/build/${{ matrix.config }}' \
               --buildtype=debug \
               --wrap-mode=forcefallback \
               -Db_lto=true \
@@ -97,85 +115,6 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.tag }}-${{ github.sha }}-install-log
-          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
-
-  "Windows_Compile_Naev":
-    needs: "Package_Source"
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            shell: msys2 {0}
-            config: windows.ini
-
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Set-up and Configure MinGW Environment
-        if: ${{ runner.os == 'Windows'}}
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          path-type: strict
-          install: git tar mingw-w64-x86_64-clang mingw-w64-x86_64-freetype mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libxml2 mingw-w64-x86_64-mesa mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-openal mingw-w64-x86_64-pkg-config mingw-w64-x86_64-physfs mingw-w64-x86_64-SDL2
-
-      - name: Get Source
-        uses: actions/download-artifact@v1
-        with:
-          name: naev-dist-${{ github.sha }}
-
-      - name: Extract Source
-        run: |
-          mkdir source
-          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
-
-      - name: Meson Setup
-        id: setup
-        run: |
-          meson setup build source \
-              --native-file='source/utils/build/${{ matrix.config }}' \
-              --buildtype=debug \
-              --wrap-mode=forcefallback \
-              -Db_lto=true \
-              -Dauto_features=enabled \
-              -Ddocs_c=disabled \
-              -Ddocs_lua=disabled \
-              -Dforce_fallback_for=SuiteSparse
-
-      - name: Upload Setup Log
-        uses: actions/upload-artifact@v1
-        if: ${{ success() || steps.setup.outcome == 'failure' }}
-        with:
-          name: ${{ matrix.os }}-${{ github.sha }}-setup-log
-          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
-
-      - name: Meson Compile
-        id: compile
-        run: |
-          meson compile -C build
-
-      - name: Upload Compile Log
-        uses: actions/upload-artifact@v1
-        if: ${{ success() || steps.compile.outcome == 'failure' }}
-        with:
-          name: ${{ matrix.os }}-${{ github.sha }}-compile-log
-          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
-
-      - name: Test Install
-        run: |
-          meson install -C build
-
-      - name: Upload Install Log
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{ matrix.os }}-${{ github.sha }}-install-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
   "AppImage_Compile_Naev":

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -206,6 +206,7 @@ jobs:
           brew update
           brew install \
             intltool \
+            mercurial \
             openal-soft \
             sdl2
 

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -4,23 +4,112 @@ name: CI
 
 env:
   DESTDIR: "${{ github.workspace }}/dist"
-  MESON: "${{ github.workspace }}/repo/meson.sh"
 
 jobs:
-  "Meson_Compile_Naev":
+  "Package_Source":
+    runs-on: ubuntu-latest
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
+
+    steps:
+      - name: Checkout Naev Repository
+        uses: actions/checkout@v2
+        with:
+          path: source
+          fetch-depth: 0
+
+      - name: Package Dist
+        run: |
+          meson setup build source -Dexecutable=disabled -Ddocs_c=disabled -Ddocs_lua=disabled
+          meson dist -C build --no-tests --include-subprojects
+
+      - name: Upload Dist Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-dist-${{ github.sha }}
+          path: ${{ github.workspace }}/build/meson-dist/*
+
+  "Linux_Compile_Naev":
+    needs: "Package_Source"
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            shell: bash
+          - tag: naev-ubuntu2004
             config: linux.ini
 
+          - tag: naev-steamruntime
+            config: linux_steamruntime.ini
+
+    runs-on: ubuntu-latest
+    container:
+      image: "projectsynchro/synchros_sexy_docker_images:${{ matrix.tag }}"
+
+    steps:
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist-${{ github.sha }}
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --native-file='source/utils/build/${{ matrix.config }}' \
+              --buildtype=debug \
+              --wrap-mode=forcefallback \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled \
+              -Dforce_fallback_for=SuiteSparse
+
+      - name: Upload Setup Log
+        uses: actions/upload-artifact@v1
+        if: ${{ success() || steps.setup.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-setup-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Meson Compile
+        id: compile
+        run: |
+          meson compile -C build
+
+      - name: Upload Compile Log
+        uses: actions/upload-artifact@v1
+        if: ${{ success() || steps.compile.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-compile-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Test Install
+        run: |
+          meson install -C build
+
+      - name: Upload Install Log
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-install-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+  "Windows_Compile_Naev":
+    needs: "Package_Source"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - os: windows-latest
             shell: msys2 {0}
             config: windows.ini
-            
+
     defaults:
       run:
         shell: ${{ matrix.shell }}
@@ -28,203 +117,135 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Update APT Cache
-      if: ${{ runner.os == 'Linux'}}
-      run: |
-        sudo apt-get update
+      - name: Set-up and Configure MinGW Environment
+        if: ${{ runner.os == 'Windows'}}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          path-type: strict
+          install: git tar mingw-w64-x86_64-clang mingw-w64-x86_64-freetype mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libxml2 mingw-w64-x86_64-mesa mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-openal mingw-w64-x86_64-pkg-config mingw-w64-x86_64-physfs mingw-w64-x86_64-SDL2
 
-    - name: Install Additional Build Dependencies
-      if: ${{ runner.os == 'Linux'}}
-      run: |
-        sudo apt-get install \
-          build-essential \
-          binutils-dev \
-          gettext \
-          intltool \
-          libsdl2-dev \
-          libsdl2-image-dev \
-          libgl1-mesa-dev \
-          libgl1-mesa-dri \
-          libxml2-dev \
-          libfreetype6-dev \
-          libpng-dev \
-          libopenal-dev \
-          libvorbis-dev \
-          libiberty-dev \
-          llvm \
-          ninja-build \
-          xvfb
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist-${{ github.sha }}
 
-    - name: Install MinGW Packages
-      if: ${{ runner.os == 'Windows'}}
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        update: true
-        path-type: strict
-        install: git tar mercurial mingw-w64-x86_64-cmake mingw-w64-x86_64-clang mingw-w64-x86_64-freetype mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libxml2 mingw-w64-x86_64-make mingw-w64-x86_64-mesa mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-openal mingw-w64-x86_64-pkg-config mingw-w64-x86_64-physfs mingw-w64-x86_64-SDL2
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
 
-    - name: Checkout Naev Repository
-      uses: actions/checkout@v2
-      with:
-        path: repo
-        fetch-depth: 0
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --native-file='source/utils/build/${{ matrix.config }}' \
+              --buildtype=debug \
+              --wrap-mode=forcefallback \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled \
+              -Dforce_fallback_for=SuiteSparse
 
-    - name:  Package Meson Dist
-      run: |
-        sh $MESON setup dist repo -Dexecutable=disabled -Ddocs_c=disabled -Ddocs_lua=disabled
-        sh $MESON dist -C dist --no-tests --include-subprojects
-        
-    - name: Upload Meson Dist Artifact
-      uses: actions/upload-artifact@v2
-      if: ${{ runner.os == 'Linux' }}
-      with:
-        name: naev-meson-dist-${{ github.sha }}
-        path: ${{ github.workspace }}/dist/meson-dist/*
-        if-no-files-found: error
-        
-    - name: Extract Source
-      run: |
-        mkdir source
-        tar -xf dist/meson-dist/naev-*.tar.xz -C source --strip 1
-      working-directory: "${{ github.workspace }}"
+      - name: Upload Setup Log
+        uses: actions/upload-artifact@v1
+        if: ${{ success() || steps.setup.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.os }}-${{ github.sha }}-setup-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
-    - name: Meson Setup
-      id: setup
-      run: |
-        sh $MESON setup build source \
-            --native-file='source/utils/build/${{ matrix.config }}' \
-            --buildtype=debug \
-            -Db_lto=true \
-            -Dauto_features=enabled \
-            -Ddocs_c=disabled \
-            -Ddocs_lua=disabled
+      - name: Meson Compile
+        id: compile
+        run: |
+          meson compile -C build
 
-    - name: Upload Setup Log
-      uses: actions/upload-artifact@v2
-      if: ${{ success() || steps.setup.outcome == 'failure' }}
-      with:
-        name: ${{ matrix.os }}-meson-${{ github.sha }}-setup-log
-        path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
-        if-no-files-found: ignore
+      - name: Upload Compile Log
+        uses: actions/upload-artifact@v1
+        if: ${{ success() || steps.compile.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.os }}-${{ github.sha }}-compile-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
-    - name: Meson Compile
-      id: compile
-      run: |
-        sh $MESON compile -C build
+      - name: Test Install
+        run: |
+          meson install -C build
 
-    - name: Upload Compile Log
-      uses: actions/upload-artifact@v2
-      if: ${{ success() || steps.compile.outcome == 'failure' }}
-      with:
-        name: ${{ matrix.os }}-meson-${{ github.sha }}-compile-log
-        path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
-        if-no-files-found: ignore
-
-    - name: Test Meson Install
-      run: |
-        sh $MESON install -C build
-
-    - name: Upload Install Log
-      uses: actions/upload-artifact@v2
-      if: ${{ success() || steps.compile.outcome == 'failure' }}
-      with:
-        name: ${{ matrix.os }}-meson-${{ github.sha }}-install-log
-        path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
-        if-no-files-found: ignore
+      - name: Upload Install Log
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }}-${{ github.sha }}-install-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
   "AppImage_Compile_Naev":
-    needs: Meson_Compile_Naev
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - buildtype: meson
-
-    runs-on: ubuntu-16.04
+    needs: [Package_Source, Linux_Compile_Naev]
+    runs-on: ubuntu-latest
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
 
     steps:
-    - name: Update APT Cache
-      run: |
-        sudo apt-get update
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist-${{ github.sha }}
 
-    - name: Install Additional Build Dependencies
-      run: |
-        sudo apt-get install \
-          binutils-dev \
-          build-essential \
-          gettext \
-          intltool \
-          libfreetype6-dev \
-          libgl1-mesa-dev \
-          libiberty-dev \
-          libopenal-dev \
-          libpng-dev \
-          libsdl2-dev \
-          libsdl2-image-dev \
-          libvorbis-dev \
-          libxml2-dev \
-          ninja-build=1.7.1-1~ubuntu16.04.1
-        sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-9 90
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
 
-    - name: Checkout Naev Repository
-      uses: actions/checkout@v2
-      with:
-        path: repo
-        fetch-depth: 0
+      - name: Compile AppImage
+        id: appimageCompile
+        run: |
+          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "${{ github.workspace }}/dist"" appImageBuildLog.txt
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: 1
 
-    - name: Compile AppImage Meson
-      id: mesonCompile
-      run: |
-        ./repo/utils/buildAppImage.sh -c -m -s "repo" -b "build" -o "${{ env.DESTDIR }}" |& tee -a appImageBuildLog.txt
+      - name: Upload AppImage Compile Log
+        uses: actions/upload-artifact@v1
+        if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
+        with:
+          name: naev-${{ github.sha }}-AppImageBuild-log
+          path: ${{ github.workspace }}/appImageBuildLog.txt
 
-    - name: Upload Compile Log
-      uses: actions/upload-artifact@v2
-      if: ${{ (success() || steps.mesonCompile.outcome == 'failure') }}
-      with:
-        name: naev-${{ github.sha }}-${{ matrix.buildtype }}AppImageBuild-log
-        path: ${{ github.workspace }}/appImageBuildLog.txt
-        if-no-files-found: ignore
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-AppImage-${{ github.sha }}
+          path: "${{ github.workspace }}/dist/out/*.AppImage"
+          if-no-files-found: error
 
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: naev-${{ matrix.buildtype }}AppImage-${{ github.sha }}
-        path: "${{ env.DESTDIR }}/out/*.AppImage"
-        if-no-files-found: error
-
-  "Documentation":
-    needs: [AppImage_Compile_Naev, Meson_Compile_Naev]
-    runs-on: ubuntu-20.04
+  "Lua_Documentation":
+    runs-on: ubuntu-latest
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu2004
+    needs: [Package_Source, Linux_Compile_Naev, Windows_Compile_Naev]
 
     steps:
-    - name: Update APT Cache
-      run: |
-        sudo apt-get update
-        
-    - name: Install Additional Build Dependencies
-      run: |
-        sudo apt-get install \
-          lua-ldoc \
-          graphviz \
-          doxygen \
-          ninja-build
-          
-    - name: Checkout Naev Repository
-      uses: actions/checkout@v2
-      with:
-        path: repo
-        fetch-depth: 0
-        
-    - name: Meson Build
-      run: |
-        sh $MESON setup build repo \
-            -Dexecutable=disabled
-        
-    - name: Trigger API Site Update
-      if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
-      run: |
-        curl -X POST https://api.github.com/repos/naev/naev.github.io/dispatches \
-        -H 'Accept: application/vnd.github.everest-preview+json' \
-        -u ${{ secrets.WEBSITE_ACCESS_TOKEN }} \
-        --data '{"event_type": "api", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist-${{ github.sha }}
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        run: |
+          meson setup build source \
+              -Dexecutable=disabled
+
+      - name: Meson Compile
+        run: |
+          meson compile -C build
+
+      - name: Trigger API Documentation Update
+        if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
+        run: |
+          curl -X POST https://api.github.com/repos/naev/naev.github.io/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.WEBSITE_ACCESS_TOKEN }} \
+          --data '{"event_type": "api", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -4,6 +4,7 @@ name: CI
 
 env:
   DESTDIR: "${{ github.workspace }}/dist"
+  WINEPREFIX: "/tmp/.wine"
 
 jobs:
   "Package_Source":
@@ -78,8 +79,6 @@ jobs:
         if: ${{ matrix.tag == 'naev-windows' }}
         id: crossSetup
         run: |
-          chown "$USER":"$USER" -R /github/home
-          winecfg
           meson setup build source \
               --cross-file='source/utils/build/${{ matrix.config }}' \
               --buildtype=debug \

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -192,11 +192,9 @@ jobs:
         include:
           - os: macos-10.15
             config: macos.ini
-            pkg-config-path: "/usr/local/opt/openal-soft/lib/pkgconfig"
 
           - os: macos-11.0
             config: macos.ini
-            pkg-config-path: "/usr/local/opt/openal-soft/lib/pkgconfig"
 
     runs-on: "${{ matrix.os }}"
 
@@ -206,8 +204,7 @@ jobs:
           brew update
           brew install \
             intltool \
-            mercurial \
-            openal-soft \
+            physfs \
             sdl2
 
       - name: Setup Python
@@ -233,13 +230,11 @@ jobs:
           meson setup build source \
               --native-file='source/utils/build/${{ matrix.config }}' \
               --buildtype=debug \
-              --wrap-mode=forcefallback \
               --pkg-config-path=${{ matrix.pkg-config-path }} \
               -Db_lto=true \
               -Dauto_features=enabled \
               -Ddocs_c=disabled \
-              -Ddocs_lua=disabled \
-              -Dforce_fallback_for=SuiteSparse
+              -Ddocs_lua=disabled
 
       - name: Upload Setup Log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -123,7 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
-
+      volumes:
+        - /tmp/out:${{ github.workspace }}/VolMount
     steps:
       - name: Get Source
         uses: actions/download-artifact@v1
@@ -138,24 +139,26 @@ jobs:
       - name: Compile AppImage
         id: appimageCompile
         run: |
-          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "dist"" appImageBuildLog.txt
+          mkdir -p /tmp/out
+          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "$DESTDIR"" /tmp/out/appImageBuildLog.txt
+          cp $DESTDIR/out/*.AppImage /tmp/out
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
       - name: Upload AppImage Compile Log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v1
         if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
         with:
           name: naev-${{ github.sha }}-AppImageBuild-log
           path: |
-            appImageBuildLog.txt
+            ${{ github.workspace }}/VolMount/*.txt
 
       - name: Upload AppImage Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v1
         with:
           name: naev-${{ github.sha }}-AppImageBuild
           path: |
-            dist/out/*
+            ${{ github.workspace }}/VolMount/*.AppImage
           if-no-files-found: error
 
   "Lua_Documentation":

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -139,11 +139,6 @@ jobs:
         id: appimageCompile
         run: |
           script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "dist"" appImageBuildLog.txt
-          pwd
-          ls -l ${{ github.workspace }}/dist
-          pwd
-          ls -l ${{ github.workspace }}/dist/out
-          pwd
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -30,7 +30,7 @@ jobs:
           name: naev-dist-${{ github.sha }}
           path: ${{ github.workspace }}/build/meson-dist/*
 
-  "Compile_Naev":
+  "Linux_Compile_Naev":
     needs: "Package_Source"
 
     strategy:
@@ -42,9 +42,6 @@ jobs:
 
           - tag: naev-steamruntime
             config: linux_steamruntime.ini
-
-          - tag: naev-windows
-            config: windows_cross_mxe.ini
 
     runs-on: ubuntu-latest
     container:
@@ -62,7 +59,6 @@ jobs:
           tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
 
       - name: Meson Setup
-        if: ${{ matrix.tag != 'naev-windows' }}
         id: setup
         run: |
           meson setup build source \
@@ -75,23 +71,9 @@ jobs:
               -Ddocs_lua=disabled \
               -Dforce_fallback_for=SuiteSparse
 
-      - name: Cross-compile Meson Setup
-        if: ${{ matrix.tag == 'naev-windows' }}
-        id: crossSetup
-        run: |
-          meson setup build source \
-              --cross-file='source/utils/build/${{ matrix.config }}' \
-              --buildtype=debug \
-              --wrap-mode=forcefallback \
-              -Db_lto=true \
-              -Dauto_features=enabled \
-              -Ddocs_c=disabled \
-              -Ddocs_lua=disabled \
-              -Dforce_fallback_for=SuiteSparse
-
       - name: Upload Setup Log
         uses: actions/upload-artifact@v1
-        if: ${{ success() || steps.setup.outcome == 'failure' || steps.crossSetup.outcome == 'failure' }}
+        if: ${{ success() || steps.setup.outcome == 'failure' }}
         with:
           name: ${{ matrix.tag }}-${{ github.sha }}-setup-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
@@ -126,8 +108,177 @@ jobs:
           name: ${{ matrix.tag }}-${{ github.sha }}-install-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
+  "Windows_Compile_Naev":
+    needs: "Package_Source"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: naev-windows
+            config: windows_cross_mxe.ini
+
+    runs-on: ubuntu-latest
+    container:
+      image: "projectsynchro/synchros_sexy_docker_images:${{ matrix.tag }}"
+
+    steps:
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist-${{ github.sha }}
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --cross-file='source/utils/build/${{ matrix.config }}' \
+              --buildtype=debug \
+              --wrap-mode=forcefallback \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled \
+              -Dforce_fallback_for=SuiteSparse
+
+      - name: Upload Setup Log
+        uses: actions/upload-artifact@v2
+        if: ${{ success() || steps.setup.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-setup-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Meson Compile
+        id: compile
+        run: |
+          meson compile -C build
+
+      - name: Upload Compile Log
+        uses: actions/upload-artifact@v2
+        if: ${{ success() || steps.compile.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-compile-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-buildArtifacts
+          path: |
+            ${{ github.workspace }}/build
+          if-no-files-found: error
+
+      - name: Test Install
+        run: |
+          meson install -C build
+
+      - name: Upload Install Log
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-install-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+  "Darwin_Compile_Naev":
+    needs: "Package_Source"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-10.15
+            config: macos.ini
+            pkg-config-path: "/usr/local/opt/openal-soft/lib/pkgconfig"
+
+          - os: macos-11.0
+            config: macos.ini
+            pkg-config-path: "/usr/local/opt/openal-soft/lib/pkgconfig"
+
+    runs-on: "${{ matrix.os }}"
+
+    steps:
+      - name: Install Homebrew Packages
+        run: |
+          brew update
+          brew install \
+            binutils \
+            fontconfig \
+            intltool \
+            libpng \
+            libvorbis \
+            meson \
+            ninja \
+            openal-soft \
+            pkg-config \
+            sdl2
+
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist-${{ github.sha }}
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --native-file='source/utils/build/${{ matrix.config }}' \
+              --buildtype=debug \
+              --wrap-mode=forcefallback \
+              --pkg-config-path=${{ matrix.pkg-config-path }} \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled \
+              -Dforce_fallback_for=SuiteSparse
+
+      - name: Upload Setup Log
+        uses: actions/upload-artifact@v1
+        if: ${{ success() || steps.setup.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-setup-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Meson Compile
+        id: compile
+        run: |
+          meson compile -C build
+
+      - name: Upload Compile Log
+        uses: actions/upload-artifact@v2
+        if: ${{ success() || steps.compile.outcome == 'failure' }}
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-compile-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-buildArtifacts
+          path: |
+            ${{ github.workspace }}/build
+          if-no-files-found: error
+
+      - name: Test Install
+        run: |
+          meson install -C build
+
+      - name: Upload Install Log
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.tag }}-${{ github.sha }}-install-log
+          path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
   "AppImage_Compile_Naev":
-    needs: [Package_Source, Compile_Naev]
+    needs: [Package_Source, Linux_Compile_Naev]
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
@@ -171,7 +322,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu2004
-    needs: [Package_Source, Compile_Naev]
+    needs:
+      [
+        Package_Source,
+        Linux_Compile_Naev,
+        Windows_Compile_Naev,
+        Darwin_Compile_Naev,
+      ]
 
     steps:
       - name: Get Source

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -139,8 +139,11 @@ jobs:
         id: appimageCompile
         run: |
           script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "${{ github.workspace }}/dist"" appImageBuildLog.txt
+          pwd
           ls -l ${{ github.workspace }}/dist
+          pwd
           ls -l ${{ github.workspace }}/dist/out
+          pwd
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
 
@@ -150,14 +153,14 @@ jobs:
         with:
           name: naev-${{ github.sha }}-AppImageBuild-log
           path: |
-            ${{ github.workspace }}/appImageBuildLog.txt
+            appImageBuildLog.txt
 
       - name: Upload AppImage Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-${{ github.sha }}-AppImageBuild
           path: |
-            ${{ github.workspace }}/dist/out/*.*
+            dist/out/*
           if-no-files-found: error
 
   "Lua_Documentation":

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -9,6 +9,7 @@ name: Nightly Release
 jobs:
   "Package_Source":
     runs-on: ubuntu-latest
+
     container:
       image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
 
@@ -86,20 +87,15 @@ jobs:
 
   "Windows_Naev_Release":
     needs: "Package_Source"
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        shell: msys2 {0}
+    env:
+      WINEPREFIX: "/tmp/.wine"
+
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-windows
 
     steps:
-      - name: Install MinGW Packages
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: git python tar mingw-w64-x86_64-clang mingw-w64-x86_64-freetype mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libxml2 mingw-w64-x86_64-luajit mingw-w64-x86_64-mesa mingw-w64-x86_64-meson mingw-w64-x86_64-ninja mingw-w64-x86_64-nsis mingw-w64-x86_64-openal mingw-w64-x86_64-pkg-config mingw-w64-x86_64-physfs mingw-w64-x86_64-SDL2 mingw-w64-x86_64-suitesparse
-
       - name: Get Source
         uses: actions/download-artifact@v2
         with:
@@ -113,7 +109,7 @@ jobs:
       - name: Meson Setup
         run: |
           meson setup build source \
-            --native-file='source/utils/build/windows.ini' \
+            --cross-file='source/utils/build/windows_cross_mxe.ini' \
             --buildtype=release \
             -Db_lto=true \
             -Dauto_features=enabled \
@@ -195,8 +191,8 @@ jobs:
       matrix:
         include:
           - releasetype: github
-          - releasetype: steam
-          - releasetype: itch
+#          - releasetype: steam
+#          - releasetype: itch
 
     runs-on: ubuntu-latest
     needs:
@@ -206,7 +202,7 @@ jobs:
         Windows_Naev_Release,
         Steam_Naev_Release,
       ]
-    if: ${{ github.repository == 'naev/naev' }}
+    #if: ${{ github.repository == 'naev/naev' }}
 
     steps:
       - name: Checkout Naev Repository

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -1,8 +1,9 @@
 on:
   repository_dispatch:
     types: manual-nightly
-  schedule:
-    - cron: "0 0 * * *"
+push:
+#  schedule:
+#    - cron: "0 0 * * *"
 
 name: Nightly Release
 

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -1,7 +1,7 @@
 on:
   repository_dispatch:
     types: manual-nightly
-push:
+  push:
 #  schedule:
 #    - cron: "0 0 * * *"
 

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -1,9 +1,8 @@
 on:
   repository_dispatch:
     types: manual-nightly
-  push:
-#  schedule:
-#    - cron: "0 0 * * *"
+  schedule:
+    - cron: "0 0 * * *"
 
 name: Nightly Release
 
@@ -192,8 +191,8 @@ jobs:
       matrix:
         include:
           - releasetype: github
-#          - releasetype: steam
-#          - releasetype: itch
+          - releasetype: steam
+          - releasetype: itch
 
     runs-on: ubuntu-latest
     needs:
@@ -203,7 +202,7 @@ jobs:
         Windows_Naev_Release,
         Steam_Naev_Release,
       ]
-    #if: ${{ github.repository == 'naev/naev' }}
+    if: ${{ github.repository == 'naev/naev' }}
 
     steps:
       - name: Checkout Naev Repository

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -1,10 +1,10 @@
 on:
   push:
     tags:
-      - '!v*.*.*'
-      - 'v*.*.*-alpha*'
-      - 'v*.*.*-beta*'
-      - 'v*.*.*-rc*'
+      - "!v*.*.*"
+      - "v*.*.*-alpha*"
+      - "v*.*.*-beta*"
+      - "v*.*.*-rc*"
 
 name: Pre-Release
 
@@ -210,7 +210,7 @@ jobs:
       - name: Create Release Staging and Output Areas
         run: |
           mkdir -p {temp,dist/{staging,out/{lin64,win64}}}
-          
+
       - name: Update APT Cache
         if: ${{ matrix.releasetype == 'steam' }}
         run: |
@@ -223,7 +223,7 @@ jobs:
         run: |
           echo steamcmd steam/question select "I AGREE" | sudo debconf-set-selections
           sudo apt-get install lib32gcc1 libsdl2-2.0-0:i386 steamcmd
-          
+
       - name: Install Butler
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
@@ -258,7 +258,7 @@ jobs:
           prerelease: true
           files: |
             ${{ github.workspace }}/dist/out/*
-          
+
       - name: Build and Upload itch.io Release
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
@@ -271,7 +271,7 @@ jobs:
 
           tar -Jxf "dist/staging/naev-win64/steam-win64.tar.xz" -C "dist/out/win64"
           tar -Jxf "dist/staging/naev-ndata/steam-ndata.tar.xz" -C "dist/out/win64" --strip 1
-          
+
           ./butler push --userversion="$SUFFIX" dist/out/lin64 naev/naev:linux-x86-64-beta
           ./butler push --userversion="$SUFFIX" dist/out/win64 naev/naev:windows-x86-64-beta
         env:

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           mkdir -p dist/out/steam
           mv build/meson-dist/naev-*.tar.xz dist/out/source.tar.xz
+          cp source/CHANGELOG dist/out
           cp source/dat/VERSION dist/out
           cp -r source/utils/ci/steam/* dist/out/steam
 

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -49,6 +49,13 @@ jobs:
           path: ${{ github.workspace }}/dist/out/VERSION
           if-no-files-found: error
 
+      - name: Upload Changelog Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-changelog
+          path: ${{ github.workspace }}/dist/out/CHANGELOG
+          if-no-files-found: error
+
       - name: Upload Deployment Script Artifact
         uses: actions/upload-artifact@v2
         with:
@@ -251,13 +258,13 @@ jobs:
           chmod +x dist/out/naev-$SUFFIX-linux-x86-64.AppImage
 
       - name: Upload Github Release
+        uses: ncipollo/release-action@v1
         if: ${{ matrix.releasetype == 'github' }}
-        uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          artifacts: "dist/out/*.*"
+          bodyFile: "dist/staging/naev-changelog/CHANGELOG"
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          files: |
-            ${{ github.workspace }}/dist/out/*
 
       - name: Build and Upload itch.io Release
         if: ${{ matrix.releasetype == 'itch' }}

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -1,67 +1,45 @@
 on:
-  repository_dispatch:
-    types: manual-prerelease
   push:
     tags:
       - '!v*.*.*'
+      - 'v*.*.*-alpha*'
       - 'v*.*.*-beta*'
       - 'v*.*.*-rc*'
 
 name: Pre-Release
 
 jobs:
-  "Generate_Source":
+  "Package_Source":
     runs-on: ubuntu-latest
 
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
+
     steps:
-      - name: Update APT Cache
-        run: |
-          sudo apt-get update
-
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get install \
-            automake \
-            autopoint \
-            autoconf-archive \
-            build-essential \
-            binutils-dev \
-            gettext \
-            intltool \
-            libsdl2-dev \
-            libsdl2-mixer-dev \
-            libsdl2-image-dev \
-            libgl1-mesa-dev \
-            libxml2-dev \
-            libfreetype6-dev \
-            libpng-dev \
-            libopenal-dev \
-            libvorbis-dev \
-            libiberty-dev
-
       - name: Checkout Naev Repository
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
+          path: source
           submodules: true
 
-      - name: Generate source archive
+      - name: Package Dist
         run: |
-          ./autogen.sh
-          ./configure
-          make dist-gzip
-          make dat/VERSION
+          meson setup build source -Dexecutable=disabled -Ddocs_c=disabled -Ddocs_lua=disabled
+          meson dist -C build --no-tests --include-subprojects
 
       - name: Collect Artifacts
         run: |
-          mkdir -p dist/out
-          mv naev-*.tar.gz dist/out/source.tar.gz
-          cp dat/VERSION dist/out
+          mkdir -p dist/out/steam
+          mv build/meson-dist/naev-*.tar.xz dist/out/source.tar.xz
+          cp source/dat/VERSION dist/out
+          cp -r source/utils/ci/steam/* dist/out/steam
 
       - name: Upload Source Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-dist
-          path: ${{ github.workspace }}/dist/out/source.tar.gz
+          path: ${{ github.workspace }}/dist/out/source.tar.xz
           if-no-files-found: error
 
       - name: Upload Version Artifact
@@ -75,149 +53,139 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: naev-steam-deployment
-          path: ${{ github.workspace }}/utils/ci/steam/*
+          path: ${{ github.workspace }}/dist/out/steam/*
           if-no-files-found: error
 
-  "Build_Naev_Release":
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-16.04
-            buildoutput: naev-linux-x86-64
-            shell: bash
-            make: make
-          - os: windows-latest
-            buildoutput: naev-win64
-            shell: msys2 {0}
-            make: mingw32-make
-    
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
-            
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Update APT Cache
-        if: ${{ runner.os == 'Linux'}}
-        run: |
-          sudo apt-get update
-
-      - name: Install Build Dependencies
-        if: ${{ runner.os == 'Linux'}}
-        run: |
-          sudo apt-get install \
-            automake \
-            autopoint \
-            autoconf-archive \
-            build-essential \
-            binutils-dev \
-            gettext \
-            intltool \
-            libsdl2-dev \
-            libsdl2-mixer-dev \
-            libsdl2-image-dev \
-            libgl1-mesa-dev \
-            libxml2-dev \
-            libfreetype6-dev \
-            libpng-dev \
-            libopenal-dev \
-            libvorbis-dev \
-            libiberty-dev \
-            libluajit-5.1-dev \
-            libsuitesparse-dev
-            
-      - name: Install MinGW Packages
-        if: ${{ runner.os == 'Windows'}}
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-itstool mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-python-pip mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis mingw-w64-x86_64-make mingw-w64-x86_64-pkg-config mingw-w64-x86_64-suitesparse autoconf autoconf-archive automake-wrapper git intltool python tar
-
-      - name: Checkout Naev Repository
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-          
-      - name: Build Naev for Win64
-        if: ${{ runner.os == 'Windows'}}
-        run: |
-          ./autogen.sh
-          ./configure --disable-debug
-          $MAKE -j$(nproc --all)
-        env:
-          CFLAGS: "-O3"
-          MAKE: "${{ matrix.make }}"
-          
-      - name: Build and Package Naev for Linux64
-        if: ${{ runner.os == 'Linux'}}
-        run: |
-          ./utils/buildAppImage.sh -s "$(pwd)" -b "$(pwd)" -o "$(pwd)/dist"
-        env:
-          CFLAGS: "-O3"
-          
-      - name: Build Windows Installer
-        if: ${{ runner.os == 'Windows'}}
-        run: |
-          ./extras/windows/packageWindows.sh -s "$(pwd)" -b "$(pwd)" -o "$(pwd)/dist"
-          
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.buildoutput }}
-          path: |
-            ${{ github.workspace }}/dist/out/*
-          if-no-files-found: error
-            
-  "Build_Naev_Steam_Release":
+  "Linux_Naev_Release":
+    needs: "Package_Source"
     runs-on: ubuntu-latest
 
     container:
-      image: dosowisko/steam-runtime-amd64
-      volumes:
-        - ${{ github.workspace }}:${{ github.workspace }}
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
 
     steps:
-      - name: Clone Naev Repository
-        run: |
-          git clone https://github.com/naev/naev.git ${{ github.workspace }}
+      - name: Get Source
+        uses: actions/download-artifact@v2
+        with:
+          name: naev-dist
 
-      - name: Install Additional Build Dependencies
+      - name: Extract Source
         run: |
-          sudo apt-get -y install autoconf-archive intltool
+          mkdir source
+          tar -xf source.tar.xz -C source --strip 1
 
-      - name: Build Naev for Steam on Linux64
+      - name: Compile AppImage
+        id: appimageCompile
         run: |
-          cd ${{ github.workspace }}
-          ./autogen.sh
-          ./configure --disable-debug --build=x86_64-linux-gnu
-          make -j$(nproc --all)
-          make data
+          ./source/utils/buildAppImage.sh -m -s "source" -b "build" -o "${{ env.DESTDIR }}"
         env:
-          CFLAGS: "-O3 -std=gnu11"
+          APPIMAGE_EXTRACT_AND_RUN: 1
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-linux-x86-64
+          path: "${{ env.DESTDIR }}/out/*.AppImage"
+
+  "Windows_Naev_Release":
+    needs: "Package_Source"
+    runs-on: ubuntu-latest
+
+    env:
+      WINEPREFIX: "/tmp/.wine"
+
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-windows
+
+    steps:
+      - name: Get Source
+        uses: actions/download-artifact@v2
+        with:
+          name: naev-dist
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf source.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        run: |
+          meson setup build source \
+            --cross-file='source/utils/build/windows_cross_mxe.ini' \
+            --buildtype=release \
+            -Db_lto=true \
+            -Dauto_features=enabled \
+            -Ddocs_c=disabled \
+            -Ddocs_lua=disabled
+
+      - name: Meson Compile
+        run: |
+          meson compile -C build
+
+      - name: Build Windows Installer
+        run: |
+          ./source/extras/windows/packageWindows.sh -s "source" -b "build" -o "$(pwd)/dist"
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-win64
+          path: ${{ github.workspace }}/dist/out/*
+          if-no-files-found: error
+
+  "Steam_Naev_Release":
+    needs: "Package_Source"
+    runs-on: ubuntu-latest
+
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-steamruntime
+
+    steps:
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist/source.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --native-file='source/utils/build/linux_steamruntime.ini' \
+              --buildtype=release \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled
+
+      - name: Meson Compile
+        run: |
+          meson compile -C build
 
       - name: Collect Steam Linux64 Artifacts
         run: |
-          mkdir -p ${{ github.workspace }}/dist/out/
+          mkdir -p dist/out/
 
-          mv ${{ github.workspace }}/src/naev ${{ github.workspace }}/dist/out/naev.x64
-          chmod +x ${{ github.workspace }}/dist/out/naev.x64
+          mv build/naev dist/out/naev.x64
+          chmod +x dist/out/naev.x64
 
-          tar -cJvf ${{ github.workspace }}/dist/out/steam-ndata.tar.xz dat
-      
+          tar -cJvf dist/out/steam-ndata.tar.xz source/dat
+
       - name: Upload Naev Binary Artifact
         uses: actions/upload-artifact@v1
         with:
           name: naev-steamruntime
-          path: ${{ github.workspace }}/dist/out/naev.x64
+          path: dist/out/naev.x64
 
       - name: Upload Naev Data Artifact
         uses: actions/upload-artifact@v1
         with:
           name: naev-ndata
-          path: ${{ github.workspace }}/dist/out/steam-ndata.tar.xz
+          path: dist/out/steam-ndata.tar.xz
 
   "Upload_Naev_Release":
     strategy:
@@ -227,9 +195,15 @@ jobs:
           - releasetype: github
           - releasetype: steam
           - releasetype: itch
-            
+
     runs-on: ubuntu-latest
-    needs: [Generate_Source, Build_Naev_Release, Build_Naev_Steam_Release]
+    needs:
+      [
+        Package_Source,
+        Linux_Naev_Release,
+        Windows_Naev_Release,
+        Steam_Naev_Release,
+      ]
     if: ${{ github.repository == 'naev/naev' }}
 
     steps:
@@ -268,11 +242,11 @@ jobs:
         run: |
           BUILD_DATE="$(date +%Y%m%d)"
           VERSION="$(<"dist/staging/naev-version/VERSION")"
-          SUFFIX="$VERSION"
+          SUFFIX="$VERSION.$BUILD_DATE"
 
           mv dist/staging/naev-linux-x86-64/*.AppImage dist/out/naev-$SUFFIX-linux-x86-64.AppImage
           mv dist/staging/naev-win64/naev*.exe dist/out/naev-$SUFFIX-win64.exe
-          mv dist/staging/naev-dist/source.tar.gz dist/out/naev-$SUFFIX-source.tar.gz
+          mv dist/staging/naev-dist/source.tar.xz dist/out/naev-$SUFFIX-source.tar.xz
 
           chmod +x dist/out/naev-$SUFFIX-linux-x86-64.AppImage
 
@@ -296,7 +270,7 @@ jobs:
           chmod +x dist/out/lin64/naev-$SUFFIX-linux-x86-64.AppImage
 
           tar -Jxf "dist/staging/naev-win64/steam-win64.tar.xz" -C "dist/out/win64"
-          tar -Jxf "dist/staging/naev-ndata/steam-ndata.tar.xz" -C "dist/out/win64"
+          tar -Jxf "dist/staging/naev-ndata/steam-ndata.tar.xz" -C "dist/out/win64" --strip 1
           
           ./butler push --userversion="$SUFFIX" dist/out/lin64 naev/naev:linux-x86-64-beta
           ./butler push --userversion="$SUFFIX" dist/out/win64 naev/naev:windows-x86-64-beta
@@ -308,7 +282,7 @@ jobs:
         run: |
           chmod -R +x dist/staging/naev-steam-deployment
           cp -r dist/staging/naev-steam-deployment/* ${{ github.workspace }}
-          ./SteamDeploy.sh -v "${{ github.workspace }}/dist/staging/naev-version" -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
+          ./SteamDeploy.sh -p -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
         env:
           STEAMCMD_USER: ${{ secrets.STEAMCMD_USER }}
           STEAMCMD_PASS: ${{ secrets.STEAMCMD_PASS }}

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -235,7 +235,7 @@ jobs:
 
           unzip build/naev-*-soundtrack.zip -d dist/staging
           cp build/naev-*-soundtrack.zip dist/out
-          cp extras/logos/naev_soundtrack_cover.png dist/out/steam
+          cp source/extras/logos/naev_soundtrack_cover.png dist/out/steam
 
       - name: Transcode Steam Soundtrack
         run: |

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Transcode Steam Soundtrack
         run: |
-          ./utils/convertToMP3.sh -i dist/staging -f ogg -o dist/out/steam
+          ./source/utils/convertToMP3.sh -i dist/staging -f ogg -o dist/out/steam
 
       - name: Upload Soundtrack Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           mkdir -p dist/out/steam
           mv build/meson-dist/naev-*.tar.xz dist/out/source.tar.xz
+          cp source/CHANGELOG dist/out
           cp source/dat/VERSION dist/out
           cp -r source/utils/ci/steam/* dist/out/steam
 

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -234,7 +234,7 @@ jobs:
           mkdir -p dist/out/steam
 
           unzip build/naev-*-soundtrack.zip -d dist/staging
-          cp naev-*-soundtrack.zip dist/out
+          cp build/naev-*-soundtrack.zip dist/out
           cp extras/logos/naev_soundtrack_cover.png dist/out/steam
 
       - name: Transcode Steam Soundtrack

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -1,67 +1,45 @@
 on:
-  repository_dispatch:
-    types: manual-release
   push:
     tags:
-      - 'v*.*.*'
-      - '!v*.*.*-beta*'
-      - '!v*.*.*-rc*'
+      - "v*.*.*"
+      - "!v*.*.*-alpha*"
+      - "!v*.*.*-beta*"
+      - "!v*.*.*-rc*"
 
 name: Release
 
 jobs:
-  "Generate_Source":
+  "Package_Source":
     runs-on: ubuntu-latest
 
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
+
     steps:
-      - name: Update APT Cache
-        run: |
-          sudo apt-get update
-
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get install \
-            automake \
-            autopoint \
-            autoconf-archive \
-            build-essential \
-            binutils-dev \
-            gettext \
-            intltool \
-            libsdl2-dev \
-            libsdl2-mixer-dev \
-            libsdl2-image-dev \
-            libgl1-mesa-dev \
-            libxml2-dev \
-            libfreetype6-dev \
-            libpng-dev \
-            libopenal-dev \
-            libvorbis-dev \
-            libiberty-dev
-
       - name: Checkout Naev Repository
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
+          path: source
           submodules: true
 
-      - name: Generate source archive
+      - name: Package Dist
         run: |
-          ./autogen.sh
-          ./configure
-          make dist-gzip
-          make dat/VERSION
+          meson setup build source -Dexecutable=disabled -Ddocs_c=disabled -Ddocs_lua=disabled
+          meson dist -C build --no-tests --include-subprojects
 
       - name: Collect Artifacts
         run: |
-          mkdir -p dist/out
-          mv naev-*.tar.gz dist/out/source.tar.gz
-          cp dat/VERSION dist/out
+          mkdir -p dist/out/steam
+          mv build/meson-dist/naev-*.tar.xz dist/out/source.tar.xz
+          cp source/dat/VERSION dist/out
+          cp -r source/utils/ci/steam/* dist/out/steam
 
       - name: Upload Source Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-dist
-          path: ${{ github.workspace }}/dist/out/source.tar.gz
+          path: ${{ github.workspace }}/dist/out/source.tar.xz
           if-no-files-found: error
 
       - name: Upload Version Artifact
@@ -71,210 +49,191 @@ jobs:
           path: ${{ github.workspace }}/dist/out/VERSION
           if-no-files-found: error
 
+      - name: Upload Changelog Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-changelog
+          path: ${{ github.workspace }}/dist/out/CHANGELOG
+          if-no-files-found: error
+
       - name: Upload Deployment Script Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-steam-deployment
-          path: ${{ github.workspace }}/utils/ci/steam/*
+          path: ${{ github.workspace }}/dist/out/steam/*
           if-no-files-found: error
 
-  "Build_Naev_Release":
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-16.04
-            buildoutput: naev-linux-x86-64
-            shell: bash
-            make: make
-          - os: windows-latest
-            buildoutput: naev-win64
-            shell: msys2 {0}
-            make: mingw32-make
-    
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
-            
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Update APT Cache
-        if: ${{ runner.os == 'Linux'}}
-        run: |
-          sudo apt-get update
-
-      - name: Install Build Dependencies
-        if: ${{ runner.os == 'Linux'}}
-        run: |
-          sudo apt-get install \
-            automake \
-            autopoint \
-            autoconf-archive \
-            build-essential \
-            binutils-dev \
-            gettext \
-            intltool \
-            libsdl2-dev \
-            libsdl2-mixer-dev \
-            libsdl2-image-dev \
-            libgl1-mesa-dev \
-            libxml2-dev \
-            libfreetype6-dev \
-            libpng-dev \
-            libopenal-dev \
-            libvorbis-dev \
-            libiberty-dev \
-            libluajit-5.1-dev \
-            libsuitesparse-dev
-            
-      - name: Install MinGW Packages
-        if: ${{ runner.os == 'Windows'}}
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: mingw-w64-x86_64-libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-libxml2 mingw-w64-x86_64-libpng mingw-w64-x86_64-openal mingw-w64-x86_64-libvorbis mingw-w64-x86_64-binutils mingw-w64-x86_64-itstool mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-python-pip mingw-w64-x86_64-luajit mingw-w64-x86_64-nsis mingw-w64-x86_64-make mingw-w64-x86_64-pkg-config mingw-w64-x86_64-suitesparse autoconf autoconf-archive automake-wrapper git intltool python tar
-
-      - name: Checkout Naev Repository
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-          
-      - name: Build Naev for Win64
-        if: ${{ runner.os == 'Windows'}}
-        run: |
-          ./autogen.sh
-          ./configure --disable-debug
-          $MAKE -j$(nproc --all)
-        env:
-          CFLAGS: "-O3"
-          MAKE: "${{ matrix.make }}"
-          
-      - name: Build and Package Naev for Linux64
-        if: ${{ runner.os == 'Linux'}}
-        run: |
-          ./utils/buildAppImage.sh -s "$(pwd)" -b "$(pwd)" -o "$(pwd)/dist"
-        env:
-          CFLAGS: "-O3"
-          
-      - name: Build Windows Installer
-        if: ${{ runner.os == 'Windows'}}
-        run: |
-          ./extras/windows/packageWindows.sh -s "$(pwd)" -b "$(pwd)" -o "$(pwd)/dist"
-          
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.buildoutput }}
-          path: |
-            ${{ github.workspace }}/dist/out/*
-          if-no-files-found: error
-            
-  "Build_Naev_Steam_Release":
+  "Linux_Naev_Release":
+    needs: "Package_Source"
     runs-on: ubuntu-latest
 
     container:
-      image: dosowisko/steam-runtime-amd64
-      volumes:
-        - ${{ github.workspace }}:${{ github.workspace }}
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
 
     steps:
-      - name: Clone Naev Repository
-        run: |
-          git clone https://github.com/naev/naev.git ${{ github.workspace }}
+      - name: Get Source
+        uses: actions/download-artifact@v2
+        with:
+          name: naev-dist
 
-      - name: Install Additional Build Dependencies
+      - name: Extract Source
         run: |
-          sudo apt-get -y install autoconf-archive intltool
+          mkdir source
+          tar -xf source.tar.xz -C source --strip 1
 
-      - name: Build Naev for Steam on Linux64
+      - name: Compile AppImage
+        id: appimageCompile
         run: |
-          cd ${{ github.workspace }}
-          ./autogen.sh
-          ./configure --disable-debug --build=x86_64-linux-gnu
-          make -j$(nproc --all)
-          make data
+          ./source/utils/buildAppImage.sh -m -s "source" -b "build" -o "${{ env.DESTDIR }}"
         env:
-          CFLAGS: "-O3 -std=gnu11"
+          APPIMAGE_EXTRACT_AND_RUN: 1
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-linux-x86-64
+          path: "${{ env.DESTDIR }}/out/*.AppImage"
+
+  "Windows_Naev_Release":
+    needs: "Package_Source"
+    runs-on: ubuntu-latest
+
+    env:
+      WINEPREFIX: "/tmp/.wine"
+
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-windows
+
+    steps:
+      - name: Get Source
+        uses: actions/download-artifact@v2
+        with:
+          name: naev-dist
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf source.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        run: |
+          meson setup build source \
+            --cross-file='source/utils/build/windows_cross_mxe.ini' \
+            --buildtype=release \
+            -Db_lto=true \
+            -Dauto_features=enabled \
+            -Ddocs_c=disabled \
+            -Ddocs_lua=disabled
+
+      - name: Meson Compile
+        run: |
+          meson compile -C build
+
+      - name: Build Windows Installer
+        run: |
+          ./source/extras/windows/packageWindows.sh -s "source" -b "build" -o "$(pwd)/dist"
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-win64
+          path: ${{ github.workspace }}/dist/out/*
+          if-no-files-found: error
+
+  "Steam_Naev_Release":
+    needs: "Package_Source"
+    runs-on: ubuntu-latest
+
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-steamruntime
+
+    steps:
+      - name: Get Source
+        uses: actions/download-artifact@v1
+        with:
+          name: naev-dist
+
+      - name: Extract Source
+        run: |
+          mkdir source
+          tar -xf naev-dist/source.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --native-file='source/utils/build/linux_steamruntime.ini' \
+              --buildtype=release \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled
+
+      - name: Meson Compile
+        run: |
+          meson compile -C build
 
       - name: Collect Steam Linux64 Artifacts
         run: |
-          mkdir -p ${{ github.workspace }}/dist/out/
+          mkdir -p dist/out/
 
-          mv ${{ github.workspace }}/src/naev ${{ github.workspace }}/dist/out/naev.x64
-          chmod +x ${{ github.workspace }}/dist/out/naev.x64
+          mv build/naev dist/out/naev.x64
+          chmod +x dist/out/naev.x64
 
-          tar -cJvf ${{ github.workspace }}/dist/out/steam-ndata.tar.xz dat
-      
+          tar -cJvf dist/out/steam-ndata.tar.xz source/dat
+
       - name: Upload Naev Binary Artifact
         uses: actions/upload-artifact@v1
         with:
           name: naev-steamruntime
-          path: ${{ github.workspace }}/dist/out/naev.x64
+          path: dist/out/naev.x64
 
       - name: Upload Naev Data Artifact
         uses: actions/upload-artifact@v1
         with:
           name: naev-ndata
-          path: ${{ github.workspace }}/dist/out/steam-ndata.tar.xz
+          path: dist/out/steam-ndata.tar.xz
 
-  "Build_Naev_Steam_Soundtrack":
+  "Steam_Naev_Soundtrack_Release":
+    needs: "Package_Source"
     runs-on: ubuntu-latest
 
+    container:
+      image: projectsynchro/synchros_sexy_docker_images:naev-ubuntu1604
+
     steps:
-      - name: Update APT Cache
-        run: |
-          sudo apt-get update
-
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get install \
-            automake \
-            autopoint \
-            autoconf-archive \
-            build-essential \
-            binutils-dev \
-            ffmpeg \
-            gettext \
-            intltool \
-            libsdl2-dev \
-            libsdl2-mixer-dev \
-            libsdl2-image-dev \
-            libgl1-mesa-dev \
-            libxml2-dev \
-            libfreetype6-dev \
-            libpng-dev \
-            libopenal-dev \
-            libvorbis-dev \
-            libiberty-dev \
-            unzip \
-            zip
-            
-      - name: Install Python Modules
-        run: |
-          python3 -m pip install mutagen
-          
-      - name: Checkout Naev Repository
-        uses: actions/checkout@v2
+      - name: Get Source
+        uses: actions/download-artifact@v1
         with:
-          submodules: true
+          name: naev-dist
 
-      - name: Generate Soundtrack
+      - name: Extract Source
         run: |
-          ./autogen.sh
-          ./configure
-          make dat/VERSION
-          make soundtrack
+          mkdir source
+          tar -xf naev-dist/source.tar.xz -C source --strip 1
+
+      - name: Meson Setup
+        id: setup
+        run: |
+          meson setup build source \
+              --native-file='source/utils/build/linux_steamruntime.ini' \
+              --buildtype=release \
+              -Db_lto=true \
+              -Dauto_features=enabled \
+              -Ddocs_c=disabled \
+              -Ddocs_lua=disabled
+
+      - name: Meson Compile
+        run: |
+          meson compile -C build soundtrack
 
       - name: Collect Artifacts
         run: |
-          VERSION="$(cat dat/VERSION)"
           mkdir -p dist/staging
           mkdir -p dist/out/steam
 
-          unzip naev-$VERSION-soundtrack.zip -d dist/staging
-          cp naev-$VERSION-soundtrack.zip dist/out
+          unzip build/naev-*-soundtrack.zip -d dist/staging
+          cp naev-*-soundtrack.zip dist/out
           cp extras/logos/naev_soundtrack_cover.png dist/out/steam
 
       - name: Transcode Steam Soundtrack
@@ -287,7 +246,7 @@ jobs:
           name: naev-soundtrack
           path: ${{ github.workspace }}/dist/out/naev-*-soundtrack.zip
           if-no-files-found: error
-          
+
       - name: Upload Steam Soundtrack Artifact
         uses: actions/upload-artifact@v2
         with:
@@ -303,16 +262,22 @@ jobs:
           - releasetype: github
           - releasetype: steam
           - releasetype: itch
-            
+
     runs-on: ubuntu-latest
-    needs: [Generate_Source, Build_Naev_Release, Build_Naev_Steam_Release, Build_Naev_Steam_Soundtrack]
+    needs:
+      [
+        Package_Source,
+        Linux_Naev_Release,
+        Windows_Naev_Release,
+        Steam_Naev_Release,
+      ]
     if: ${{ github.repository == 'naev/naev' }}
 
     steps:
       - name: Create Release Staging and Output Areas
         run: |
           mkdir -p {temp,dist/{staging,out/{lin64,win64,soundtrack}}}
-          
+
       - name: Update APT Cache
         if: ${{ matrix.releasetype == 'steam' }}
         run: |
@@ -325,7 +290,7 @@ jobs:
         run: |
           echo steamcmd steam/question select "I AGREE" | sudo debconf-set-selections
           sudo apt-get install lib32gcc1 libsdl2-2.0-0:i386 steamcmd
-          
+
       - name: Install Butler
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
@@ -348,20 +313,20 @@ jobs:
 
           mv dist/staging/naev-linux-x86-64/*.AppImage dist/out/naev-$SUFFIX-linux-x86-64.AppImage
           mv dist/staging/naev-win64/naev*.exe dist/out/naev-$SUFFIX-win64.exe
-          mv dist/staging/naev-dist/source.tar.gz dist/out/naev-$SUFFIX-source.tar.gz
+          mv dist/staging/naev-dist/source.tar.gz dist/out/naev-$SUFFIX-source.tar.xz
           mv dist/staging/naev-soundtrack/naev-*-soundtrack.zip dist/out/naev-$SUFFIX-soundtrack.zip
 
           chmod +x dist/out/naev-$SUFFIX-linux-x86-64.AppImage
 
       - name: Upload Github Release
+        uses: ncipollo/release-action@v1
         if: ${{ matrix.releasetype == 'github' }}
-        uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          artifacts: "dist/out/*.*"
+          bodyFile: "dist/staging/naev-changelog/CHANGELOG"
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
-          files: |
-            ${{ github.workspace }}/dist/out/*
-          
+
       - name: Build and Upload itch.io Release
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
@@ -375,7 +340,7 @@ jobs:
 
           tar -Jxf "dist/staging/naev-win64/steam-win64.tar.xz" -C "dist/out/win64"
           tar -Jxf "dist/staging/naev-ndata/steam-ndata.tar.xz" -C "dist/out/win64"
-          
+
           ./butler push --userversion="$SUFFIX" dist/out/lin64 naev/naev:linux-x86-64
           ./butler push --userversion="$SUFFIX" dist/out/win64 naev/naev:windows-x86-64
           ./butler push --userversion="$SUFFIX" dist/out/soundtrack naev/naev:soundtrack
@@ -387,7 +352,7 @@ jobs:
         run: |
           chmod -R +x dist/staging/naev-steam-deployment
           cp -r dist/staging/naev-steam-deployment/* ${{ github.workspace }}
-          ./SteamDeploy.sh -v "${{ github.workspace }}/dist/staging/naev-version" -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
+          ./SteamDeploy.sh -t "${{ github.workspace }}/dist/staging" -o "${{ github.workspace }}/dist/out"
         env:
           STEAMCMD_USER: ${{ secrets.STEAMCMD_USER }}
           STEAMCMD_PASS: ${{ secrets.STEAMCMD_PASS }}

--- a/extras/windows/installer/naev.nsi
+++ b/extras/windows/installer/naev.nsi
@@ -2,7 +2,7 @@
 ;SetCompress Off
 
 ;Enables Unicode installer to clear ANSI deprecation message 
-Unicode true
+;Unicode true
 ;Version, Icon and URL
 ;!define SUFFIX "0.8.0-win64"
 !define URL "https://naev.org"

--- a/extras/windows/packageWindows.sh
+++ b/extras/windows/packageWindows.sh
@@ -47,7 +47,7 @@ echo "NIGHTLY:      $NIGHTLY"
 echo "BUILD OUTPUT: $BUILDOUTPUT"
 
 # MinGW DLL search paths
-MINGW_BUNDLEDLLS_SEARCH_PATH="/mingw64/bin:/usr/x86_64-w64-mingw32/bin"
+MINGW_BUNDLEDLLS_SEARCH_PATH="/mingw64/bin:/usr/x86_64-w64-mingw32/bin:/usr/lib/mxe/usr/x86_64-w64-mingw32.shared/bin"
 # Include all subdirs (mingw-bundledlls can't search recursively) of in-tree and out-of-tree subproject dirs.
 # Normally, Meson builds everything out-of-tree, but some subprojects have their own build systems which do as they please.
 for MESON_SUBPROJ_DIR in "${SOURCEROOT}/subprojects" "${BUILDPATH}/subprojects"; do
@@ -92,7 +92,7 @@ cp "$BUILDPATH/naev.exe" "$STAGING/naev-$SUFFIX.exe"
 
 # Collect DLLs
 echo "Collecting DLLs in staging area"
-/usr/bin/python3 "$SOURCEROOT/extras/windows/mingw-bundledlls/mingw-bundledlls" --copy "$STAGING/naev-$SUFFIX.exe"
+python3 "$SOURCEROOT/extras/windows/mingw-bundledlls/mingw-bundledlls" --copy "$STAGING/naev-$SUFFIX.exe"
 
 # Create distribution folder
 

--- a/utils/build/windows_cross_mxe.ini
+++ b/utils/build/windows_cross_mxe.ini
@@ -1,0 +1,29 @@
+[binaries]
+c = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-gcc'
+cpp = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-g++'
+ar = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-ar'
+strip = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-strip'
+pkgconfig = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-pkg-config'
+windres = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-windres'
+exe_wrapper = 'wine64'
+cmake = '/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.shared-cmake'
+
+[properties]
+# Directory that contains 'bin', 'lib', etc
+root = '/usr/lib/mxe/usr'
+# Directory that contains 'bin', 'lib', etc for the toolchain and system libraries
+sys_root = '/usr/lib/mxe/usr/x86_64-w64-mingw32.shared'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[cmake]
+
+CMAKE_BUILD_WITH_INSTALL_RPATH     = 'ON'
+CMAKE_FIND_ROOT_PATH_MODE_PROGRAM  = 'NEVER'
+CMAKE_FIND_ROOT_PATH_MODE_LIBRARY  = 'ONLY'
+CMAKE_FIND_ROOT_PATH_MODE_INCLUDE  = 'ONLY'
+CMAKE_FIND_ROOT_PATH_MODE_PACKAGE  = 'ONLY'

--- a/utils/convertToMP3.sh
+++ b/utils/convertToMP3.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Renders audio to mp3, while retaining metadata
+# Requires ffmpeg to be installed and available on PATH
 
 # Pass in -i <inputDir> (no trailing '/') -f <fileextension> -o <outputDir> (no trailing '/')
 


### PR DESCRIPTION
Within this PR:

- [x] Adds Darwin back to CI, it will fail in it's current state due to issues when building the luajit submodule.
- [x] Opt to use MXE cross-compile environment to build Windows binaries in CI and in releases.
- [x] Adds cross-file for meson in utils/build