### PR TITLE
Changed how the Schroedinger does fuel a bit

### DIFF
--- a/dat/ships/schroedinger.xml
+++ b/dat/ships/schroedinger.xml
@@ -21,8 +21,8 @@
  <characteristics>
   <crew>2</crew>
   <mass>20</mass>
-  <fuel>800</fuel>
-  <fuel_consumption>100</fuel_consumption>
+  <fuel>150</fuel>
+  <fuel_consumption>50</fuel_consumption>
   <cargo>5</cargo>
  </characteristics>
  <slots>


### PR DESCRIPTION
This is based on an idea @nenau-again mentioned in Discord. Link to the conversation for those in the server: https://discord.com/channels/661743268505190400/772643725255245875/939522574050787358

The idea was to have the Schroedinger fuel use lowered to 50 per jump and have the base fuel bonus reduced as well. The reason I've reduced the bonus so much (800 to 150) is because the amount of fuel that the engines give also doubles. With a Tricon engine, you'd still get 9 jumps; only two less than before. If you use a fuel pod with a Tricon engine, then you get the same amount as before: 13 jumps.

The maximum amount you can get (achieved by using a Mendelez engine and a fuel pod) is 17 jumps, only two more than the previous maximum. The minimum amount is 7, three less than the previous minimum, but who's going to be using a beat up engine, anyways?