### PR TITLE
Fix issues pushing Naev releases. (0.8.x)

### DIFF
--- a/utils/ci/steam/scripts/app_build_1411430_soundtrack.vdf
+++ b/utils/ci/steam/scripts/app_build_1411430_soundtrack.vdf
@@ -4,7 +4,7 @@
 	"desc" "Naev Soundtrack Release" // description for this build
 	"buildoutput" "..\output\" // build output folder for .log, .csm & .csd files, relative to location of this file
 	"contentroot" "..\content\" // root content folder, relative to location of this file
-	"setlive"	"default" // branch to set live after successful build, non if empty
+	"setlive"	"" // branch to set live after successful build, non if empty
 	"preview" "0" // to enable preview builds
 	"local"	""	// set to flie path of local content server 
 	

--- a/utils/ci/steam/scripts/app_build_598530_release.vdf
+++ b/utils/ci/steam/scripts/app_build_598530_release.vdf
@@ -4,7 +4,7 @@
 	"desc" "Stable Build for Naev" // description for this build
 	"buildoutput" "..\output\" // build output folder for .log, .csm & .csd files, relative to location of this file
 	"contentroot" "..\content\" // root content folder, relative to location of this file
-	"setlive"	"default" // branch to set live after successful build, non if empty
+	"setlive"	"" // branch to set live after successful build, non if empty
 	"preview" "0" // to enable preview builds
 	"local"	""	// set to flie path of local content server 
 	


### PR DESCRIPTION
Looks like reading does in fact pay off..

We cannot set the default branch as live using the setlive option in build scripts.
Setting builds as live, will need to manually be done within Steamworks.