### PR TITLE
CPU Modification Outfits

### DIFF
--- a/dat/outfits/structure/auxiliary_processing_unit_i.xml
+++ b/dat/outfits/structure/auxiliary_processing_unit_i.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Auxiliary Proccessing Unit I">
+ <general>
+  <typename>CPU Modifier</typename>
+  <slot>structure</slot>
+  <size>small</size>
+  <mass>15</mass>
+  <price>20000</price>
+  <description>An additional proccessing unit to supplement the main processor of the core system, giving small ships a little more processing power.</description>
+  <gfx_store>placeholder.webp</gfx_store>
+  <cpu>5</cpu>
+ </general>
+ <specific type="modification">
+  <energy_regen_malus>4</energy_regen_malus>
+ </specific>
+</outfit>

--- a/dat/outfits/structure/auxiliary_processing_unit_ii.xml
+++ b/dat/outfits/structure/auxiliary_processing_unit_ii.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Auxiliary Proccessing Unit II">
+ <general>
+  <typename>CPU Modifier</typename>
+  <slot>structure</slot>
+  <size>medium</size>
+  <mass>30</mass>
+  <price>60000</price>
+  <description>An additional proccessing unit to supplement the main processor of the core system, giving medium ships a little more processing power.</description>
+  <gfx_store>placeholder.webp</gfx_store>
+  <cpu>20</cpu>
+ </general>
+ <specific type="modification">
+  <energy_regen_malus>8</energy_regen_malus>
+ </specific>
+</outfit>

--- a/dat/outfits/structure/auxiliary_processing_unit_iii.xml
+++ b/dat/outfits/structure/auxiliary_processing_unit_iii.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Auxiliary Proccessing Unit III">
+ <general>
+  <typename>CPU Modifier</typename>
+  <slot>structure</slot>
+  <size>large</size>
+  <mass>60</mass>
+  <price>180000</price>
+  <description>An additional proccessing unit to supplement the main processor of the core system, giving large ships a little more processing power.</description>
+  <gfx_store>placeholder.webp</gfx_store>
+  <cpu>60</cpu>
+ </general>
+ <specific type="modification">
+  <energy_regen_malus>16</energy_regen_malus>
+ </specific>
+</outfit>

--- a/dat/outfits/structure/auxiliary_processing_unit_iv.xml
+++ b/dat/outfits/structure/auxiliary_processing_unit_iv.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Auxiliary Proccessing Unit IV">
+ <general>
+  <typename>CPU Modifier</typename>
+  <slot>structure</slot>
+  <size>large</size>
+  <mass>120</mass>
+  <price>540000</price>
+  <description>An additional proccessing unit to supplement the main processor of the core system, giving capital ships a little more processing power.</description>
+  <gfx_store>placeholder.webp</gfx_store>
+  <cpu>120</cpu>
+ </general>
+ <specific type="modification">
+  <energy_regen_malus>32</energy_regen_malus>
+ </specific>
+</outfit>

--- a/dat/outfits/utility/combatai/efficiency_combat_ai.xml
+++ b/dat/outfits/utility/combatai/efficiency_combat_ai.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Efficiency Combat AI">
+ <general>
+  <typename>Combat AI</typename>
+  <slot>utility</slot>
+  <size>medium</size>
+  <rarity>1</rarity>
+  <license>Heavy Weapon</license>
+  <mass>0</mass>
+  <price>850000</price>
+  <description>This Combat AI utilizes advanced energy routing to make the ship's computing power more efficient, allowing more power to be packed into the same energy usage.</description>
+  <gfx_store>placeholder.webp</gfx_store>
+  <limit>combatai</limit>
+ </general>
+ <specific type="modification">
+  <cpu_mod>5</cpu_mod>
+ </specific>
+</outfit>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -541,6 +541,8 @@
   <item>Mercenary License</item>
  </tech>
  <tech name="High Tech Upgrades 1">
+  <item>Auxiliary Proccessing Unit I</item>
+  <item>Auxiliary Proccessing Unit II</item>
   <item>Battery I</item>
   <item>Battery II</item>
   <item>Reactor Class I</item>
@@ -568,12 +570,15 @@
   <item>Emergency Shield Booster</item>
   <item>Asteroid Scanner</item>
   <item>Agility Combat AI</item>
+  <item>Efficiency Combat AI</item>
   <item>Boarding Androids MK1</item>
   <item>Targeting Conduit</item>
   <item>Blink Drive</item>
   <item>Cryogenic Repair Nanobots</item>
  </tech>
  <tech name="High Tech Upgrades 2">
+  <item>Auxiliary Proccessing Unit III</item>
+  <item>Auxiliary Proccessing Unit IV</item>
   <item>Battery III</item>
   <item>Battery IV</item>
   <item>Reactor Class II</item>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -235,6 +235,7 @@
   <item>Nexus Stealth Coating</item>
   <item>Photo-Voltaic Nanobot Coating</item>
   <item>Nebula Resistant Coating</item>
+  <item>Efficiency Combat AI</item>
   <item>Bio-Neural Combat AI</item>
   <item>Cyclic Combat AI</item>
   <item>Hive Combat AI</item>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -77,6 +77,10 @@
   <item>Shield Capacitor II</item>
   <item>Shield Capacitor III</item>
   <item>Shield Capacitor IV</item>
+  <item>Auxiliary Proccessing Unit I</item>
+  <item>Auxiliary Proccessing Unit II</item>
+  <item>Auxiliary Proccessing Unit III</item>
+  <item>Auxiliary Proccessing Unit IV</item>
   <item>Small Shield Booster</item>
   <item>Medium Shield Booster</item>
   <item>Large Shield Booster</item>


### PR DESCRIPTION
I've added some outfits that increase ships' CPU capacity since I saw that nothing but the Left Boot did that:

Efficiency Combat AI: Medium utility, requires heavy weapon license, only one combat ai per ship etc. same as the other Combat AIs. This provides a 5% increase in CPU capacity. If that proves to be too much, it could be nerfed down to 4% or 3%.
If "Efficiency" turns our to be an unsuitable name, we could use some variation of "Overclock" instead. 

Auxiliary Processing Units: Structure outfits that provide a set amount of CPU capacity at the cost of mass and energy. Comparable to Shield Capacitors and Batteries. If we wanted to make the graphics relatively simple, we could reuse the graphics from those with some different colors and call these something like "Advanced Processor Capacitors" instead.

Please don't mind the extra commits of me merging stuff into main.