### PR TITLE
Newton aim

### DIFF
--- a/dat/outfits/launchers/teracom_banshee_launcher.xml
+++ b/dat/outfits/launchers/teracom_banshee_launcher.xml
@@ -27,7 +27,6 @@
   <duration blowup="shield">7</duration>
   <thrust>150</thrust>
   <speed>200</speed>
-  <speed_max>300</speed_max>
   <damage>
    <type>impact</type>
    <penetrate>60</penetrate>

--- a/dat/outfits/launchers/teracom_mace_launcher.xml
+++ b/dat/outfits/launchers/teracom_mace_launcher.xml
@@ -29,7 +29,6 @@ TeraCom's Mace launcher uses an advanced reload mechanism that allows the launch
   <duration blowup="armour">1.5</duration>
   <thrust>800</thrust>
   <speed>600</speed>
-  <speed_max>1200</speed_max>
   <damage>
    <type>impact</type>
    <penetrate>12</penetrate>

--- a/dat/outfits/launchers/unicorp_banshee_launcher.xml
+++ b/dat/outfits/launchers/unicorp_banshee_launcher.xml
@@ -27,7 +27,6 @@
   <duration blowup="shield">7</duration>
   <thrust>150</thrust>
   <speed>200</speed>
-  <speed_max>300</speed_max>
   <damage>
    <type>impact</type>
    <penetrate>60</penetrate>

--- a/dat/outfits/launchers/unicorp_mace_launcher.xml
+++ b/dat/outfits/launchers/unicorp_mace_launcher.xml
@@ -27,7 +27,6 @@
   <duration blowup="armour">1.5</duration>
   <thrust>800</thrust>
   <speed>600</speed>
-  <speed_max>1200</speed_max>
   <damage>
    <type>impact</type>
    <penetrate>12</penetrate>

--- a/src/ai.c
+++ b/src/ai.c
@@ -2749,6 +2749,9 @@ static int aiL_setasterotarget( lua_State *L )
    cur_pilot->nav_anchor = field;
    cur_pilot->nav_asteroid = ast;
 
+   /* Untarget pilot. */
+   cur_pilot->target = cur_pilot->id;
+
    return 0;
 }
 

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -1620,6 +1620,8 @@ static void outfit_parseSLauncher( Outfit* temp, const xmlNodePtr parent )
    temp->u.lau.turn *= M_PI/180.; /* Convert to rad/s. */
    if (temp->u.lau.speed_max < 0.)
       temp->u.lau.speed_max = temp->u.lau.speed;
+   else if (temp->u.lau.speed > 0. && temp->u.lau.thrust > 0.) /* Condition for not taking max_speed into account. */
+      WARN(_("Max speed of ammo '%s' will be ignored."), temp->name);
    temp->u.lau.resist /= 100.;
 
    /* Set default outfit size if necessary. */

--- a/src/outfit.c
+++ b/src/outfit.c
@@ -707,7 +707,11 @@ double outfit_range( const Outfit* o )
       return o->u.bem.range;
    else if (outfit_isLauncher(o)) {
       if (o->u.lau.thrust) {
-         double speedinc = o->u.lau.speed_max - o->u.lau.speed;
+         double speedinc;
+         if (o->u.lau.speed > 0.) /* Ammo that don't start stopped don't have max speed. */
+            speedinc = INFINITY;
+         else
+            speedinc = o->u.lau.speed_max - o->u.lau.speed;
          double at = speedinc / o->u.lau.thrust;
          if (at < o->u.lau.duration)
             return speedinc * (o->u.lau.duration - at / 2.) + o->u.lau.speed * o->u.lau.duration;
@@ -734,7 +738,12 @@ double outfit_speed( const Outfit* o )
       if (o->u.lau.thrust == 0.)
          return o->u.lau.speed;
       else { /* Gets the average speed. */
-         double t = (o->u.lau.speed_max - o->u.lau.speed) / o->u.lau.thrust; /* Time to reach max speed */
+         double t;
+         if (o->u.lau.speed > 0.) /* Ammo that don't start stopped don't have max speed. */
+            t = INFINITY;
+         else
+            t = (o->u.lau.speed_max - o->u.lau.speed) / o->u.lau.thrust; /* Time to reach max speed */
+
          /* Reaches max speed. */
          if (t < o->u.lau.duration)
             return (o->u.lau.thrust * t * t / 2. + (o->u.lau.speed_max - o->u.lau.speed) * (o->u.lau.duration - t)) / o->u.lau.duration + o->u.lau.speed;
@@ -1666,7 +1675,8 @@ static void outfit_parseSLauncher( Outfit* temp, const xmlNodePtr parent )
    }
    else
       SDESC_COND( l, temp, _("\n%.0f Speed"), temp->u.lau.speed );
-   SDESC_ADD(  l, temp, _("\n%.0f Maximum Speed"), temp->u.lau.speed_max );
+   if (!(temp->u.lau.thrust > 0. && temp->u.lau.speed > 0.))
+      SDESC_ADD(  l, temp, _("\n%.0f Maximum Speed"), temp->u.lau.speed_max );
    SDESC_ADD(  l, temp, _("\n%.1f Seconds to Reload"), temp->u.lau.reload_time );
    SDESC_COND( l, temp, _("\n%.1f EPS [%.0f Energy]"), temp->u.lau.delay * temp->u.lau.energy, temp->u.lau.energy );
    SDESC_COND( l, temp, _("\n%.0f%% Jam Resistance"), temp->u.lau.resist * 100. );

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -1382,6 +1382,10 @@ void pilot_setTarget( Pilot* p, unsigned int id )
 
    /* Set the scan timer. */
    pilot_ewScanStart( p );
+
+   /* Untarget asteroid (if any). */
+   p->nav_anchor   = -1;
+   p->nav_asteroid = -1;
 }
 
 /**

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -1015,12 +1015,14 @@ static int pilot_shootWeapon( Pilot *p, PilotOutfitSlot *w, double time )
 
    /* Get weapon mount position. */
    pilot_getMount( p, w, &vp );
-   vp.x += p->solid->pos.x;
-   vp.y += p->solid->pos.y;
 
    /* Modify velocity to take into account the rotation. */
-   vect_cset( &vv, p->solid->vel.x + vp.x*p->solid->dir_vel,
-         p->solid->vel.y + vp.y*p->solid->dir_vel );
+   vect_cset( &vv, p->solid->vel.x - vp.y*p->solid->dir_vel,
+         p->solid->vel.y + vp.x*p->solid->dir_vel );
+
+   /* Get absolute weapon mount position. */
+   vp.x += p->solid->pos.x;
+   vp.y += p->solid->pos.y;
 
    /*
     * regular bolt weapons
@@ -1039,7 +1041,7 @@ static int pilot_shootWeapon( Pilot *p, PilotOutfitSlot *w, double time )
       p->energy  -= energy;
       pilot_heatAddSlot( p, w );
       weapon_add( w, w->heat_T, p->solid->dir,
-            &vp, &p->solid->vel, p, p->target, time );
+            &vp, &vv, p, p->target, time );
    }
 
    /*
@@ -1097,7 +1099,7 @@ static int pilot_shootWeapon( Pilot *p, PilotOutfitSlot *w, double time )
       p->energy  -= energy;
       pilot_heatAddSlot( p, w );
       weapon_add( w, w->heat_T, p->solid->dir,
-            &vp, &p->solid->vel, p, p->target, time );
+            &vp, &vv, p, p->target, time );
 
       pilot_rmAmmo( p, w, 1 );
 

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -119,10 +119,10 @@ static int pilot_weapSetFire( Pilot *p, PilotWeaponSet *ws, int level )
       if (pt != NULL)
          time = pilot_weapFlyTime( o, p, &pt->solid->pos, &pt->solid->vel);
       /* Looking for a closer targeted asteroid */
-      if (p->nav_asteroid != -1) {
+      else if (p->nav_asteroid != -1) {
          field = &cur_system->asteroids[p->nav_anchor];
          ast = &field->asteroids[p->nav_asteroid];
-         time = MIN( time, pilot_weapFlyTime( o, p, &ast->pos, &ast->vel) );
+         time = pilot_weapFlyTime( o, p, &ast->pos, &ast->vel);
       }
 
       /* Only "inrange" outfits. */
@@ -834,7 +834,7 @@ void pilot_stopBeam( Pilot *p, PilotOutfitSlot *w )
  *
  *    @param o the weapon to shoot.
  *    @param parent Parent of the weapon.
- *    @param pos Target of the weapon.
+ *    @param pos Target's position.
  *    @param vel Target's velocity.
  */
 double pilot_weapFlyTime( const Outfit *o, const Pilot *parent, const Vector2d *pos, const Vector2d *vel )

--- a/src/player.c
+++ b/src/player.c
@@ -1476,6 +1476,9 @@ void player_targetAsteroidSet( int field, int id )
    }
 
    player.p->nav_anchor = field;
+
+   /* Untarget pilot. */
+   player.p->target = player.p->id;
 }
 
 /**

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -116,6 +116,8 @@ static void weapon_createAmmo( Weapon *w, const Outfit* outfit, double T,
 static Weapon* weapon_create( PilotOutfitSlot* po, double T,
       const double dir, const Vector2d* pos, const Vector2d* vel,
       const Pilot *parent, const unsigned int target, double time );
+static double weapon_computeTimes( double rdir, double rx, double ry, double dvx, double dvy, double pxv,
+      double vmin, double acc, double *tt );
 /* Updating. */
 static void weapon_render( Weapon* w, const double dt );
 static void weapons_updateLayer( const double dt, const WeaponLayer layer );
@@ -1406,7 +1408,10 @@ static double weapon_aimTurret( const Outfit *outfit, const Pilot *parent,
    Vector2d *target_vel;
    double rdir;
    double rx, ry, x, y, t;
-   double off;
+   double off, dvx, dvy;
+   double vmin;
+   int i, niter;
+   double tt, ddir, dtdd, acc, pxv, ang, d, dd;
 
    if (pilot_target != NULL) {
       target_pos = &pilot_target->solid->pos;
@@ -1448,6 +1453,49 @@ static double weapon_aimTurret( const Outfit *outfit, const Pilot *parent,
    }
    rdir     = ANGLE(x,y);
 
+   /* For unguided rockets: use a FD quasi-Newton algorithm to aim better. */
+   if (outfit_isLauncher(outfit) && outfit->u.lau.ai == AMMO_AI_UNGUIDED) {
+      vmin  = outfit->u.lau.speed;
+
+      if ( vmin > 0. ) {
+         /* Get various details. */
+         acc   = outfit->u.lau.thrust;
+         niter = 5;
+
+         /* Get the relative velocity. */
+         dvx = target_vel->x - vel->x;
+         dvy = target_vel->y - vel->y;
+
+         /* Cross product between position and vel. */
+         /* For having a better conditionning, ddir is adapted to the angular difference. */
+         pxv = rx*dvy - ry*dvx;
+         ang = atan2( pxv, rx*dvx+ry*dvy ); /*Angle between position and velocity. */         
+         if (fabs(ang + M_PI) < fabs(ang)) ang = ang + M_PI; /* Periodicity tricks. */
+         else if (fabs(ang - M_PI) < fabs(ang)) ang = ang-+ M_PI;
+         ddir = -ang/1000;
+
+         /* Iterate to correct the initial guess rdir. */
+         /* We compute more precisely ta and tt. */
+         /* (times for the ammo and the target to get to intersection point) */
+         /* The aim is to nullify ta-tt. */
+         if (fabs(ang) > 1e-7) { /* No need to iterate if it's already nearly aligned. */
+            for (i=0; i<niter; i++) {
+               d  = weapon_computeTimes( rdir, rx, ry, dvx, dvy, pxv, vmin, acc, &tt );
+               dd = weapon_computeTimes( rdir+ddir, rx, ry, dvx, dvy, pxv, vmin, acc, &tt );
+
+               /* Manage an exception (tt<0), and regular stopping condition. */
+               /* TODO: this stopping criterion is too restrictive. */
+               /* (for example when pos and vel are nearly aligned). */
+               if ( tt < 0. || fabs(d) < 5. )
+                  break;
+
+               dtdd = (dd-d)/ddir; /* Derivative of the criterion wrt. rdir. */
+               rdir = rdir - d/dtdd; /* Update. */
+            }
+         }
+      }
+   }
+
    /* Calculate bounds. */
    off = angle_diff( rdir, dir );
    if (FABS(off) > swivel) {
@@ -1461,14 +1509,47 @@ static double weapon_aimTurret( const Outfit *outfit, const Pilot *parent,
 }
 
 /**
+ * @brief Computes precisely interception times for propelled weapons (rockets).
+ *
+ *    @param rdir tried shooting angle.
+ *    @param rx Relative position x.
+ *    @param ry Relative position y.
+ *    @param dvx Relative velocity x.
+ *    @param dvy Relative velocity y.
+ *    @param pxv Cross product between relative position and relative velocity
+ *    @param vmin min ammo velocity.
+ *    @param acc ammo acceleration.
+ *    @param[out] tt Time for the target to reach the interception point.
+ */
+static double weapon_computeTimes( double rdir, double rx, double ry, double dvx, double dvy, double pxv,
+      double vmin, double acc, double *tt )
+{
+   double l, dxv, dxp, ct, st, d;
+
+   /* Trigonometry. */
+   ct = cos(rdir); st = sin(rdir);
+   
+   /* Two extra cross products. */
+   dxv = ct*dvy - st*dvx;
+   dxp = ct*ry  - st*rx;
+
+   /* Compute criterion. */
+   *tt = -dxp/dxv; /* Time to interception for target. Because triangle aera. */
+   l = pxv/dxv; /* Length to interception for shooter. Because triangle aera. */
+   d = .5*acc*(*tt)*(*tt) + vmin*(*tt); /* Estimate how far the projectile went. */
+
+   return (d-l); /* Criterion is distance of projectile to intersection when target is there. */
+}
+
+/**
  * @brief Creates the bolt specific properties of a weapon.
  *
  *    @param w Weapon to create bolt specific properties of.
  *    @param outfit Outfit which spawned the weapon.
  *    @param T temperature of the shooter.
  *    @param dir Direction the shooter is facing.
- *    @param pos Position of the shooter.
- *    @param vel Velocity of the shooter.
+ *    @param pos Position of the slot (absolute).
+ *    @param vel Velocity of the slot (absolute).
  *    @param parent Shooter.
  *    @param time Expected flight time.
  */
@@ -1536,8 +1617,8 @@ static void weapon_createBolt( Weapon *w, const Outfit* outfit, double T,
  *    @param launcher Outfit which spawned the weapon.
  *    @param T temperature of the shooter.
  *    @param dir Direction the shooter is facing.
- *    @param pos Position of the shooter.
- *    @param vel Velocity of the shooter.
+ *    @param pos Position of the slot (absolute).
+ *    @param vel Velocity of the slot (absolute).
  *    @param parent Shooter.
  *    @param time Expected flight time.
  */
@@ -1589,7 +1670,7 @@ static void weapon_createAmmo( Weapon *w, const Outfit* launcher, double T,
       /* Limit speed, we only relativize in the case it has thrust + initila speed. */
       w->solid->speed_max = w->outfit->u.lau.speed_max;
       if (w->outfit->u.lau.speed > 0.)
-         w->solid->speed_max += VMOD(*vel);
+         w->solid->speed_max += VMOD(*vel); /* TODO: this is odd. */
    }
 
    /* Handle seekers. */
@@ -1632,8 +1713,8 @@ static void weapon_createAmmo( Weapon *w, const Outfit* launcher, double T,
  *    @param po Outfit slot which spawned the weapon.
  *    @param T temperature of the shooter.
  *    @param dir Direction the shooter is facing.
- *    @param pos Position of the shooter.
- *    @param vel Velocity of the shooter.
+ *    @param pos Position of the slot (absolute).
+ *    @param vel Velocity of the slot (absolute).
  *    @param parent Shooter.
  *    @param target Target ID of the shooter.
  *    @param time Expected flight time.
@@ -1749,8 +1830,8 @@ static Weapon* weapon_create( PilotOutfitSlot *po, double T,
  *    @param po Outfit slot which spawns the weapon.
  *    @param T Temperature of the shooter.
  *    @param dir Direction of the shooter.
- *    @param pos Position of the shooter.
- *    @param vel Velocity of the shooter.
+ *    @param pos Position of the slot (absolute).
+ *    @param vel Velocity of the slot (absolute).
  *    @param parent Pilot ID of the shooter.
  *    @param target Target ID that is getting shot.
  *    @param time Expected flight time.
@@ -1805,8 +1886,8 @@ void weapon_add( PilotOutfitSlot *po, const double T, const double dir,
  *
  *    @param po Outfit slot which spawns the weapon.
  *    @param dir Direction of the shooter.
- *    @param pos Position of the shooter.
- *    @param vel Velocity of the shooter.
+ *    @param pos Position of the slot (absolute).
+ *    @param vel Velocity of the slot (absolute).
  *    @param parent Pilot shooter.
  *    @param target Target ID that is getting shot.
  *    @return The identifier of the beam weapon.

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1454,7 +1454,7 @@ static double weapon_aimTurret( const Outfit *outfit, const Pilot *parent,
    rdir     = ANGLE(x,y);
 
    /* For unguided rockets: use a FD quasi-Newton algorithm to aim better. */
-   if (outfit_isLauncher(outfit) && outfit->u.lau.ai == AMMO_AI_UNGUIDED) {
+   if (outfit_isLauncher(outfit) && outfit->u.lau.thrust > 0.) {
       vmin  = outfit->u.lau.speed;
 
       if ( vmin > 0. ) {
@@ -1670,7 +1670,7 @@ static void weapon_createAmmo( Weapon *w, const Outfit* launcher, double T,
       /* Limit speed, we only relativize in the case it has thrust + initila speed. */
       w->solid->speed_max = w->outfit->u.lau.speed_max;
       if (w->outfit->u.lau.speed > 0.)
-         w->solid->speed_max += VMOD(*vel); /* TODO: this is odd. */
+         w->solid->speed_max = -1; /* No limit. */
    }
 
    /* Handle seekers. */


### PR DESCRIPTION
Four changes (separated into commits) :
* asteroid or pilot targetting is exclusive (to avoid accidents when mining)
* solved an error in the engine (speed induced by rotation was computed (wrongly), and not added to the ammo). This nearly changes nothing.
* Main contribution, that motivated the other ones : AI is now able to aim unguided rockets perfectly (but of course this is still modulated by tracking)
* rockets physics was not the one we thought it was, so I kept how it works now, but made it explicit.