### PR TITLE
proposal of new tracking values for bolt weapons

### DIFF
--- a/dat/outfits/bio_weapons/bioplasma_claw_stage_1.xml
+++ b/dat/outfits/bio_weapons/bioplasma_claw_stage_1.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>10</energy>
   <heatup>20</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_claw_stage_2.xml
+++ b/dat/outfits/bio_weapons/bioplasma_claw_stage_2.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>10</energy>
   <heatup>23</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_claw_stage_3.xml
+++ b/dat/outfits/bio_weapons/bioplasma_claw_stage_3.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>10</energy>
   <heatup>27</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_claw_stage_4.xml
+++ b/dat/outfits/bio_weapons/bioplasma_claw_stage_4.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>10</energy>
   <heatup>31</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_claw_stage_x.xml
+++ b/dat/outfits/bio_weapons/bioplasma_claw_stage_x.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>10</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_fang_stage_1.xml
+++ b/dat/outfits/bio_weapons/bioplasma_fang_stage_1.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>15</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_fang_stage_2.xml
+++ b/dat/outfits/bio_weapons/bioplasma_fang_stage_2.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>18</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_fang_stage_3.xml
+++ b/dat/outfits/bio_weapons/bioplasma_fang_stage_3.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>21</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_fang_stage_4.xml
+++ b/dat/outfits/bio_weapons/bioplasma_fang_stage_4.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>24</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_fang_stage_5.xml
+++ b/dat/outfits/bio_weapons/bioplasma_fang_stage_5.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>27</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_fang_stage_x.xml
+++ b/dat/outfits/bio_weapons/bioplasma_fang_stage_x.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>30</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_stinger_stage_1.xml
+++ b/dat/outfits/bio_weapons/bioplasma_stinger_stage_1.xml
@@ -23,7 +23,7 @@
   <energy>4</energy>
   <heatup>25</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/bio_weapons/bioplasma_stinger_stage_2.xml
+++ b/dat/outfits/bio_weapons/bioplasma_stinger_stage_2.xml
@@ -24,7 +24,7 @@
   <energy>4</energy>
   <heatup>30</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/bio_weapons/bioplasma_stinger_stage_3.xml
+++ b/dat/outfits/bio_weapons/bioplasma_stinger_stage_3.xml
@@ -24,7 +24,7 @@
   <energy>4</energy>
   <heatup>35</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/bio_weapons/bioplasma_stinger_stage_x.xml
+++ b/dat/outfits/bio_weapons/bioplasma_stinger_stage_x.xml
@@ -24,7 +24,7 @@
   <energy>4</energy>
   <heatup>40</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_1.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_1.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>45</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_2.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_2.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>50</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_3.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_3.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>55</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_4.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_4.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>60</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_5.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_5.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>65</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_6.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_6.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>70</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_talon_stage_x.xml
+++ b/dat/outfits/bio_weapons/bioplasma_talon_stage_x.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>75</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_1.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_1.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>25</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_2.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_2.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>30</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_3.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_3.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>35</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_4.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_4.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>40</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_5.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_5.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>45</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_6.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_6.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>50</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_7.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_7.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>55</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/bio_weapons/bioplasma_tentacle_stage_x.xml
+++ b/dat/outfits/bio_weapons/bioplasma_tentacle_stage_x.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>60</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/weapons/base_ripper_mk2.xml
+++ b/dat/outfits/weapons/base_ripper_mk2.xml
@@ -22,8 +22,8 @@
   <gfx_end>ripperM-end.png</gfx_end>
   <energy>1</energy>
   <heatup>10000</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <damage>
    <type>normal</type>
    <penetrate>50</penetrate>

--- a/dat/outfits/weapons/gauss_gun.xml
+++ b/dat/outfits/weapons/gauss_gun.xml
@@ -21,7 +21,7 @@
   <energy>1</energy>
   <heatup>40</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/heavy_ion_cannon.xml
+++ b/dat/outfits/weapons/heavy_ion_cannon.xml
@@ -22,8 +22,8 @@
   <gfx_end>ionL-end.png</gfx_end>
   <energy>42</energy>
   <heatup>60</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>6000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>ion</type>

--- a/dat/outfits/weapons/heavy_ion_turret.xml
+++ b/dat/outfits/weapons/heavy_ion_turret.xml
@@ -23,8 +23,8 @@
   <gfx_end>ionL-end.png</gfx_end>
   <energy>54</energy>
   <heatup>60</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>14000</trackmax>
+  <trackmin>2000</trackmin>
+  <trackmax>8000</trackmax>
   <damage>
    <type>ion</type>
    <penetrate>48</penetrate>

--- a/dat/outfits/weapons/heavy_laser_turret.xml
+++ b/dat/outfits/weapons/heavy_laser_turret.xml
@@ -23,8 +23,8 @@
   <gfx_end>laser2L.png</gfx_end>
   <energy>49</energy>
   <heatup>75</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>2000</trackmin>
+  <trackmax>8000</trackmax>
   <damage>
    <type>normal</type>
    <penetrate>62</penetrate>

--- a/dat/outfits/weapons/heavy_razor_turret.xml
+++ b/dat/outfits/weapons/heavy_razor_turret.xml
@@ -23,8 +23,8 @@
   <gfx_end>razorL-end.png</gfx_end>
   <energy>174</energy>
   <heatup>60</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>ion</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/weapons/heavy_ripper_cannon.xml
+++ b/dat/outfits/weapons/heavy_ripper_cannon.xml
@@ -23,8 +23,8 @@
   <gfx_end>ripperM-end.png</gfx_end>
   <energy>42</energy>
   <heatup>50</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>6000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/weapons/heavy_ripper_turret.xml
+++ b/dat/outfits/weapons/heavy_ripper_turret.xml
@@ -23,8 +23,8 @@
   <gfx_end>ripperM-end.png</gfx_end>
   <energy>153</energy>
   <heatup>60</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>3000</trackmin>
+  <trackmax>10000</trackmax>
   <damage>
    <type>normal</type>
    <penetrate>72</penetrate>

--- a/dat/outfits/weapons/laser_cannon_mk1.xml
+++ b/dat/outfits/weapons/laser_cannon_mk1.xml
@@ -21,7 +21,7 @@
   <energy>4</energy>
   <heatup>40</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/weapons/laser_cannon_mk2.xml
+++ b/dat/outfits/weapons/laser_cannon_mk2.xml
@@ -22,8 +22,8 @@
   <gfx_end>laser1S.png</gfx_end>
   <energy>10</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/weapons/laser_turret_mk1.xml
+++ b/dat/outfits/weapons/laser_turret_mk1.xml
@@ -21,8 +21,8 @@
   <falloff>750</falloff>
   <energy>8</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <damage>
    <type>normal</type>
    <penetrate>6</penetrate>

--- a/dat/outfits/weapons/laser_turret_mk2.xml
+++ b/dat/outfits/weapons/laser_turret_mk2.xml
@@ -22,8 +22,8 @@
   <gfx_end>laser1M.png</gfx_end>
   <energy>30</energy>
   <heatup>50</heatup>
-  <trackmin>4000</trackmin>
-  <trackmax>14000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <damage>
    <type>normal</type>
    <penetrate>36</penetrate>

--- a/dat/outfits/weapons/mass_driver.xml
+++ b/dat/outfits/weapons/mass_driver.xml
@@ -21,8 +21,8 @@
   <range blowup="armour">1900</range>
   <energy>10.5</energy>
   <heatup>50</heatup>
-  <trackmin>4000</trackmin>
-  <trackmax>14000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>6000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/neutron_disruptor.xml
+++ b/dat/outfits/weapons/neutron_disruptor.xml
@@ -24,7 +24,7 @@
   <energy>5</energy>
   <heatup>40</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/weapons/neutron_disruptor_heavy.xml
+++ b/dat/outfits/weapons/neutron_disruptor_heavy.xml
@@ -23,8 +23,8 @@
   <gfx_end>neutron-end.png</gfx_end>
   <energy>25</energy>
   <heatup>30</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/weapons/plasma_blaster_mk1.xml
+++ b/dat/outfits/weapons/plasma_blaster_mk1.xml
@@ -21,7 +21,7 @@
   <energy>4</energy>
   <heatup>40</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/plasma_blaster_mk2.xml
+++ b/dat/outfits/weapons/plasma_blaster_mk2.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>10</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/plasma_cannon.xml
+++ b/dat/outfits/weapons/plasma_cannon.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>30</energy>
   <heatup>30</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/plasma_cluster_cannon.xml
+++ b/dat/outfits/weapons/plasma_cluster_cannon.xml
@@ -22,8 +22,8 @@
   <gfx_end>plasma2-end.png</gfx_end>
   <energy>42</energy>
   <heatup>50</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>6000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/plasma_turret_mk1.xml
+++ b/dat/outfits/weapons/plasma_turret_mk1.xml
@@ -21,8 +21,8 @@
   <falloff>750</falloff>
   <energy>8</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>6</penetrate>

--- a/dat/outfits/weapons/plasma_turret_mk2.xml
+++ b/dat/outfits/weapons/plasma_turret_mk2.xml
@@ -21,8 +21,8 @@
   <falloff>950</falloff>
   <energy>30</energy>
   <heatup>50</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>36</penetrate>

--- a/dat/outfits/weapons/railgun.xml
+++ b/dat/outfits/weapons/railgun.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>60</energy>
   <heatup>75</heatup>
-  <trackmin>7000</trackmin>
-  <trackmax>20000</trackmax>
+  <trackmin>4000</trackmin>
+  <trackmax>12000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/railgun_turret.xml
+++ b/dat/outfits/weapons/railgun_turret.xml
@@ -23,8 +23,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>153</energy>
   <heatup>60</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>72</penetrate>

--- a/dat/outfits/weapons/razor_mk1.xml
+++ b/dat/outfits/weapons/razor_mk1.xml
@@ -22,7 +22,7 @@
   <energy>4</energy>
   <heatup>40</heatup>
   <trackmin>0</trackmin>
-  <trackmax>3000</trackmax>
+  <trackmax>2000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>ion</type>

--- a/dat/outfits/weapons/razor_mk2.xml
+++ b/dat/outfits/weapons/razor_mk2.xml
@@ -21,8 +21,8 @@
   <gfx_end>razorS-end.png</gfx_end>
   <energy>10</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>ion</type>

--- a/dat/outfits/weapons/razor_turret_mk1.xml
+++ b/dat/outfits/weapons/razor_turret_mk1.xml
@@ -22,8 +22,8 @@
   <gfx_end>razorS-end.png</gfx_end>
   <energy>8</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <damage>
    <type>ion</type>
    <penetrate>6</penetrate>

--- a/dat/outfits/weapons/razor_turret_mk2.xml
+++ b/dat/outfits/weapons/razor_turret_mk2.xml
@@ -22,8 +22,8 @@
   <gfx_end>razorM-end.png</gfx_end>
   <energy>30</energy>
   <heatup>50</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <damage>
    <type>ion</type>
    <penetrate>36</penetrate>

--- a/dat/outfits/weapons/repeating_railgun.xml
+++ b/dat/outfits/weapons/repeating_railgun.xml
@@ -24,8 +24,8 @@
   <gfx_end>massL-end.png</gfx_end>
   <energy>52</energy>
   <heatup>50</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>4000</trackmin>
+  <trackmax>12000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/ripper_cannon.xml
+++ b/dat/outfits/weapons/ripper_cannon.xml
@@ -22,8 +22,8 @@
   <gfx_end>ripperS-end.png</gfx_end>
   <energy>30</energy>
   <heatup>30</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>normal</type>

--- a/dat/outfits/weapons/shredder.xml
+++ b/dat/outfits/weapons/shredder.xml
@@ -21,8 +21,8 @@
   <range blowup="armour">1200</range>
   <energy>7.5</energy>
   <heatup>30</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>

--- a/dat/outfits/weapons/slicer.xml
+++ b/dat/outfits/weapons/slicer.xml
@@ -22,8 +22,8 @@
   <gfx_end>razorS-end.png</gfx_end>
   <energy>30</energy>
   <heatup>30</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>ion</type>

--- a/dat/outfits/weapons/tesla_cannon.xml
+++ b/dat/outfits/weapons/tesla_cannon.xml
@@ -24,8 +24,8 @@
   <gfx_end>ionL.png</gfx_end>
   <energy>70</energy>
   <heatup>75</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>4000</trackmin>
+  <trackmax>12000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>ion</type>

--- a/dat/outfits/weapons/turbolaser.xml
+++ b/dat/outfits/weapons/turbolaser.xml
@@ -23,8 +23,8 @@
   <gfx_end>laser3L.png</gfx_end>
   <energy>174</energy>
   <heatup>60</heatup>
-  <trackmin>10000</trackmin>
-  <trackmax>30000</trackmax>
+  <trackmin>5000</trackmin>
+  <trackmax>20000</trackmax>
   <damage>
    <type>normal</type>
    <penetrate>100</penetrate>

--- a/dat/outfits/weapons/turreted_gauss_gun.xml
+++ b/dat/outfits/weapons/turreted_gauss_gun.xml
@@ -21,8 +21,8 @@
   <range blowup="armour">1000</range>
   <energy>2.5</energy>
   <heatup>40</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>6</penetrate>

--- a/dat/outfits/weapons/turreted_vulcan_gun.xml
+++ b/dat/outfits/weapons/turreted_vulcan_gun.xml
@@ -22,8 +22,8 @@
   <range blowup="armour">1200</range>
   <energy>7.5</energy>
   <heatup>50</heatup>
-  <trackmin>2000</trackmin>
-  <trackmax>8000</trackmax>
+  <trackmin>1000</trackmin>
+  <trackmax>4000</trackmax>
   <damage>
    <type>impact</type>
    <penetrate>36</penetrate>

--- a/dat/outfits/weapons/vulcan_gun.xml
+++ b/dat/outfits/weapons/vulcan_gun.xml
@@ -21,8 +21,8 @@
   <range blowup="armour">1100</range>
   <energy>2.5</energy>
   <heatup>35</heatup>
-  <trackmin>1000</trackmin>
-  <trackmax>4000</trackmax>
+  <trackmin>0</trackmin>
+  <trackmax>3000</trackmax>
   <swivel>22</swivel>
   <damage>
    <type>impact</type>


### PR DESCRIPTION
I did not consider launcher, nor beams. just bolt cannons and turrets.

Considered values of evasion:
* Scout: 2000
* Interceptor: 4000
* Fighter: 6000
* Corvette: 10000
* Destroyer: 13000
* Cruiser: 22000
* Battleship: 35000

So the proposed tracking values are: (trackmin--trackmax)
* Smallest cannon (laser mk1) is 100% accurate with everything but ultrastealth scouts: 0--2000
* Cannon mk2 has problems with scouts: 0--3000
* Corvette miniaturized cannon (ripper): idem 0--3000
* Corvette heavy cannon (hvy ripper) unable to track scouts, and has problems with interceptors: 1000-6000
* Superheavy cannon (railgun and tesla) hits destroyers or heavier: 4000--12000
* Small turret (laser mk1) hits everything but scouts: 0--3000
* Medium Turret (laser mk2) has problems with stealth interceptors: 1000--4000
* Heavy turret (heavy laser) has problems with fighters, and tracks corvettes: 2000--8000
* Heavy ripper turret: tracks corvettes and above: 3000--10000
* Superheavy turret (turbolaser): has problems with destroyers, and tracks perfectly cruisers: 5000-20000

(Of course I also did in-game tests and I found it to be satisfactory for me).

Remarks:
* One thing I think could be considered would be giving the heavy turret (heavy laser) the same values as heavy ripper turret, to make them unusable against fighters.
* Is the trackmin value really necessary? It could be fixed to zero, or to a fixed fraction of trackmax. It would reduce the number of parameters the player has to consider.
* (unrelated) It would be really better for maintaining if the soromid outfits were defined only by one file, that contains info from which the upper stages stats would be computed.