### PR TITLE
Use smallFont for search input box, not defFont.

### DIFF
--- a/src/map_find.c
+++ b/src/map_find.c
@@ -1024,7 +1024,7 @@ void map_inputFind( unsigned int parent, char* str )
 
    /* Create input. */
    window_addInput( wid, 30, y, w - 60, 20,
-         "inpSearch", 32, 1, &gl_defFont );
+         "inpSearch", 32, 1, &gl_smallFont );
    y -= 40;
 
    /* Create buttons. */


### PR DESCRIPTION
This puts that input box in line with other input boxes throughout Naev. (It was the only one using defFont instead of smallFont, the default for this widget type.)

🕵️