### PR TITLE
Kestrel shenanigans

### DIFF
--- a/dat/outfits/core_engine/krain_remige_engine.xml
+++ b/dat/outfits/core_engine/krain_remige_engine.xml
@@ -11,8 +11,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <energy_usage>21</energy_usage>
-  <engine_limit>3800</engine_limit>
+  <energy_usage>65</energy_usage>
+  <engine_limit>3900</engine_limit>
   <fuel>1600</fuel>
   <speed>125</speed>
   <thrust>70</thrust>

--- a/dat/ships/kestrel.xml
+++ b/dat/ships/kestrel.xml
@@ -20,7 +20,7 @@
  </health>
  <characteristics>
   <crew>27</crew>
-  <mass>1400</mass>
+  <mass>1100</mass>
   <fuel_consumption>400</fuel_consumption>
   <cargo>80</cargo>
  </characteristics>
@@ -46,6 +46,9 @@
   <structure size="medium" />
  </slots>
  <stats>
+  <shield_mod>5</shield_mod>
+  <speed_mod>5</speed_mod>
+  <turn_mod>5</turn_mod>
   <ew_hide>5</ew_hide>
  </stats>
 </ship>

--- a/dat/ships/pirate_kestrel.xml
+++ b/dat/ships/pirate_kestrel.xml
@@ -20,7 +20,7 @@
  </health>
  <characteristics>
   <crew>28</crew>
-  <mass>1300</mass>
+  <mass>1000</mass>
   <fuel_consumption>400</fuel_consumption>
   <cargo>80</cargo>
  </characteristics>
@@ -46,8 +46,9 @@
   <structure size="medium" />
  </slots>
  <stats>
-  <speed_mod>5</speed_mod>
-  <turn_mod>5</turn_mod>
+  <shield_mod>5</shield_mod>
+  <speed_mod>10</speed_mod>
+  <turn_mod>10</turn_mod>
   <thrust_mod>5</thrust_mod>
   <cargo_mod>15</cargo_mod>
   <armour_mod>-10</armour_mod>


### PR DESCRIPTION
First-pass rebalance of the iconic Kestrel.

- Hulls are 300 tons lighter and have small bonuses to speed, turning and shields.
- Krain Remige engines' power usage was absurdly low. Fixed, with a consolation of 100 extra mass limit.
Now on the proper branch! Pay no attention to the idiot behind the curtain.