### PR TITLE
Changes to bays and docks

### DIFF
--- a/dat/outfits/fighter_bays/hyena_fighter_dockk.xml
+++ b/dat/outfits/fighter_bays/hyena_fighter_dockk.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<outfit name="Hyena Fighter Bay">
+<outfit name="Hyena Fighter Dock">
  <general>
   <slot prop="fighter_bay">weapon</slot>
   <size>medium</size>


### PR DESCRIPTION
currently broken after trying to squash all the commits into one


I'll add my explanation here for those who didn't see it in discord:
I found the current naming scheme for fighter bays/docks to be rather backwards. The name for the medium outfits was ~~"Docks"~~ "Bay" (see, I'm still getting confused) and the name for the large outfits was "Dock."
Large ships have quite a lot of space inside, so why bother holding the fighters on the outside when you could have them in a convenient bay on the inside of the ship?
On the flip side, medium ships don't have as much space as large ships do, so it would make more sense to dock the fighters on the outside of the ship instead of storing them on the inside. (How else am I going to fit 1000+ tons of hot dogs in a mule?)

After some discussion in Discord, bobbens suggested removing the "Fighter" from the names of the outfits along with the idea of "Bays"/"Mini Bays" for Za'lek drones, so I added that in this pull request too.

I've also updated the descriptions of the Za'lek drone bays to be more similar to its large/medium counterpart. This wasn't as necessary and I'm not so sure I did that good of a job with it, so feel free to dump that part.

Also with the drone descriptions, I've added the tidbit that tells you that the bays have everything you need to maintain and fly the drones. Other bays/docks had that bit, so I figured the Zal'ek ones could use it too.