### PR TITLE
Prioritize planet clearing over jump point clearing.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1961,7 +1961,8 @@ void player_targetPrev( int mode )
 void player_targetClear (void)
 {
    gui_forceBlink();
-   if (player.p->target == PLAYER_ID && (preemption == 1 || player.p->nav_planet == -1)
+   if ((player.p->target == PLAYER_ID) && (player.p->nav_planet < 0)
+         && (preemption == 1 || player.p->nav_planet == -1)
          && !pilot_isFlag(player.p, PILOT_HYP_PREP)) {
       player.p->nav_hyperspace = -1;
       player_hyperspacePreempt(0);


### PR DESCRIPTION
This change causes the target clear action (C key) to first deselect planets before deselecting hyperspace navigation. This allows clearing planet selections while autonaving without causing interruptions.

🕵️