### PR TITLE
Fixed missions and events to work with escorts.

### DIFF
--- a/dat/events/dvaered/warlords_battle.lua
+++ b/dat/events/dvaered/warlords_battle.lua
@@ -227,7 +227,7 @@ end
 
 function defenderAttacked(victim, attacker)
    --The player chose his side
-   if attacker == player.pilot() then
+   if attacker == player.pilot() or attacker:leader() == player.pilot() then
       for i, p in ipairs(defenders) do
          hook.rm(defAttHook[i])
          if p ~= nil and p:exists() then
@@ -247,7 +247,7 @@ end
 
 function attackerAttacked(victim, attacker)
    --The player chose his side
-   if attacker == player.pilot() then
+   if attacker == player.pilot() or attacker:leader() == player.pilot() then
       for i, p in ipairs(attackers) do
          hook.rm(attAttHook[i])
          if p ~= nil and p:exists() then
@@ -269,7 +269,7 @@ function attackerDeath(victim, attacker)
    if batInProcess then
       attdeath = attdeath + 1
 
-      if attacker == player.pilot() then
+      if attacker == player.pilot() or attacker:leader() == player.pilot() then
          attkilled = attkilled + victim:stats().mass
       end
 
@@ -293,7 +293,7 @@ function defenderDeath(victim, attacker)
    if batInProcess then
       defdeath = defdeath + 1
 
-      if attacker == player.pilot() then
+      if attacker == player.pilot() or attacker:leader() == player.pilot() then
          defkilled = defkilled + victim:stats().mass
       end
 

--- a/dat/events/flf/flf_catastrophe.lua
+++ b/dat/events/flf/flf_catastrophe.lua
@@ -226,7 +226,7 @@ end
 
 
 function pilot_attacked_sindbad( pilot, attacker, arg )
-   if attacker == player.pilot()
+   if (attacker == player.pilot() or attacker:leader() == player.pilot())
          and faction.get("FLF"):playerStanding() > -100 then
       -- Punish the player with a faction hit every time they attack
       faction.get("FLF"):modPlayer(-10)
@@ -256,7 +256,7 @@ function pilot_death_sindbad( pilot, attacker, arg )
       end
    end
 
-   if attacker == player.pilot()
+   if attacker == player.pilot() or attacker:leader() == player.pilot()
          or faction.get("FLF"):playerStanding() < 0 then
       -- Player decided to help destroy Sindbad for some reason. Set FLF
       -- reputation to "enemy", add a log entry, and finish the event

--- a/dat/missions/dvaered/assault_on_unicorn.lua
+++ b/dat/missions/dvaered/assault_on_unicorn.lua
@@ -82,7 +82,9 @@ function jumpin()
 end
 
 function death(pilot,killer)
-   if pilot:faction() == faction.get("Pirate") and killer == player.pilot() then
+   if pilot:faction() == faction.get("Pirate")
+         and (killer == player.pilot()
+            or killer:leader() == player.pilot()) then
       reward_table = {
          ["Hyena"]             =  10000,
          ["Pirate Shark"]      =  30000,

--- a/dat/missions/dvaered/championship.lua
+++ b/dat/missions/dvaered/championship.lua
@@ -407,7 +407,8 @@ function land_everyone()
 end
 
 function oppo_attacked(pilot, attacker)  --The player tries to cheat by attacking before the signal
-   if stage == 0 and attacker == player.pilot() then
+   if stage == 0 and (attacker == player.pilot()
+            or attacker:leader() == player.pilot()) then
       land_everyone()
       tk.msg(dismisstitle, cheetext)
       system.mrkRm(mark)
@@ -526,7 +527,7 @@ function escort_attacked(pilot,attacker) --someone attacked the escort
       k:land(mispla)
    end
 
-   if attacker == player.pilot() then
+   if attacker == player.pilot() or attacker:leader() == player.pilot() then
       misn.finish(false)
    end
 

--- a/dat/missions/dvaered/frontier_war/fw02_escape.lua
+++ b/dat/missions/dvaered/frontier_war/fw02_escape.lua
@@ -395,7 +395,9 @@ end
 
 -- Test to see if the player killed a zlk inhabited ship
 function killed_zlk(pilot,killer)
-   if pilot:faction() == faction.get("Za'lek") and killer == player.pilot() then
+   if pilot:faction() == faction.get("Za'lek")
+         and (killer == player.pilot()
+            or killer:leader() == player.pilot()) then
       killed_ship = pilot:ship():nameRaw()
       if (elt_inlist( killed_ship, {"Za'lek Scout Drone", "Za'lek Light Drone", "Za'lek Heavy Drone", "Za'lek Bomber Drone"} ) == 0) then
          tk.msg(kill_title, kill_text)

--- a/dat/missions/flf/flf_diversion.lua
+++ b/dat/missions/flf/flf_diversion.lua
@@ -148,7 +148,8 @@ end
 
 
 function pilot_attacked_dv( p, attacker )
-   if attacker == player.pilot() and not dv_coming and rnd.rnd() < 0.1 then
+   if (attacker == player.pilot() or attacker:leader() == player.pilot())
+         and not dv_coming and rnd.rnd() < 0.1 then
       dv_coming = true
       hook.timer( 10000, "timer_spawn_dv" )
    end
@@ -156,7 +157,8 @@ end
 
 
 function pilot_death_dv( p, attacker )
-   if attacker == player.pilot() and not dv_coming then
+   if (attacker == player.pilot() or attacker:leader() == player.pilot())
+         and not dv_coming then
       dv_coming = true
       hook.timer( 10000, "timer_spawn_dv" )
    end

--- a/dat/missions/neutral/pirbounty_dead.lua
+++ b/dat/missions/neutral/pirbounty_dead.lua
@@ -279,7 +279,7 @@ end
 
 
 function pilot_death( p, attacker )
-   if attacker == player.pilot() then
+   if attacker == player.pilot() or attacker:leader() == player.pilot() then
       succeed()
       target_killed = true
    else
@@ -290,7 +290,7 @@ function pilot_death( p, attacker )
       for i, j in ipairs( hunters ) do
          total_hits = total_hits + hunter_hits[i]
          if j ~= nil then
-            if j == player.pilot() then
+            if j == player.pilot() or j:leader() == player.pilot() then
                player_hits = player_hits + hunter_hits[i]
             elseif j:exists() and hunter_hits[i] > top_hits then
                top_hunter = j

--- a/dat/missions/neutral/seek_n_destroy.lua
+++ b/dat/missions/neutral/seek_n_destroy.lua
@@ -496,7 +496,8 @@ end
 -- Player attacks an informant who has refused to give info
 function clue_attacked( p, attacker )
    -- Target was hit sufficiently to get more talkative
-   if attacker == player.pilot() and p:health() < 100 then
+   if (attacker == player.pilot() or attacker:leader() == player.pilot())
+         and p:health() < 100 then
       p:control()
       p:runaway(player.pilot())
       tk.msg( scared_title, scared_text[rnd.rnd(1,#scared_text)]:format( name, mysys[cursys+1]:name() ) )

--- a/dat/missions/pirate/empbounty_dead.lua
+++ b/dat/missions/pirate/empbounty_dead.lua
@@ -220,7 +220,7 @@ end
 
 
 function pilot_death( p, attacker )
-   if attacker == player.pilot() then
+   if attacker == player.pilot() or attacker:leader() == player.pilot() then
       succeed()
    else
       local top_hunter = nil
@@ -230,7 +230,7 @@ function pilot_death( p, attacker )
       for i, j in ipairs( hunters ) do
          total_hits = total_hits + hunter_hits[i]
          if j ~= nil then
-            if j == player.pilot() then
+            if j == player.pilot() or j:leader() == player.pilot() then
                player_hits = player_hits + hunter_hits[i]
             elseif j:exists() and hunter_hits[i] > top_hits then
                top_hunter = j

--- a/dat/missions/pirate/hitman.lua
+++ b/dat/missions/pirate/hitman.lua
@@ -111,7 +111,8 @@ function trader_attacked (hook_pilot, hook_attacker, hook_arg)
 
    if ( hook_pilot:faction() == faction.get("Trader")
             or hook_pilot:faction() == faction.get("Traders Guild") )
-         and hook_attacker == player.pilot() then
+         and ( hook_attacker == player.pilot()
+            or hook_attacker:leader() == player.pilot() ) then
       hook_pilot:hookClear()
       hook.pilot(hook_pilot, "jump", "trader_jumped")
       hook.pilot(hook_pilot, "land", "trader_jumped")

--- a/dat/missions/pirate/hitman2.lua
+++ b/dat/missions/pirate/hitman2.lua
@@ -112,7 +112,8 @@ function trader_death (hook_pilot, hook_attacker, hook_arg)
 
    if ( hook_pilot:faction() == faction.get("Trader")
             or hook_pilot:faction() == faction.get("Traders Guild") )
-         and hook_attacker == player.pilot() then
+         and ( hook_attacker == player.pilot()
+            or hook_attacker:leader() == player.pilot() ) then
       attack_finished()
    end
 end


### PR DESCRIPTION
Long-standing issue. Many missions assumed that the player would always be the direct attacker, which isn't necessarily true with
escorts. This adds checks for whether or not an attacker's leader is the player as well as whether the attacker is literally the player.

(Note: this comes from Naikari, so if there are any other instances in Naev that were removed there then this won't cover them. But at least in Naikari, this covers all current cases of this mistake in mission/event code.)

EDIT: Ah, and want to note this as well: this fix is important even if escort hiring is never adopted because it affects fighter bay fighters, too.

🕵️