### PR TITLE
Fix interesting errors in CI (0.8.x)

### DIFF
--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -96,7 +96,6 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
       - name: Upload Build Artifacts
-        if: ${{ matrix.image != 'naev-steamruntime' }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.image }}-${{ github.sha }}-buildArtifacts

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -42,9 +42,10 @@ jobs:
         include:
           - image: naev-linux-latest
             config: linux.ini
-
+          - image: naev-linux-lts
+            config: linux.ini
           - image: naev-steamruntime
-            config: linux_steamruntime.ini
+            config: linux.ini
 
     runs-on: ubuntu-latest
     container:
@@ -111,6 +112,20 @@ jobs:
         with:
           name: ${{ matrix.image }}-${{ github.sha }}-install-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
+
+      - name: Compile AppImage
+        id: appimageCompile
+        run: |
+          mkdir -p /tmp/out
+          ./source/utils/buildAppImage.sh -c -m -s "source" -b "appImageBuild" -o "$DESTDIR" | tee appImageBuildLog.txt
+
+      - name: Upload AppImage Compile Log
+        uses: actions/upload-artifact@v2
+        if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
+        with:
+          name: ${{ matrix.image }}-${{ github.sha }}-AppImageBuild-log
+          path: |
+            ${{ github.workspace }}/appImageBuildLog.txt
 
   "Windows_Compile_Naev":
     needs: "Package_Source"
@@ -262,47 +277,6 @@ jobs:
           name: ${{ matrix.image }}-${{ github.sha }}-install-log
           path: ${{ github.workspace }}/build/meson-logs/meson-log.txt
 
-  "AppImage_Compile_Naev":
-    needs: [Package_Source, Linux_Compile_Naev]
-    runs-on: ubuntu-latest
-    container:
-      image: "ghcr.io/projectsynchro/naev-linux-lts:latest"
-
-    steps:
-      - name: Get Source
-        uses: actions/download-artifact@v1
-        with:
-          name: naev-dist-${{ github.sha }}
-
-      - name: Extract Source
-        run: |
-          mkdir source
-          tar -xf naev-dist-${{ github.sha }}/naev-*.tar.gz -C source --strip 1
-
-      - name: Compile AppImage
-        id: appimageCompile
-        run: |
-          mkdir -p /tmp/out
-          script -c "./source/utils/buildAppImage.sh -c -m -s "source" -b "build" -o "$DESTDIR"" appImageBuildLog.txt
-        env:
-          APPIMAGE_EXTRACT_AND_RUN: 1
-
-      - name: Upload AppImage Compile Log
-        uses: actions/upload-artifact@v2
-        if: ${{ (success() || steps.appimageCompile.outcome == 'failure') }}
-        with:
-          name: naev-${{ github.sha }}-AppImageBuild-log
-          path: |
-            ${{ github.workspace }}/appImageBuildLog.txt
-
-      - name: Upload AppImage Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: naev-${{ github.sha }}-AppImageBuild
-          path: |
-            ${{ github.workspace }}/dist/out
-          if-no-files-found: error
-
   "Lua_Documentation":
     runs-on: ubuntu-latest
     container:
@@ -335,11 +309,3 @@ jobs:
         run: |
           meson compile -C build
           meson compile -C build naev-gmo
-
-      - name: Trigger API Documentation Update
-        if: ${{ github.event_name == 'push' && github.repository == 'naev/naev' }}
-        run: |
-          curl -X POST https://api.github.com/repos/naev/naev.github.io/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u ${{ secrets.WEBSITE_ACCESS_TOKEN }} \
-          --data '{"event_type": "api", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: source
           fetch-depth: 0
-          submodules: true
+          submodules: recursive
 
       - name: Package Dist
         run: |

--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           path: source
           fetch-depth: 0
+          submodules: true
 
       - name: Package Dist
         run: |

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -89,8 +89,6 @@ jobs:
       - name: Compile AppImage
         run: |
           ./source/utils/buildAppImage.sh -m -s "source" -b "build" -o "${{ env.DESTDIR }}"
-        env:
-          APPIMAGE_EXTRACT_AND_RUN: 1
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
@@ -208,8 +206,9 @@ jobs:
       - name: Meson Setup
         run: |
           meson setup build source \
-              --native-file='source/utils/build/linux_steamruntime.ini' \
+              --native-file='source/utils/build/linux.ini' \
               --buildtype=release \
+              -Dprefix="/usr" \
               -Db_lto=true \
               -Dauto_features=enabled \
               -Ddocs_c=disabled \

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           path: source
-          submodules: true
+          submodules: recursive
 
       - name: Package Dist
         run: |

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -209,8 +209,9 @@ jobs:
       - name: Meson Setup
         run: |
           meson setup build source \
-              --native-file='source/utils/build/linux_steamruntime.ini' \
+              --native-file='source/utils/build/linux.ini' \
               --buildtype=release \
+              -Dprefix="/usr" \
               -Db_lto=true \
               -Dauto_features=enabled \
               -Ddocs_c=disabled \

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           path: source
-          submodules: true
+          submodules: recursive
 
       - name: Package Dist
         run: |

--- a/utils/build/linux_appimage.ini
+++ b/utils/build/linux_appimage.ini
@@ -1,6 +1,0 @@
-[binaries]
-c = 'gcc'
-c_ld = 'bfd'
-
-[built-in options]
-prefix = '/usr'

--- a/utils/build/linux_steamruntime.ini
+++ b/utils/build/linux_steamruntime.ini
@@ -1,6 +1,0 @@
-[binaries]
-c = 'gcc'
-c_ld = 'bfd'
-
-[built-in options]
-prefix = '/usr'

--- a/utils/buildAppImage.sh
+++ b/utils/buildAppImage.sh
@@ -77,8 +77,9 @@ if [ "$USEMESON" == "true" ]; then
     if [ "$BUILDDEBUG" == "true" ]; then
         # Setup AppImage Build Directory
         sh "$MESON" setup "$BUILDPATH" "$SOURCEROOT" \
-        --native-file "$SOURCEROOT/utils/build/linux_appimage.ini" \
+        --native-file "$SOURCEROOT/utils/build/linux.ini" \
         --buildtype debug \
+        -Dprefix="/usr" \
         -Db_lto=true \
         -Dauto_features=enabled \
         -Ddocs_c=disabled \
@@ -91,8 +92,9 @@ if [ "$USEMESON" == "true" ]; then
     else
         # Setup AppImage Build Directory
         sh "$MESON" setup "$BUILDPATH" "$SOURCEROOT" \
-        --native-file "$SOURCEROOT/utils/build/linux_appimage.ini" \
+        --native-file "$SOURCEROOT/utils/build/linux.ini" \
         --buildtype release \
+        -Dprefix="/usr" \
         -Db_lto=true \
         -Dauto_features=enabled \
         -Ddocs_c=disabled \


### PR DESCRIPTION
Backports fixes for this weird build issue seen in this CI run:
https://github.com/naev/naev/runs/1932806004?check_suite_focus=true

AppImages are now built for every Linux environment we test for (for consistency if nothing else), and build logging is now working again.

I have also disabled triggering an API documentation update, as well as fixed the inclusion of git submodules into the dist, as autotools doesn't fetch them like meson did.