### PR TITLE
Radar zoom

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -169,7 +169,6 @@ typedef struct Radar_ {
 #define RADAR_RES_MAX      100. /**< Maximum radar resolution. */
 #define RADAR_RES_MIN      10. /**< Minimum radar resolution. */
 #define RADAR_RES_INTERVAL 10. /**< Steps used to increase/decrease resolution. */
-#define RADAR_RES_DEFAULT  50. /**< Default resolution. */
 static Radar gui_radar;
 
 /* needed to render properly */
@@ -245,7 +244,7 @@ static int gui_runFunc( const char* func, int nargs, int nret );
  */
 void gui_setDefaults (void)
 {
-   gui_radar.res = RADAR_RES_DEFAULT;
+   gui_radar.res = player.radar_res;
    memset( mesg_stack, 0, sizeof(Mesg)*mesg_max );
 }
 
@@ -1018,7 +1017,7 @@ int gui_getMapOverlayBoundLeft(void)
 int gui_radarInit( int circle, int w, int h )
 {
    gui_radar.shape   = circle ? RADAR_CIRCLE : RADAR_RECT;
-   gui_radar.res     = RADAR_RES_DEFAULT;
+   gui_radar.res     = player.radar_res;
    gui_radar.w       = w;
    gui_radar.h       = h;
    return 0;
@@ -1770,7 +1769,7 @@ int gui_init (void)
    /*
     * radar
     */
-   gui_radar.res = RADAR_RES_DEFAULT;
+   gui_radar.res = player.radar_res;
 
    /*
     * messages

--- a/src/gui.c
+++ b/src/gui.c
@@ -167,6 +167,7 @@ typedef struct Radar_ {
 } Radar;
 /* radar resolutions */
 #define RADAR_RES_MAX      300. /**< Maximum radar resolution. */
+#define RADAR_RES_REF      100. /**< Reference radar resolution. */
 #define RADAR_RES_MIN      10. /**< Minimum radar resolution. */
 #define RADAR_RES_INTERVAL 10. /**< Steps used to increase/decrease resolution. */
 static Radar gui_radar;
@@ -1272,7 +1273,7 @@ void gui_renderPilot( const Pilot* p, RadarShape shape, double w, double h, doub
       y = ((p->solid->pos.y - player.p->solid->pos.y) / res);
    }
    /* Get size. */
-   scale = ((double)ship_size( p->ship ) + 1.)/2. * (1. + RADAR_RES_MAX / res );
+   scale = ((double)ship_size( p->ship ) + 1.)/2. * (1. + RADAR_RES_REF / res );
 
    /* Check if pilot in range. */
    if ( ((shape==RADAR_RECT) &&

--- a/src/gui.c
+++ b/src/gui.c
@@ -166,7 +166,7 @@ typedef struct Radar_ {
    double res; /**< Resolution */
 } Radar;
 /* radar resolutions */
-#define RADAR_RES_MAX      100. /**< Maximum radar resolution. */
+#define RADAR_RES_MAX      300. /**< Maximum radar resolution. */
 #define RADAR_RES_MIN      10. /**< Minimum radar resolution. */
 #define RADAR_RES_INTERVAL 10. /**< Steps used to increase/decrease resolution. */
 static Radar gui_radar;

--- a/src/player.c
+++ b/src/player.c
@@ -78,6 +78,11 @@ static char *player_message_noland = NULL; /**< No landing message (when PLAYER_
  */
 static char **player_licenses = NULL; /**< Licenses player has. */
 
+/*
+ * Default radar resolution.
+ */
+#define RADAR_RES_DEFAULT  50. /**< Default resolution. */
+
 
 /*
  * player sounds.
@@ -200,6 +205,7 @@ static void player_newSetup()
    double x, y;
 
    /* Set up GUI. */
+   player.radar_res = RADAR_RES_DEFAULT;
    gui_setDefaults();
 
    /* Setup sound */
@@ -3085,6 +3091,8 @@ int player_save( xmlTextWriterPtr writer )
       xmlw_elem(writer,"gui","%s",player.gui);
    xmlw_elem(writer,"guiOverride","%d",player.guiOverride);
    xmlw_elem(writer,"mapOverlay","%d",ovr_isOpen());
+   gui_radarGetRes( &player.radar_res );
+   xmlw_elem(writer,"radar_res","%f",player.radar_res);
 
    /* Time. */
    xmlw_startElem(writer,"time");
@@ -3427,6 +3435,7 @@ static Planet* player_parse( xmlNodePtr parent )
    map_overlay_enabled = 0;
 
    player.dt_mod = 1.; /* For old saves. */
+   player.radar_res = RADAR_RES_DEFAULT;
 
    /* Must get planet first. */
    node = parent->xmlChildrenNode;
@@ -3445,6 +3454,7 @@ static Planet* player_parse( xmlNodePtr parent )
       xmlr_int(node, "guiOverride", player.guiOverride);
       xmlr_int(node, "mapOverlay", map_overlay_enabled);
       ovr_setOpen(map_overlay_enabled);
+      xmlr_float(node, "radar_res", player.radar_res);
 
       /* Time. */
       if (xml_isNode(node,"time")) {

--- a/src/player.h
+++ b/src/player.h
@@ -79,6 +79,7 @@ typedef struct Player_s {
    char *gui;        /**< Player's GUI. */
    int guiOverride;  /**< GUI is overridden (not default). */
    int favourite;    /**< Whether or not this ship is favourited. */
+   double radar_res;    /**< Player's radar resolution. */
 
    /* Player data. */
    PlayerFlags flags;/**< Player's flags. */


### PR DESCRIPTION
Two things that I have considered desirable for a long time now:
* radar resolution is saved in player data
* maximal radar resolution is much higher (300) which allows to see nearly any detected ship. Player will probably want to change between 100 and 300 depending on the situation.

Maybe later, we could add an option to automatically adapt the radar resolution depending on what object is targeted.