### PR TITLE
Fixed outfit details in search assuming 128x128 icon size.

### DIFF
--- a/src/map_find.c
+++ b/src/map_find.c
@@ -708,7 +708,7 @@ static void map_showOutfitDetail(unsigned int wid, char* wgtname, int x, int y, 
 
    outfit = outfit_get( map_foundOutfitNames[toolkit_getListPos(wid, wgtname)] );
    window_modifyText( wid, "txtOutfitName", _(outfit->name) );
-   window_modifyImage( wid, "imgOutfit", outfit->gfx_store, 0, 0 );
+   window_modifyImage( wid, "imgOutfit", outfit->gfx_store, 128, 128 );
 
    mass = outfit->mass;
    if ((outfit_isLauncher(outfit) || outfit_isFighterBay(outfit)) &&


### PR DESCRIPTION
This implicit assumption caused larger images to be sized wrongly (they would extend up and to the right, possibly leaving the window depending on the image size).

I think more work on that display in general is needed, but for now, this at least fixes that particular bug and enables using shop graphics rendered at sizes larger than 128x128.

🕵️