### PR TITLE
Fix Issues Launching Naev on Windows via Itch.io Client

### DIFF
--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -28,10 +28,11 @@ jobs:
 
       - name: Collect Artifacts
         run: |
-          mkdir -p build/dist/steam
+          mkdir -p build/dist/{steam,itch}
           mv build/meson-dist/naev-*.tar.xz build/dist/source.tar.xz
           cp source/dat/VERSION build/dist
           cp -r source/utils/ci/steam/* build/dist/steam
+          cp -r source/utils/ci/itch/* build/dist/itch
 
       - name: Upload Source Artifact
         uses: actions/upload-artifact@v2
@@ -47,11 +48,18 @@ jobs:
           path: ${{ github.workspace }}/build/dist/VERSION
           if-no-files-found: error
 
-      - name: Upload Deployment Script Artifact
+      - name: Upload Steam Deployment Script Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-steam-deployment
           path: ${{ github.workspace }}/build/dist/steam/*
+          if-no-files-found: error
+
+      - name: Upload Itch Deployment Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-itch-deployment
+          path: ${{ github.workspace }}/build/dist/itch/*
           if-no-files-found: error
 
   "Linux_Naev_Release":
@@ -346,17 +354,39 @@ jobs:
       - name: Build and Upload itch.io Release
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
+          # Collect BUILD_DATE, VERSION and assemble SUFFIX for naming files.
+
           BUILD_DATE="$(date +%Y%m%d)"
           VERSION="$(<"build/staging/naev-version/VERSION")"
           SUFFIX="$VERSION.$BUILD_DATE"
 
-          mv build/staging/naev-linux-x86-64/*.AppImage build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
+          # Build Linux Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/lin64
+          sed -i "s/%EXECNAME%/naev-$SUFFIX-linux-x86-64.AppImage/" build/dist/lin64/.itch.toml
+          sed -i 's/%PLATFORM%/linux/' build/dist/lin64/.itch.toml
+          
+          cp build/staging/naev-linux-x86-64/*.AppImage build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
           chmod +x build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
 
-          mv build/staging/naev-macos/*.zip build/dist/macos/naev-$SUFFIX-macos.zip
+          # Build macOS Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/macos
+          sed -i 's/%EXECNAME%/Naev.app/' build/dist/macos/.itch.toml
+          sed -i 's/%PLATFORM%/osx/' build/dist/macos/.itch.toml
+
+          unzip build/staging/naev-macos/*.zip -d build/dist/macos
+
+          # Build Windows Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/win64
+          sed -i "s/%EXECNAME%/naev-$SUFFIX-win64.exe/" build/dist/win64/.itch.toml
+          sed -i 's/%PLATFORM%/windows/' build/dist/win64/.itch.toml
 
           tar -Jxf "build/staging/naev-win64/steam-win64.tar.xz" -C "build/dist/win64"
           tar -Jxf "build/staging/naev-ndata/steam-ndata.tar.xz" -C "build/dist/win64"
+
+          # Push builds to itch.io via butler
 
           ./butler push --userversion="$SUFFIX" build/dist/lin64 naev/naev:linux-x86-64-nightly
           ./butler push --userversion="$SUFFIX" build/dist/macos naev/naev:macos-x86-64-nightly

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -30,11 +30,12 @@ jobs:
 
       - name: Collect Artifacts
         run: |
-          mkdir -p build/dist/steam
+          mkdir -p build/dist/{steam,itch}
           mv build/meson-dist/naev-*.tar.xz build/dist/source.tar.xz
           cp source/CHANGELOG build/dist
           cp source/dat/VERSION build/dist
           cp -r source/utils/ci/steam/* build/dist/steam
+          cp -r source/utils/ci/itch/* build/dist/itch
 
       - name: Upload Source Artifact
         uses: actions/upload-artifact@v2
@@ -57,11 +58,18 @@ jobs:
           path: ${{ github.workspace }}/build/dist/CHANGELOG
           if-no-files-found: error
 
-      - name: Upload Deployment Script Artifact
+      - name: Upload Steam Deployment Script Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-steam-deployment
           path: ${{ github.workspace }}/build/dist/steam/*
+          if-no-files-found: error
+
+      - name: Upload Itch Deployment Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-itch-deployment
+          path: ${{ github.workspace }}/build/dist/itch/*
           if-no-files-found: error
 
   "Linux_Naev_Release":
@@ -326,17 +334,39 @@ jobs:
       - name: Build and Upload itch.io Release
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
+          # Collect BUILD_DATE, VERSION and assemble SUFFIX for naming files.
+
           BUILD_DATE="$(date +%Y%m%d)"
           VERSION="$(<"build/staging/naev-version/VERSION")"
           SUFFIX="$VERSION"
 
-          mv build/staging/naev-linux-x86-64/*.AppImage build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
+          # Build Linux Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/lin64
+          sed -i "s/%EXECNAME%/naev-$SUFFIX-linux-x86-64.AppImage/" build/dist/lin64/.itch.toml
+          sed -i 's/%PLATFORM%/linux/' build/dist/lin64/.itch.toml
+          
+          cp build/staging/naev-linux-x86-64/*.AppImage build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
           chmod +x build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
 
-          mv build/staging/naev-macos/*.zip build/dist/macos/naev-$SUFFIX-macos.zip
+          # Build macOS Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/macos
+          sed -i 's/%EXECNAME%/Naev.app/' build/dist/macos/.itch.toml
+          sed -i 's/%PLATFORM%/osx/' build/dist/macos/.itch.toml
+
+          unzip build/staging/naev-macos/*.zip -d build/dist/macos
+
+          # Build Windows Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/win64
+          sed -i "s/%EXECNAME%/naev-$SUFFIX-win64.exe/" build/dist/win64/.itch.toml
+          sed -i 's/%PLATFORM%/windows/' build/dist/win64/.itch.toml
 
           tar -Jxf "build/staging/naev-win64/steam-win64.tar.xz" -C "build/dist/win64"
           tar -Jxf "build/staging/naev-ndata/steam-ndata.tar.xz" -C "build/dist/win64"
+
+          # Push builds to itch.io via butler
 
           ./butler push --userversion="$SUFFIX" build/dist/lin64 naev/naev:linux-x86-64-beta
           ./butler push --userversion="$SUFFIX" build/dist/macos naev/naev:macos-x86-64-beta

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -429,7 +429,7 @@ jobs:
 
           # Build Soundtrack Release
 
-          mv build/staging/naev-steam-soundtrack/* build/dist/soundtrack
+          cp build/staging/naev-steam-soundtrack/* build/dist/soundtrack
 
           # Push builds to itch.io via butler
 

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -30,11 +30,12 @@ jobs:
 
       - name: Collect Artifacts
         run: |
-          mkdir -p build/dist/steam
+          mkdir -p build/dist/{steam,itch}
           mv build/meson-dist/naev-*.tar.xz build/dist/source.tar.xz
           cp source/CHANGELOG build/dist
           cp source/dat/VERSION build/dist
           cp -r source/utils/ci/steam/* build/dist/steam
+          cp -r source/utils/ci/itch/* build/dist/itch
 
       - name: Upload Source Artifact
         uses: actions/upload-artifact@v2
@@ -57,11 +58,18 @@ jobs:
           path: ${{ github.workspace }}/build/dist/CHANGELOG
           if-no-files-found: error
 
-      - name: Upload Deployment Script Artifact
+      - name: Upload Steam Deployment Script Artifact
         uses: actions/upload-artifact@v2
         with:
           name: naev-steam-deployment
           path: ${{ github.workspace }}/build/dist/steam/*
+          if-no-files-found: error
+
+      - name: Upload Itch Deployment Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: naev-itch-deployment
+          path: ${{ github.workspace }}/build/dist/itch/*
           if-no-files-found: error
 
   "Linux_Naev_Release":
@@ -387,18 +395,43 @@ jobs:
       - name: Build and Upload itch.io Release
         if: ${{ matrix.releasetype == 'itch' }}
         run: |
+          # Collect BUILD_DATE, VERSION and assemble SUFFIX for naming files.
+
           BUILD_DATE="$(date +%Y%m%d)"
           VERSION="$(<"build/staging/naev-version/VERSION")"
           SUFFIX="$VERSION"
 
-          mv build/staging/naev-linux-x86-64/*.AppImage build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
-          mv build/staging/naev-steam-soundtrack/* build/dist/soundtrack
+          # Build Linux Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/lin64
+          sed -i "s/%EXECNAME%/naev-$SUFFIX-linux-x86-64.AppImage/" build/dist/lin64/.itch.toml
+          sed -i 's/%PLATFORM%/linux/' build/dist/lin64/.itch.toml
+          
+          cp build/staging/naev-linux-x86-64/*.AppImage build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
           chmod +x build/dist/lin64/naev-$SUFFIX-linux-x86-64.AppImage
 
-          mv build/staging/naev-macos/*.zip build/dist/macos/naev-$SUFFIX-macos.zip
+          # Build macOS Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/macos
+          sed -i 's/%EXECNAME%/Naev.app/' build/dist/macos/.itch.toml
+          sed -i 's/%PLATFORM%/osx/' build/dist/macos/.itch.toml
+
+          unzip build/staging/naev-macos/*.zip -d build/dist/macos
+
+          # Build Windows Release
+
+          cp build/staging/naev-itch-deployment/.itch.toml build/dist/win64
+          sed -i "s/%EXECNAME%/naev-$SUFFIX-win64.exe/" build/dist/win64/.itch.toml
+          sed -i 's/%PLATFORM%/windows/' build/dist/win64/.itch.toml
 
           tar -Jxf "build/staging/naev-win64/steam-win64.tar.xz" -C "build/dist/win64"
           tar -Jxf "build/staging/naev-ndata/steam-ndata.tar.xz" -C "build/dist/win64"
+
+          # Build Soundtrack Release
+
+          mv build/staging/naev-steam-soundtrack/* build/dist/soundtrack
+
+          # Push builds to itch.io via butler
 
           ./butler push --userversion="$SUFFIX" build/dist/lin64 naev/naev:linux-x86-64
           ./butler push --userversion="$SUFFIX" build/dist/macos naev/naev:macos-x86-64

--- a/utils/ci/itch/.itch.toml
+++ b/utils/ci/itch/.itch.toml
@@ -1,0 +1,5 @@
+[[actions]]
+name = "play"
+path = "%EXECNAME%"
+platform = "%PLATFORM%"
+args = []


### PR DESCRIPTION
Found an interesting issue when trying to play Naev through itch.io's desktop client. 

The default behaviour for the client is to launch the first executable available, and for previous releases this works fine, but in the latest nightlies (since blackjack and other love2d stuff was added to master) the itch client was actually trying to launch the love2d bundle directly.. (and to answer your question the bundle does launch via love2d assuming it's on PATH but fails to do anything exciting see: [here](https://cdn.discordapp.com/attachments/785497094366035989/801633532271132732/love_759VA4q1ee.png)) 

This PR adds an itch.io manifest to launch the correct binary for each respective supported platform (linux, windows, macos) by copying a master file with some placeholder text and uses sed to configure it correctly.
Documentation for manifests is [here](https://itch.io/docs/itch/integrating/manifest-actions.html)

Another plus is that we are now technically shipping '[Platinum tier](https://itch.io/docs/itch/integrating/compatibility-policy.html)' builds to itch.io everywhere
