### PR TITLE
Fixed a bug where there is a missing character at the beginning of the line.

### DIFF
--- a/src/gui_omsg.c
+++ b/src/gui_omsg.c
@@ -109,7 +109,9 @@ static void omsg_setMsg( omsg_t *omsg, const char *msg )
    m  = 0;
    while (n < l) {
       s  = gl_printWidthForText( font, &msg[n], omsg_center_w, NULL );
-      n += s+1;
+      n += s;
+      if ((msg[n] == '\n') || (msg[n] == ' '))
+         n++; /* Skip "empty char". */
       m++;
    }
 
@@ -126,7 +128,9 @@ static void omsg_setMsg( omsg_t *omsg, const char *msg )
       s  = gl_printWidthForText( font, &msg[n], omsg_center_w, NULL );
       omsg->msg[m] = strndup( &msg[n], s );
       m++;
-      n += s+1;
+      n += s;
+      if ((msg[n] == '\n') || (msg[n] == ' '))
+         n++; /* Skip "empty char". */
    }
 }
 

--- a/src/gui_osd.c
+++ b/src/gui_osd.c
@@ -212,7 +212,9 @@ void osd_wordwrap( OSD_t* osd )
          array_push_back( &osd->items[i], chunk );
 
          /* Go to next line. */
-         n += s + 1;
+         n += s;
+         if ((osd->msg[i][n] == '\n') || (osd->msg[i][n] == ' '))
+            n++; /* Skip "empty char". */
       }
    }
 }

--- a/src/news.c
+++ b/src/news.c
@@ -348,7 +348,9 @@ void news_widget( unsigned int wid, int x, int y, int w, int h )
          array_push_back( &news_restores, restore );
       }
 
-      p += i + 1;    /* Move pointer. */
+      p += i;    /* Move pointer. */
+      if ((buf[p] == '\n') || (buf[p] == ' '))
+         p++; /* Skip "empty char". */
    }
    /* </load text> */
 


### PR DESCRIPTION
The text with no space, such as Japanese text, makes it wrap forcibly, and a character at the beginning of the next line is deleted in some texts.
This PR avoids to delete it.

I checked a news text and a mission objective in Japanese.