### PR TITLE
Fix a bug that causes invalid unicode characters.

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -1092,7 +1092,9 @@ int gl_printHeightRaw( const glFont *ft_font,
    p = 0;
    do {
       i = gl_printWidthForText( ft_font, &text[p], width, NULL );
-      p += i + 1;
+      p += i;
+      if ((text[p] == '\n') || (text[p] == ' ') || (text[p] == '\0'))
+         p++; /* Skip "empty char". */
       y += 1.5*(double)ft_font->h; /* move position down */
    } while (text[p-1] != '\0');
 


### PR DESCRIPTION
When a text is forcibly wrapped, it may cause an invalid unicode character.
This PR fixes it.

I checked the tutorial mission in Japanese and Naev showed no 'Warning: [font_makeChar]...' messages. (a82f1ca87eea15b96c1526a305c6a4f43fbeed34 printed "Warning: [font_makeChar] Font 'fonts/IBMPlexSansJP-Medium.otf' unicode character '0xfffff279' not found in font! Using missing glyph.")
