### PR TITLE
backport 3 fixes: Loading Bar, Disabled Btn, License

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -147,7 +147,7 @@ void conf_setDefaults (void)
    /* GUI. */
    conf.mesg_visible = 5;
    conf.map_overlay_opacity = MAP_OVERLAY_OPACITY_DEFAULT;
-   conf.big_icons = 1;
+   conf.big_icons = BIG_ICONS_DEFAULT;
 
    /* Repeat. */
    conf.repeat_delay = 500;

--- a/src/conf.h
+++ b/src/conf.h
@@ -40,6 +40,7 @@
 #define SHOW_PAUSE_DEFAULT                   1     /**< Whether to display pause status. */
 #define ENGINE_GLOWS_DEFAULT                 1     /**< Whether to display engine glows. */
 #define MINIMIZE_DEFAULT                     1     /**< Whether to minimize on focus loss. */
+#define BIG_ICONS_DEFAULT                    1     /**< Whether to display BIGGER icons. */
 /* Audio options */
 #define VOICES_DEFAULT                       128   /**< Amount of voices to use. */
 #define VOICES_MIN                           16    /**< Minimum amount of voices to use. */

--- a/src/land.c
+++ b/src/land.c
@@ -829,10 +829,10 @@ void land_updateMainTab (void)
    /* Else create it. */
    else {
       /* Refuel button. */
-      credits2str( cred, o->price, 2 );
+      credits2str( cred, o->price, 0 );
       nsnprintf( buf, sizeof(buf), _("Buy Local Map (%s)"), cred );
       window_addButtonKey( land_windows[0], -20, 20 + (LAND_BUTTON_HEIGHT + 20),
-            LAND_BUTTON_WIDTH,LAND_BUTTON_HEIGHT, "btnMap",
+            LAND_BUTTON_WIDTH, LAND_BUTTON_HEIGHT, "btnMap",
             buf, spaceport_buyMap, SDLK_b );
    }
 

--- a/src/land_shipyard.c
+++ b/src/land_shipyard.c
@@ -194,7 +194,7 @@ void shipyard_update( unsigned int wid, char* str )
    (void)str;
    int i;
    Ship* ship;
-   char buf[PATH_MAX], buf2[ECON_CRED_STRLEN], buf3[ECON_CRED_STRLEN];
+   char buf[PATH_MAX], buf2[ECON_CRED_STRLEN], buf3[ECON_CRED_STRLEN], buf_license[PATH_MAX];
 
    i = toolkit_getImageArrayPos( wid, "iarShipyard" );
 
@@ -245,6 +245,14 @@ void shipyard_update( unsigned int wid, char* str )
    price2str( buf2, ship_buyPrice(ship), player.p->credits, 2 );
    credits2str( buf3, player.p->credits, 2 );
 
+   if (ship->license == NULL)
+      strncpy( buf_license, _("None"), sizeof(buf_license)-1 );
+   else if (player_hasLicense( ship->license ))
+      strncpy( buf_license, _(ship->license), sizeof(buf_license)-1 );
+   else
+      nsnprintf( buf_license, sizeof(buf_license), "\ar%s\a0", _(ship->license) );
+   buf_license[ sizeof(buf_license)-1 ] = '\0';
+
    nsnprintf( buf, PATH_MAX,
          _("%s\n"
          "%s\n"
@@ -289,7 +297,7 @@ void shipyard_update( unsigned int wid, char* str )
          ship->fuel_consumption,
          buf2,
          buf3,
-         (ship->license != NULL) ? _(ship->license) : _("None") );
+         buf_license );
    window_modifyText( wid,  "txtDDesc", buf );
 
    if (!shipyard_canBuy( ship->name, land_planet ))

--- a/src/naev.c
+++ b/src/naev.c
@@ -587,9 +587,16 @@ void loadscreen_load (void)
  */
 void loadscreen_render( double done, const char *msg )
 {
+   const double SHIP_IMAGE_WIDTH = 512.;  /**< Loadscreen Ship Image Width */
+   const double SHIP_IMAGE_HEIGHT = 512.; /**< Loadscreen Ship Image Height */
    glColour col;
-   double bx,by, bw,bh;
-   double x,y, w,h, rh;
+   double bx;  /**<  Blit Image X Coord */
+   double by;  /**<  Blit Image Y Coord */
+   double x;   /**<  Progress Bar X Coord */
+   double y;   /**<  Progress Bar Y Coord */
+   double w;   /**<  Progress Bar Width Basis */
+   double h;   /**<  Progress Bar Height Basis */
+   double rh;  /**<  Loading Progress Text Relative Height */
    SDL_Event event;
 
    /* Clear background. */
@@ -602,23 +609,18 @@ void loadscreen_render( double done, const char *msg )
     * Dimensions.
     */
    /* Image. */
-   bw = 512.;
-   bh = 512.;
-   bx = (SCREEN_W-bw)/2.;
-   by = (SCREEN_H-bh)/2.;
+   bx = (SCREEN_W-SHIP_IMAGE_WIDTH)/2.;
+   by = (SCREEN_H-SHIP_IMAGE_HEIGHT)/2.;
    /* Loading bar. */
-   w  = gl_screen.w * 0.4;
-   h  = gl_screen.h * 0.02;
+   w  = SCREEN_W * 0.4;
+   h  = SCREEN_H * 0.02;
    rh = h + gl_defFont.h + 4.;
    x  = (SCREEN_W-w)/2.;
-   if (SCREEN_H < 768)
-      y  = (SCREEN_H-h)/2.;
-   else
-      y  = (SCREEN_H-bw)/2 - rh - 5.;
+   y  = (SCREEN_H-SHIP_IMAGE_HEIGHT)/2. - rh - 5.;
 
    /* Draw loading screen image. */
    if (loading != NULL)
-      gl_blitScale( loading, bx, by, bw, bh, NULL );
+      gl_blitScale( loading, bx, by, SHIP_IMAGE_WIDTH, SHIP_IMAGE_HEIGHT, NULL );
 
    /* Draw progress bar. */
    /* BG. */

--- a/src/options.c
+++ b/src/options.c
@@ -481,6 +481,7 @@ static void opt_gameplayDefaults( unsigned int wid, char *str )
 
    /* Faders. */
    window_faderValue( wid, "fadAutonav", AUTONAV_RESET_SPEED_DEFAULT );
+   window_faderValue( wid, "fadMapOverlayOpacity", MAP_OVERLAY_OPACITY_DEFAULT );
 
    /* Input boxes. */
    nsnprintf( vmsg, sizeof(vmsg), "%d", INPUT_MESSAGES_DEFAULT );
@@ -1584,9 +1585,10 @@ static void opt_videoDefaults( unsigned int wid, char *str )
    window_checkboxSet( wid, "chkFPS", SHOW_FPS_DEFAULT );
    window_checkboxSet( wid, "chkEngineGlow", ENGINE_GLOWS_DEFAULT );
    window_checkboxSet( wid, "chkMinimize", MINIMIZE_DEFAULT );
+   window_checkboxSet( wid, "chkBigIcons", BIG_ICONS_DEFAULT );
 
    /* Faders. */
-   window_faderValue(  wid, "fadScale", SCALE_FACTOR_DEFAULT );
+   window_faderSetBoundedValue( wid, "fadScale", SCALE_FACTOR_DEFAULT );
 }
 
 /**
@@ -1599,6 +1601,7 @@ static void opt_setScalefactor( unsigned int wid, char *str )
 {
    char buf[32];
    double scale = window_getFaderValue(wid, str);
+   scale = round(scale * 10) / 10;     // Reasonable precision. Clearer value.
    if (FABS(conf.scalefactor-scale) > 1e-4)
       opt_needRestart();
    conf.scalefactor = scale;

--- a/src/tk/widget/button.c
+++ b/src/tk/widget/button.c
@@ -309,9 +309,9 @@ static void btn_render( Widget* btn, double bx, double by )
 
    /* set the colours */
    if (btn->dat.btn.disabled) {
-      c  = &cGrey20;
-      fc = &cFontGrey;
-      outline = &cGrey20;
+      c = &cGrey20;  // cGrey20 is also the background color
+      fc = &cGrey50; // Enabled text is cFontGrey 0.7; a little lighter
+      outline = &cGrey15;  // Slightly darker than the background
    }
    else {
       fc = &cFontGrey;
@@ -329,13 +329,14 @@ static void btn_render( Widget* btn, double bx, double by )
       }
    }
 
-
+   /* The face of the button, with c being the color */
    toolkit_drawRect( x, y, btn->w, btn->h, c, NULL );
 
    /* inner outline */
-   // toolkit_drawOutline( x, y, btn->w, btn->h, 0., outline, NULL );
+   // toolkit_drawOutline( x, y, btn->w, btn->h, 0, outline, NULL );
+
    /* outer outline */
-   toolkit_drawOutlineThick( x, y, btn->w, btn->h, 1., 2, outline, NULL );
+   toolkit_drawOutlineThick( x, y, btn->w, btn->h, 1, 2, outline, NULL );
 
    gl_printMidRaw( &gl_smallFont, (int)btn->w,
          bx + btn->x,

--- a/src/tk/widget/fader.h
+++ b/src/tk/widget/fader.h
@@ -35,6 +35,8 @@ void window_addFader( const unsigned int wid,
 /* Misc functions. */
 void window_faderValue( const unsigned int wid,
       char* name, double value );
+void window_faderSetBoundedValue( const unsigned int wid,
+      char* name, double value );
 void window_faderBounds( const unsigned int wid,
       char* name, double min, double max );
 double window_getFaderValue( const unsigned int wid, char* name );

--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -1018,9 +1018,9 @@ void toolkit_drawOutlineThick( int x, int y, int w, int h, int b,
    GLshort tri[5][4];
    glColour colours[10];
 
-   x -= b - thick;
+   x -= (b - thick);
    w += 2 * (b - thick);
-   y -= b - thick;
+   y -= (b - thick);
    h += 2 * (b - thick);
    lc = lc ? lc : c;
 


### PR DESCRIPTION
Pulled in changes from the following commits, for use with 0.8.x

Omitted changes in src/font.c (which didn't yet exist) and reset the Character escape key to \a.

```
commit 1e9748f534935c082ac1901ea92c665349fbab17
Date:   Thu Dec 31 07:15:01 2020 -0500

    Hilighting (sic) a missing Ship License with Color

commit aa496f71e0833a7cd89775b3752ec9f5096af668
Date:   Wed Dec 23 04:18:46 2020 -0500

    Scalefactor default applies correctly. A few other defaults enabled.

commit 9c96ddc8891b2471ba8ce7759b11a38a76c5eada
Date:   Sun Dec 20 16:40:11 2020 -0500

    Adjustments to reduce a graphical artifact while loading with resolutions like 1280x720