### PR TITLE
Drop npng's vflip feature; instead, transform our texture matrices.

### DIFF
--- a/src/naev.c
+++ b/src/naev.c
@@ -1050,7 +1050,7 @@ static void window_caption (void)
       return;
    }
    npng        = npng_open( rw );
-   naev_icon   = npng_readSurface( npng, 0, 0 );
+   naev_icon   = npng_readSurface( npng, 0 );
    npng_close( npng );
    SDL_RWclose( rw );
    if (naev_icon == NULL) {

--- a/src/nlua_tex.c
+++ b/src/nlua_tex.c
@@ -320,7 +320,7 @@ static int texL_readData( lua_State *L )
    npng = npng_open( rw );
    if (npng == NULL)
       NLUA_ERROR(L, _("problem opening png for reading") );
-   surface = npng_readSurface( npng, 0, 0 );
+   surface = npng_readSurface( npng, 0 );
    if (surface == NULL)
       NLUA_ERROR(L, _("problem reading png to surface") );
    npng_close( npng );

--- a/src/npng.c
+++ b/src/npng.c
@@ -281,10 +281,9 @@ static int npng_readInto( npng_t *npng, png_bytep *row_pointers )
  *
  *    @param npng PNG image to load.
  *    @param pad_pot Whether to pad the dimensions to a power of two.
- *    @param vflip Whether to flip vertically.
  *    @return Surface with data from the PNG image.
  */
-SDL_Surface *npng_readSurface( npng_t *npng, int pad_pot, int vflip )
+SDL_Surface *npng_readSurface( npng_t *npng, int pad_pot )
 {
    png_bytep *row_pointers;
    png_uint_32 width, height, row, rheight;
@@ -333,7 +332,7 @@ SDL_Surface *npng_readSurface( npng_t *npng, int pad_pot, int vflip )
       return NULL;
    }
    for (row=0; row<rheight; row++) { /* We only need to go to real height, not full height. */
-      row_pointers[ vflip ? rheight-row-1 : row ] = (png_bytep)
+      row_pointers[row] = (png_bytep)
          (Uint8 *) surface->pixels + row * surface->pitch;
    }
 

--- a/src/npng.h
+++ b/src/npng.h
@@ -30,7 +30,7 @@ int npng_dim( npng_t *npng, png_uint_32 *w, png_uint_32 *h );
 /*
  * Loading.
  */
-SDL_Surface *npng_readSurface( npng_t *npng, int pad_pot, int vflip );
+SDL_Surface *npng_readSurface( npng_t *npng, int pad_pot );
 
 #endif /* NPNG_H */
 

--- a/src/opengl_render.c
+++ b/src/opengl_render.c
@@ -243,7 +243,7 @@ void gl_blitTexture(  const glTexture* texture,
          0, 2, GL_FLOAT, 0 );
 
    /* Set the texture. */
-   tex_mat = gl_Matrix4_Identity();
+   tex_mat = (texture->flags & OPENGL_TEX_VFLIP) ? gl_Matrix4_Ortho(-1, 1, 2, 0, 1, -1) : gl_Matrix4_Identity();
    tex_mat = gl_Matrix4_Translate(tex_mat, tx, ty, 0);
    tex_mat = gl_Matrix4_Scale(tex_mat, tw, th, 1);
 
@@ -328,7 +328,7 @@ void gl_blitTextureInterpolate(  const glTexture* ta,
    gl_vboActivateAttribOffset( gl_squareVBO, shaders.texture_interpolate.vertex, 0, 2, GL_FLOAT, 0 );
 
    /* Set the texture. */
-   tex_mat = gl_Matrix4_Identity();
+   tex_mat = (ta->flags & OPENGL_TEX_VFLIP) ? gl_Matrix4_Ortho(-1, 1, 2, 0, 1, -1) : gl_Matrix4_Identity();
    tex_mat = gl_Matrix4_Translate(tex_mat, tx, ty, 0);
    tex_mat = gl_Matrix4_Scale(tex_mat, tw, th, 1);
 

--- a/src/opengl_tex.c
+++ b/src/opengl_tex.c
@@ -51,7 +51,6 @@ static int gl_tex_ext_npot = 0; /**< Support for GL_ARB_texture_non_power_of_two
  * prototypes
  */
 /* misc */
-/*static int SDL_VFlipSurface( SDL_Surface* surface );*/
 static int SDL_IsTrans( SDL_Surface* s, int x, int y );
 static uint8_t* SDL_MapTrans( SDL_Surface* s, int w, int h );
 static size_t gl_transSize( const int w, const int h );
@@ -77,42 +76,6 @@ int gl_pot( int n )
       i <<= 1;
    return i;
 }
-
-
-#if 0
-/**
- * @brief Flips the surface vertically.
- *
- *    @param surface Surface to flip.
- *    @return 0 on success.
- */
-static int SDL_VFlipSurface( SDL_Surface* surface )
-{
-   /* flip the image */
-   Uint8 *rowhi, *rowlo, *tmpbuf;
-   int y;
-
-   tmpbuf = malloc(surface->pitch);
-   if ( tmpbuf == NULL ) {
-      WARN("Out of memory");
-      return -1;
-   }
-
-   rowhi = (Uint8 *)surface->pixels;
-   rowlo = rowhi + (surface->h * surface->pitch) - surface->pitch;
-   for (y = 0; y < surface->h / 2; ++y ) {
-      memcpy(tmpbuf, rowhi, surface->pitch);
-      memcpy(rowhi, rowlo, surface->pitch);
-      memcpy(rowlo, tmpbuf, surface->pitch);
-      rowhi += surface->pitch;
-      rowlo -= surface->pitch;
-   }
-   free(tmpbuf);
-   /* flipping done */
-
-   return 0;
-}
-#endif
 
 
 /**

--- a/src/opengl_tex.c
+++ b/src/opengl_tex.c
@@ -59,7 +59,7 @@ static size_t gl_transSize( const int w, const int h );
 static GLuint gl_texParameters( unsigned int flags );
 static GLuint gl_loadSurface( SDL_Surface* surface, int *rw, int *rh, unsigned int flags, int freesur );
 static glTexture* gl_loadNewImage( const char* path, unsigned int flags );
-static glTexture* gl_loadNewImageRWops( const char *path, SDL_RWops *rw, const unsigned int flags );
+static glTexture* gl_loadNewImageRWops( const char *path, SDL_RWops *rw, unsigned int flags );
 /* List. */
 static glTexture* gl_texExists( const char* path );
 static int gl_texAdd( glTexture *tex );
@@ -595,6 +595,7 @@ glTexture* gl_loadImagePad( const char *name, SDL_Surface* surface,
    texture->sh    = texture->h / texture->sy;
    texture->srw   = texture->sw / texture->rw;
    texture->srh   = texture->sh / texture->rh;
+   texture->flags = flags;
 
    if (name != NULL) {
       texture->name = strdup(name);
@@ -762,7 +763,7 @@ static glTexture* gl_loadNewImage( const char* path, const unsigned int flags )
  *    @param flags Flags to control image parameters.
  *    @return Texture loaded from image.
  */
-static glTexture* gl_loadNewImageRWops( const char *path, SDL_RWops *rw, const unsigned int flags )
+static glTexture* gl_loadNewImageRWops( const char *path, SDL_RWops *rw, unsigned int flags )
 {
    glTexture *texture;
    SDL_Surface *surface;
@@ -781,7 +782,8 @@ static glTexture* gl_loadNewImageRWops( const char *path, SDL_RWops *rw, const u
    npng_dim( npng, &w, &h );
 
    /* Load surface. */
-   surface  = npng_readSurface( npng, gl_needPOT(), 1 );
+   surface  = npng_readSurface( npng, gl_needPOT() );
+   flags   |= OPENGL_TEX_VFLIP;
    npng_close( npng );
 
    if (surface == NULL) {

--- a/src/opengl_tex.h
+++ b/src/opengl_tex.h
@@ -37,6 +37,7 @@
  */
 #define OPENGL_TEX_MAPTRANS   (1<<0) /**< Create a transparency map. */
 #define OPENGL_TEX_MIPMAPS    (1<<1) /**< Creates mipmaps. */
+#define OPENGL_TEX_VFLIP      (1<<2) /**< Assume loaded from an image (where positive y means down). */
 
 /**
  * @brief Abstraction for rendering sprite sheets.

--- a/src/ship.c
+++ b/src/ship.c
@@ -504,11 +504,11 @@ static int ship_loadSpaceImage( Ship *temp, char *str, int sx, int sy )
    rw    = PHYSFSRWOPS_openRead( str );
    npng  = npng_open( rw );
    npng_dim( npng, &w, &h );
-   surface = npng_readSurface( npng, gl_needPOT(), 1 );
+   surface = npng_readSurface( npng, gl_needPOT() );
 
    /* Load the texture. */
    temp->gfx_space = gl_loadImagePadTrans( str, surface, rw,
-         OPENGL_TEX_MAPTRANS | OPENGL_TEX_MIPMAPS,
+         OPENGL_TEX_MAPTRANS | OPENGL_TEX_MIPMAPS | OPENGL_TEX_VFLIP,
          w, h, sx, sy, 0 );
 
    /* Create the target graphic. */


### PR DESCRIPTION
I think this is a good idea because it makes npng more replaceable. (For instance, it's almost possible to drop in SDL_image and gain support for whatever image format a mod or script author might want to use.)
I want to expose the change to feedback before committing; otherwise it might get confusing.