### PR TITLE
Added three new ship variants

### DIFF
--- a/dat/ships/alpaca.xml
+++ b/dat/ships/alpaca.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ship name="Llama">
+ <points>20</points>
+ <base_type>Llama</base_type>
+ <GFX size="47">llama</GFX>
+ <GUI>brushed</GUI>
+ <sound>engine</sound>
+ <class>Yacht</class>
+ <price>120000</price>
+ <time_mod>1</time_mod>
+ <trail_generator x="-12" y="-16" h="-2">nebula</trail_generator>
+ <trail_generator x="-12" y="16" h="-2">nebula</trail_generator>
+ <trail_generator x="-12" y="-6" h="0">fire-thin</trail_generator>
+ <trail_generator x="-12" y="0" h="0">fire-thin</trail_generator>
+ <trail_generator x="-12" y="6" h="0">fire-thin</trail_generator>
+ <fabricator>Melendez Corp.</fabricator>
+ <description>One of the most widely used ships in the galaxy. Renowned for its stability and stubbornness. The design hasn't been modified much since its creation many, many cycles ago. It was one of the first civilian use spacecrafts, first used by aristocracy and now used by everyone who cannot afford better.</description>
+ <characteristics>
+  <crew>2</crew>
+  <mass>80</mass>
+  <fuel_consumption>100</fuel_consumption>
+  <cargo>15</cargo>
+ </characteristics>
+ <health>
+  <armour>25</armour>
+  <armour_regen>0</armour_regen>
+ </health>
+ <slots>
+  <weapon size="small" x="7" y="0" h="1" />
+  <weapon size="small" x="-3" y="0" h="2" />
+  <utility size="small" prop="systems">Unicorp PT-16 Core System</utility>
+  <utility size="small" prop="accessory" />
+  <utility size="small" />
+  <utility size="small" />
+  <structure size="small" prop="engines">Nexus Dart 150 Engine</structure>
+  <structure size="small" prop="hull">Unicorp D-2 Light Plating</structure>
+  <structure size="small" />
+  <structure size="small" />
+ </slots>
+ <stats>
+  <turn_mod>-20</turn_mod>
+  <speed_mod>-10</speed_mod>
+  <turn_mod>-10</turn_mod>
+  <cargo_mod>20</cargo_mod>
+  <armour_mod>10</armour_mod>
+  <cargo_inertia>-20</cargo_inertia>
+  <ew_hide>-10</ew_hide>
+ </stats>
+ <tags>
+  <tag>standard</tag>
+  <tag>transport</tag>
+ </tags>
+</ship>

--- a/dat/ships/guanaco.xml
+++ b/dat/ships/guanaco.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ship name="Llama">
+ <points>20</points>
+ <base_type>Llama</base_type>
+ <GFX size="47">llama</GFX>
+ <GUI>brushed</GUI>
+ <sound>engine</sound>
+ <class>Yacht</class>
+ <price>120000</price>
+ <time_mod>1</time_mod>
+ <trail_generator x="-12" y="-16" h="-2">nebula</trail_generator>
+ <trail_generator x="-12" y="16" h="-2">nebula</trail_generator>
+ <trail_generator x="-12" y="-6" h="0">fire-thin</trail_generator>
+ <trail_generator x="-12" y="0" h="0">fire-thin</trail_generator>
+ <trail_generator x="-12" y="6" h="0">fire-thin</trail_generator>
+ <fabricator>Melendez Corp.</fabricator>
+ <description>One of the most widely used ships in the galaxy. Renowned for its stability and stubbornness. The design hasn't been modified much since its creation many, many cycles ago. It was one of the first civilian use spacecrafts, first used by aristocracy and now used by everyone who cannot afford better.</description>
+ <characteristics>
+  <crew>2</crew>
+  <mass>80</mass>
+  <fuel_consumption>100</fuel_consumption>
+  <cargo>15</cargo>
+ </characteristics>
+ <health>
+  <armour>25</armour>
+  <armour_regen>0</armour_regen>
+ </health>
+ <slots>
+  <weapon size="small" x="7" y="0" h="1" />
+  <weapon size="small" x="-3" y="0" h="2" />
+  <utility size="small" prop="systems">Unicorp PT-16 Core System</utility>
+  <utility size="small" prop="accessory" />
+  <utility size="small" />
+  <utility size="small" />
+  <structure size="small" prop="engines">Nexus Dart 150 Engine</structure>
+  <structure size="small" prop="hull">Unicorp D-2 Light Plating</structure>
+  <structure size="small" />
+  <structure size="small" />
+ </slots>
+ <stats>
+  <turn_mod>-20</turn_mod>
+  <speed_mod>-10</speed_mod>
+  <turn_mod>-10</turn_mod>
+  <cargo_mod>20</cargo_mod>
+  <armour_mod>10</armour_mod>
+  <cargo_inertia>-20</cargo_inertia>
+  <ew_hide>-10</ew_hide>
+ </stats>
+ <tags>
+  <tag>standard</tag>
+  <tag>transport</tag>
+ </tags>
+</ship>

--- a/dat/ships/vicuna.xml
+++ b/dat/ships/vicuna.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ship name="Llama">
+ <points>20</points>
+ <base_type>Llama</base_type>
+ <GFX size="47">llama</GFX>
+ <GUI>brushed</GUI>
+ <sound>engine</sound>
+ <class>Yacht</class>
+ <price>120000</price>
+ <time_mod>1</time_mod>
+ <trail_generator x="-12" y="-16" h="-2">nebula</trail_generator>
+ <trail_generator x="-12" y="16" h="-2">nebula</trail_generator>
+ <trail_generator x="-12" y="-6" h="0">fire-thin</trail_generator>
+ <trail_generator x="-12" y="0" h="0">fire-thin</trail_generator>
+ <trail_generator x="-12" y="6" h="0">fire-thin</trail_generator>
+ <fabricator>Melendez Corp.</fabricator>
+ <description>One of the most widely used ships in the galaxy. Renowned for its stability and stubbornness. The design hasn't been modified much since its creation many, many cycles ago. It was one of the first civilian use spacecrafts, first used by aristocracy and now used by everyone who cannot afford better.</description>
+ <characteristics>
+  <crew>2</crew>
+  <mass>80</mass>
+  <fuel_consumption>100</fuel_consumption>
+  <cargo>15</cargo>
+ </characteristics>
+ <health>
+  <armour>25</armour>
+  <armour_regen>0</armour_regen>
+ </health>
+ <slots>
+  <weapon size="small" x="7" y="0" h="1" />
+  <weapon size="small" x="-3" y="0" h="2" />
+  <utility size="small" prop="systems">Unicorp PT-16 Core System</utility>
+  <utility size="small" prop="accessory" />
+  <utility size="small" />
+  <utility size="small" />
+  <structure size="small" prop="engines">Nexus Dart 150 Engine</structure>
+  <structure size="small" prop="hull">Unicorp D-2 Light Plating</structure>
+  <structure size="small" />
+  <structure size="small" />
+ </slots>
+ <stats>
+  <turn_mod>-20</turn_mod>
+  <speed_mod>-10</speed_mod>
+  <turn_mod>-10</turn_mod>
+  <cargo_mod>20</cargo_mod>
+  <armour_mod>10</armour_mod>
+  <cargo_inertia>-20</cargo_inertia>
+  <ew_hide>-10</ew_hide>
+ </stats>
+ <tags>
+  <tag>standard</tag>
+  <tag>transport</tag>
+ </tags>
+</ship>


### PR DESCRIPTION
Added the Alpaca, Guanaco and Vicuna ... little acknowledged but common variants of the Llama.

The intention is to add Llama mk IIs, mk IIIs and mk IVs with the same spite (at least for now) as varients of the Llama to add a little varienty into this venerable ship that must have, similar to the AK, spawned many varients that are all but the same but with their own tweeks depending on the reagion of space you find them... I figureed the Dvaered could be a little tougher, the Sirian have a little better electronics and the Frontier have a little more protection and leasve the original Llamas as the predominent in the Empire.

None of the above would replace each other in each space, they would just split the frequency between them... thoughts?

Do we already have a way to do this more simply than adding new ships?

P.S. The three files here are currently just identical copies of the Llama and are here to create the pull request as much as anything! :)