### PR TITLE
Added capability to set a pilot as exempt from pilot.clear().

### DIFF
--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -112,6 +112,7 @@ static int pilotL_cooldown( lua_State *L );
 static int pilotL_setCooldown( lua_State *L );
 static int pilotL_setNoJump( lua_State *L );
 static int pilotL_setNoLand( lua_State *L );
+static int pilotL_setNoClear( lua_State *L );
 static int pilotL_addOutfit( lua_State *L );
 static int pilotL_rmOutfit( lua_State *L );
 static int pilotL_setFuel( lua_State *L );
@@ -226,6 +227,7 @@ static const luaL_Reg pilotL_methods[] = {
    { "setCooldown", pilotL_setCooldown },
    { "setNoJump", pilotL_setNoJump },
    { "setNoLand", pilotL_setNoLand },
+   { "setNoClear", pilotL_setNoClear },
    /* Talk. */
    { "broadcast", pilotL_broadcast },
    { "comm", pilotL_comm },
@@ -2437,6 +2439,21 @@ static int pilotL_setNoJump( lua_State *L )
 static int pilotL_setNoLand( lua_State *L )
 {
    return pilotL_setFlagWrapper( L, PILOT_NOLAND );
+}
+
+
+/**
+ * @brief Enables or disables making the the pilot exempt from pilot.clear().
+ *
+ * @usage p:setNoClear( true )
+ *
+ *    @luatparam Pilot p Pilot to modify.
+ *    @luatparam[opt] boolean state true or false
+ * @luafunc setNoClear
+ */
+static int pilotL_setNoClear( lua_State *L )
+{
+   return pilotL_setFlagWrapper( L, PILOT_NOCLEAR );
 }
 
 

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -3130,13 +3130,14 @@ void pilots_newSystem (void)
 
 
 /**
- * @brief Clears all the pilots except the player.
+ * @brief Clears all the pilots except the player and clear-exempt pilots.
  */
 void pilots_clear (void)
 {
    int i;
    for (i=0; i < array_size(pilot_stack); i++)
-      if (!pilot_isPlayer( pilot_stack[i] ))
+      if (!pilot_isPlayer(pilot_stack[i])
+            && !pilot_isFlag(pilot_stack[i], PILOT_NOCLEAR))
          pilot_delete( pilot_stack[i] );
 }
 

--- a/src/pilot_flags.h
+++ b/src/pilot_flags.h
@@ -79,6 +79,7 @@ enum {
    PILOT_HASSPEEDLIMIT, /**< Speed limiting is activated for Pilot.*/
    PILOT_BRAKING,       /**< Pilot is braking. */
    PILOT_PERSIST,       /**< Persist pilot on jump. */
+   PILOT_NOCLEAR,       /**< Pilot isn't removed by pilots_clear(). */
    /* Sentinal. */
    PILOT_FLAGS_MAX      /**< Maximum number of flags. */
 };


### PR DESCRIPTION
This is something that can be used by Lua code to ensure that special pilots aren't removed by missions as a matter of course. Intended for use by #1799.