### PR TITLE
small fixes

### DIFF
--- a/dat/assets/bastion_station.xml
+++ b/dat/assets/bastion_station.xml
@@ -22,6 +22,7 @@
    <refuel/>
    <missions/>
    <outfits/>
+   <shipyard/>
   </services>
   <commodities/>
   <description>Bastion Station is one of the two primary defense, border guard, and patrol base stations leading into Za'lek space. As such, it is one of the few military expenditures that goes (largely) unchallenged even by the notorious Za'lek political scene. The House Za'lek Defense Force conducts most of their foreign contact here, where they can keep an eye on affairs.</description>

--- a/dat/faction.xml
+++ b/dat/faction.xml
@@ -65,6 +65,7 @@
  <faction>
   <name>Miner</name>
   <ai>miner</ai>
+  <logo>miner</logo>
   <static />
   <invisible />
   <known />
@@ -280,7 +281,6 @@
   <enemies>
    <enemy>Pirate</enemy>
    <enemy>FLF</enemy>
-   <enemy>Wanted Pirate</enemy>
   </enemies>
  </faction>
  <faction>
@@ -356,7 +356,6 @@
   <enemies>
    <enemy>Civilian</enemy>
    <enemy>Collective</enemy>
-   <enemy>Dvaered</enemy>
    <enemy>Independent</enemy>
    <enemy>Miner</enemy>
    <enemy>Proteron</enemy>


### PR DESCRIPTION
No way to change ship in the primary bounty grinding location in Za'lek space. Dvaered will no longer murder your wanted alive pirates. Miners use their icon.