### PR TITLE
CPU buff to the Za'lek Heavy Drone Mini Bay

### DIFF
--- a/dat/outfits/fighter_bays/zalek_heavy_drone_mini_bay.xml
+++ b/dat/outfits/fighter_bays/zalek_heavy_drone_mini_bay.xml
@@ -11,7 +11,7 @@
   <price>1100000</price>
   <gfx_store>zalek_drone_heavy_fighter.webp</gfx_store>
   <description>This bay can launch three heavy drones, giving the mothership a good deal of punch. It comes with all the devices required for the maintenance and flight of the drones.</description>
-  <cpu>-200</cpu>
+  <cpu>-155</cpu>
  </general>
  <specific type="fighter bay" secondary="1">
   <delay>5</delay>


### PR DESCRIPTION
Changed CPU requirement from -200 to -155. The reason for this is so that you can use two of them on Za'lek's medium ships with the medium-heavy core systems and in some cases, a cpu modification outfit.

The Za'lek Demon just barely squeaks in with the right outfits. 
Example: As long as you have the Left Boot and a Milspec Thalos 5402 Core System, you can use two of these bays at -155 CPU and two -75 CPU large weapons (e.g. Grave Beam) with only 2 cpu to spare.

The Za'lek Sting has a lot more "elbow room," so to speak, due to only having medium and small weapon slots.
Example 1: If you have a Thalos 5402, you can use two of these mini bays, a -50 CPU medium weapon (e.g. Grave Lance), and two -24 CPU small weapons (e.g. Orion Lance or Laser Turret MK1).
Example 2: If you have a Milspec Orion 5501 Core System and the Left Boot, you can use two of these mini bays, a -50 CPU medium weapon (e.g. Grave Lance), and two ultralight weapons (e.g. Particle Lance or Neutron Disruptor).