### PR TITLE
Specify appimage install prefix via an argument to meson

### DIFF
--- a/utils/build/linux_appimage.ini
+++ b/utils/build/linux_appimage.ini
@@ -1,6 +1,0 @@
-[binaries]
-c = 'gcc'
-c_ld = 'bfd'
-
-[built-in options]
-prefix = '/usr'

--- a/utils/buildAppImage.sh
+++ b/utils/buildAppImage.sh
@@ -58,9 +58,10 @@ export DESTDIR="$(readlink -mf "$BUILDPATH")/dist/Naev.AppDir"
 # Run build
 # Setup AppImage Build Directory
 sh "$MESON" setup "$BUILDPATH" "$SOURCEROOT" \
---native-file "$SOURCEROOT/utils/build/linux_appimage.ini" \
+--native-file "$SOURCEROOT/utils/build/linux.ini" \
 --buildtype "$BUILDTYPE" \
 -Dnightly=$NIGHTLY \
+-Dprefix="/usr" \
 -Db_lto=true \
 -Dauto_features=enabled \
 -Ddocs_c=disabled \


### PR DESCRIPTION
Newer versions of meson removed the ability for you to specify prefixes in native files, this small tweak bypasses that.