### PR TITLE
A couple updated descriptions.

### DIFF
--- a/dat/outfits/utility/emergency_stasis_inducer.xml
+++ b/dat/outfits/utility/emergency_stasis_inducer.xml
@@ -6,7 +6,7 @@
   <size>small</size>
   <mass>2</mass>
   <price>400000</price>
-  <description>The emergency stasis inducer works by creating a strong electromagnetic field around the ship, making it seem like time slows down for everything outside of the field, thus excluding the triggering ship. The mechanism is triggered automatically upon armour damage, without need of manual intervention. It is not entirely clear how this effect is created, however, doctors do not recommend prolonged usage.</description>
+  <description>The emergency stasis inducer works by creating a strong electromagnetic field around the ship, making time appear to move slower than normal for everything outside the ship while also causing the ship and all its equipment and activities to speed up. This allows you to move faster and do far more damage than normal. The mechanism is triggered automatically upon armour damage, without need of manual intervention. It is not entirely clear how this effect is created, however, doctors do not recommend prolonged usage.</description>
   <desc_extra>Triggered on armour damage. Lasts 3 seconds with 8 seconds cooldown.</desc_extra>
   <gfx_store>emergency_stasis_inducer.webp</gfx_store>
   <limit>emergency_stasis_inducer</limit>

--- a/dat/ships/admonisher.xml
+++ b/dat/ships/admonisher.xml
@@ -16,7 +16,7 @@
  <trail_generator x="-20" y="-5" h="-5" always_under="1" />
  <fabricator>Nexus Shipyards</fabricator>
  <license>Medium Combat Vessel</license>
- <description>A very versatile combat ship. Nexus defines the Admonisher as a compromise between the ruggedness of the Pacifier and the agility of the Lancelot. Overall a very solid fighter.</description>
+ <description>A very versatile combat ship. Nexus defines the Admonisher as a compromise between the ruggedness of the Pacifier and the agility of the Lancelot. Overall a very solid combat ship.</description>
  <health>
   <armour>220</armour>
   <armour_regen>0</armour_regen>


### PR DESCRIPTION
Emergency Stasis Inducer's description should be a bit more clear now.

Changed "fighter" to "combat ship" because the Admonisher is not a fighter.