### PR TITLE
guided ammo behave like bolt weapons and guided ammo always use absolute velocity

### DIFF
--- a/dat/outfits/launchers/teracom_mace_launcher.xml
+++ b/dat/outfits/launchers/teracom_mace_launcher.xml
@@ -15,8 +15,8 @@ TeraCom's Mace launcher uses an advanced reload mechanism that allows the launch
  <specific type="launcher">
   <ammo>Mace Rocket</ammo>
   <delay>0.3</delay>
-  <reload_time>6</reload_time>
-  <amount>50</amount>
+  <reload_time>12</reload_time>
+  <amount>25</amount>
   <swivel>22</swivel>
   <trackmin>0</trackmin>
   <trackmax>5000</trackmax>

--- a/dat/outfits/launchers/unicorp_mace_launcher.xml
+++ b/dat/outfits/launchers/unicorp_mace_launcher.xml
@@ -13,8 +13,8 @@
  <specific type="launcher">
   <ammo>Mace Rocket</ammo>
   <delay>0.36</delay>
-  <reload_time>6</reload_time>
-  <amount>50</amount>
+  <reload_time>12</reload_time>
+  <amount>25</amount>
   <swivel>22</swivel>
   <trackmin>0</trackmin>
   <trackmax>5000</trackmax>

--- a/dat/outfits/rockets/caesar_iv_torpedo.xml
+++ b/dat/outfits/rockets/caesar_iv_torpedo.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpL</spfx_armour>
   <trail_generator x="-10">fire-missileL</trail_generator>
   <duration blowup="armour">33</duration>
-  <thrust>0</thrust>
+  <thrust>70</thrust>
   <turn>25</turn>
   <speed>200</speed>
   <resist>100</resist>

--- a/dat/outfits/rockets/convulsion_missile.xml
+++ b/dat/outfits/rockets/convulsion_missile.xml
@@ -14,7 +14,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-5">missile</trail_generator>
   <duration blowup="armour">4</duration>
-  <thrust>0</thrust>
+  <thrust>700</thrust>
   <turn>55</turn>
   <speed>850</speed>
   <resist>50</resist>

--- a/dat/outfits/rockets/fury_missile.xml
+++ b/dat/outfits/rockets/fury_missile.xml
@@ -14,7 +14,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-7">fire-missile</trail_generator>
   <duration blowup="armour">4</duration>
-  <thrust>0</thrust>
+  <thrust>600</thrust>
   <turn>50</turn>
   <speed>800</speed>
   <resist>10</resist>

--- a/dat/outfits/rockets/headhunter_missile.xml
+++ b/dat/outfits/rockets/headhunter_missile.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-7">fire-missile</trail_generator>
   <duration blowup="armour">5</duration>
-  <thrust>0</thrust>
+  <thrust>500</thrust>
   <turn>40</turn>
   <speed>600</speed>
   <resist>20</resist>

--- a/dat/outfits/rockets/huntsman_torpedo.xml
+++ b/dat/outfits/rockets/huntsman_torpedo.xml
@@ -15,7 +15,7 @@
   <spfx_armour>EmpM</spfx_armour>
   <trail_generator x="-10">fire-missileL</trail_generator>
   <duration blowup="armour">33</duration>
-  <thrust>0</thrust>
+  <thrust>70</thrust>
   <turn>25</turn>
   <speed>200</speed>
   <resist>100</resist>

--- a/dat/outfits/rockets/imperator_torpedo.xml
+++ b/dat/outfits/rockets/imperator_torpedo.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpL</spfx_armour>
   <trail_generator x="-10">missileL</trail_generator>
   <duration blowup="armour">60</duration>
-  <thrust>0</thrust>
+  <thrust>55</thrust>
   <turn>20</turn>
   <speed>125</speed>
   <resist>100</resist>

--- a/dat/outfits/rockets/mace_rocket.xml
+++ b/dat/outfits/rockets/mace_rocket.xml
@@ -15,8 +15,8 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-10">fire-missileS</trail_generator>
   <duration blowup="armour">1.5</duration>
-  <thrust>1200</thrust>
-  <speed>1800</speed>
+  <thrust>0</thrust>
+  <speed>900</speed>
   <damage>
    <type>impact</type>
    <penetrate>12</penetrate>

--- a/dat/outfits/rockets/medusa_missile.xml
+++ b/dat/outfits/rockets/medusa_missile.xml
@@ -14,7 +14,7 @@
   <spfx_armour>EmpM</spfx_armour>
   <trail_generator x="-7">missile</trail_generator>
   <duration blowup="armour">5</duration>
-  <thrust>0</thrust>
+  <thrust>400</thrust>
   <turn>50</turn>
   <speed>500</speed>
   <resist>20</resist>

--- a/dat/outfits/rockets/shatterer_missile.xml
+++ b/dat/outfits/rockets/shatterer_missile.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-7">missile</trail_generator>
   <duration blowup="armour">2</duration>
-  <thrust>0</thrust>
+  <thrust>900</thrust>
   <turn>5</turn>
   <speed>1200</speed>
   <resist>35</resist>

--- a/dat/outfits/rockets/spearhead_missile.xml
+++ b/dat/outfits/rockets/spearhead_missile.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-7">fire-missile</trail_generator>
   <duration blowup="armour">7</duration>
-  <thrust>0</thrust>
+  <thrust>350</thrust>
   <turn>35</turn>
   <speed>600</speed>
   <resist>20</resist>

--- a/dat/outfits/rockets/vengeance_missile.xml
+++ b/dat/outfits/rockets/vengeance_missile.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="-7">fire-missile</trail_generator>
   <duration blowup="armour">7</duration>
-  <thrust>0</thrust>
+  <thrust>250</thrust>
   <turn>30</turn>
   <speed>450</speed>
   <resist>20</resist>

--- a/dat/outfits/rockets/zalek_hunter.xml
+++ b/dat/outfits/rockets/zalek_hunter.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpM</spfx_armour>
   <trail_generator x="0">zalek-missile</trail_generator>
   <duration blowup="armour">7</duration>
-  <thrust>0</thrust>
+  <thrust>450</thrust>
   <turn>70</turn>
   <speed>550</speed>
   <resist>35</resist>

--- a/dat/outfits/rockets/zalek_reaper.xml
+++ b/dat/outfits/rockets/zalek_reaper.xml
@@ -15,7 +15,7 @@
   <spfx_armour>ExpL</spfx_armour>
   <trail_generator x="-15">zalek-missileL</trail_generator>
   <duration blowup="armour">35</duration>
-  <thrust>0</thrust>
+  <thrust>200</thrust>
   <turn>60</turn>
   <speed>220</speed>
   <resist>100</resist>

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1076,7 +1076,9 @@ static void weapon_sample_trail( Weapon* w )
    dy = w->outfit->u.amm.trail_x_offset * sin(a);
 
    /* Set the colour. */
-   if (w->solid->thrust > 0)
+   if ((w->outfit->u.amm.ai == AMMO_AI_UNGUIDED) ||
+        w->solid->vel.x*w->solid->vel.x + w->solid->vel.y*w->solid->vel.y + 1.
+        < w->solid->speed_max*w->solid->speed_max)
       mode = MODE_AFTERBURN;
    else if (w->solid->dir_vel != 0.)
       mode = MODE_GLOW;


### PR DESCRIPTION
This proposal would solve https://github.com/naev/naev/issues/922

* All unguided rockets (mace and banshee) have 0 thrust and behave like bolt ammo
* All guided rockets have non-zero thrust. The result is that their final speed is always equal to their max_speed, and they sometimes have nice trajectories when launched.
* The way trails colours are chosen has been changed to be coherent with these changes.
* Mace rockets are thus much more effective. As a result, I divided by 2 their reload rate, and their quantity in launcher. This results in this weapon being very effective, but if the shots miss, the attack is a failure.

I know it's not really in par with what was discussed on discord, but it's the easiest solution, implementation-wise, and also probably player-wise. Otherwise we would have to teach the AI to play with this absolute--relative velocity question.
Later on, we can implement unguided ammo sometimes running amok with a low probability, and turning all over the place, mainly for the cool factor.