### PR TITLE
Adventures in Za'lek Ships

### DIFF
--- a/dat/ships/zalek_mephisto.xml
+++ b/dat/ships/zalek_mephisto.xml
@@ -25,11 +25,11 @@
  <slots>
   <weapon size="large" x="40" y="0" h="2" />
   <weapon size="large" x="25" y="0" h="2" />
+  <weapon size="large" x="0" y="0" h="7" />
   <weapon size="large" x="12" y="-6" h="0" />
   <weapon size="large" x="12" y="6" h="0" />
-  <weapon size="large" x="0" y="0" h="7" />
-  <weapon size="large" prop="fighter_bay" x="-15" y="0" h="7" />
-  <weapon size="large" prop="fighter_bay" x="-33" y="0" h="7" />
+  <weapon size="large" prop="fighter_bay" x="15" y="-6" h="7" />
+  <weapon size="large" prop="fighter_bay" x="15" y="6" h="7" />
   <utility size="large" prop="systems" exclusive="1" required="1">Unicorp PT-2200 Core System</utility>
   <utility size="large" prop="accessory" exclusive="1" />
   <utility size="large" />

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -341,7 +341,6 @@
   <item>Admonisher</item>
   <item>Pirate Admonisher</item>
   <item>Empire Admonisher</item>
-  <item>Za'lek Imp</item>
   <item>Za'lek Sting</item>
   <item>Thurion Virtuosity</item>
   <item>Vigilance</item>
@@ -885,13 +884,10 @@
   <item>Thurion Certitude</item>
  </tech>
  <tech name="Za'lek Military Ships">
-  <item>Za'lek Imp</item>
   <item>Za'lek Sting</item>
   <item>Za'lek Demon</item>
   <item>Za'lek Mephisto</item>
-  <item>Za'lek Prototype</item>
   <item>Za'lek Diablo</item>
-  <item>Za'lek Hephaestus</item>
  </tech>
  <tech name="__Heavy Weapon License">
   <item>Heavy Weapon License</item>


### PR DESCRIPTION
Removed the mission-only Za'lek ships from regular shops, removed the superfluous Imp, and fixed the Mephisto's sprites.