### PR TITLE
Fix a typo in the Proteron Derivative Fighter Bay.

### DIFF
--- a/dat/outfits/fighter_bays/proteron_derivative_fighter_bay.xml
+++ b/dat/outfits/fighter_bays/proteron_derivative_fighter_bay.xml
@@ -8,7 +8,7 @@
   <mass>300</mass>
   <price>1580000</price>
   <gfx_store>placeholder.webp</gfx_store>
-  <description>This fighter bay allows your ship to carry a triplet of Soromid Brigand class fighters. It comes with all the devices required for the maintenance and flight of the fighters.</description>
+  <description>This fighter bay allows your ship to carry a triplet of Proteron Derivative class fighters. It comes with all the devices required for the maintenance and flight of the fighters.</description>
   <cpu>-500</cpu>
  </general>
  <specific type="fighter bay" secondary="1">


### PR DESCRIPTION
This PR fixes a typo in the description of the Proteron Derivative Fighter Bay.