### PR TITLE
Fixed firing missile causing a mass reduction.

### DIFF
--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -1078,11 +1078,7 @@ static int pilot_shootWeapon( Pilot* p, PilotOutfitSlot* w, double time )
       weapon_add( w->outfit, w->heat_T, p->solid->dir,
             &vp, &p->solid->vel, p, p->target, time );
 
-      w->u.ammo.quantity -= 1; /* we just shot it */
-      p->mass_outfit     -= w->u.ammo.outfit->mass;
-      p->solid->mass     -= w->u.ammo.outfit->mass;
-
-      pilot_updateMass( p );
+      pilot_rmAmmo( p, w, 1 );
 
       /* Make the AI aware a seeker has been shot */
       if (outfit_isSeeker(w->outfit))


### PR DESCRIPTION
Looks like it was cutting mass *twice*, I assume as a leftover of a previous way that mass was handled, in combination with the fact that it wasn't just using pilot_rmAmmo. This meant that every time you decreased your ammo, your ship's mass decreased until something triggered a recalculation of mass (like adding or removing an outfit). Fixed by replacing that custom code with pilot_rmAmmo.