### PR TITLE
Added logging and shipai cameos to derelict events and missions

### DIFF
--- a/dat/events/neutral/derelict.lua
+++ b/dat/events/neutral/derelict.lua
@@ -91,7 +91,7 @@ function create ()
    hook.land("destroyevent")
 end
 
-local function derelict_msg( title, text )
+local function derelict_msg( title, text, log )
    vntk.msg( title, text, {
       pre = function ()
          vn.music( der.sfx.ambient )
@@ -101,6 +101,8 @@ local function derelict_msg( title, text )
          vn.sfx( der.sfx.unboard )
       end,
    } )
+
+   der.addMiscLog( log )
 end
 
 local function islucky ()
@@ -123,7 +125,7 @@ function board()
    local pp = player.pilot()
    local stats = pp:stats()
    if stats.fuel < stats.fuel_consumption and rnd.rnd() < 0.8 then
-      derelict_msg(_("Lucky find!"), _([[The derelict appears deserted, with most everything of value long gone. As explore the ship you suddenly pick up a back-up fuel tank hidden in the walls. The fuel is in good state and you siphon it off to fill your ships fuel tanks. Talk about good timing.]]) )
+      derelict_msg(_("Lucky find!"), _([[The derelict appears deserted, with almost everything of value long gone. As you explore the ship you suddenly pick up a back-up fuel tank hidden in the walls. The fuel is in a good state and you siphon it off to fill your ship's fuel tanks. Talk about good timing.]]), fmt.f(_([[Just as you were running out of fuel you found a derelict with some to spare in {sys}, what good fortune!]]), {sys=system.cur()}))
       pp:setFuel( true )
       destroyevent()
       return
@@ -153,26 +155,29 @@ function board()
 end
 
 function neutralevent()
-   local ntitle = _("Empty derelict")
-   local ntext = {
-      _([[You spend some time searching the derelict, but it doesn't appear there are any remaining passengers, nor is there anything of interest to you. You decide to return to your ship.]]),
-      _([[This ship has clearly been abandoned a long time ago. Looters have been here many times, and all of the primary and backup systems are down. However, there is one console that is still operational. It appears to be running an ancient computer game about space exploration, trade and combat. Intrigued, you decide to give the game a try, and before long you find yourself hooked on it. You spend many fun periods hauling cargo, upgrading your ship, fighting enemies and exploring the universe. But of course you can't stay here forever. You regretfully leave the game behind and return to the reality of your everyday life.]]),
-      _([[You are exploring the derelict ship when you hear a strange creaking noise. You decide to follow it to see what is causing it, but you never seem to be able to pinpoint the source. After about an hour of fruitlessly opening up panels, pressing your ear against the deck and running hull scans from your own ship, you decide to give up and leave the derelict to its creepy creaking.]]),
-      _([[While exploring the cockpit of this derelict, you come across the captain's logs. Hoping to find some information that could be of use to you, you decide to play back the most recent entries. Unfortunately, it turns out the captain's logs are little more than recordings of the captain having heated arguments with her co-pilot. After about ten hectoseconds, you decide you probably aren't going to find anything worthwhile here, so you return to your ship.]]),
-      _([[This derelict is not deserted. The crew are still onboard. Unfortunately for them, they didn't survive whatever wrecked their ship. You decide to give them a decent space burial before moving on.]]),
-      _([[This derelict seems to have been visited by looters already. You find a message carved into the wall near the airlock. It reads: "I WUS HEAR". Below it is another carved message that says "NO U WASNT". Otherwise, there is nothing of interest left on this ship.]]),
-      _([[This derelict seems to have at one time been used as an illegal casino. There are roulette tables and slot machines set up in the cargo hold. However, it seems the local authorities caught wind of the operation, because there are also scorch marks on the furniture and the walls, and there are assault rifle shells underfoot. You don't reckon you're going to find anything here, so you leave.]]),
-      _([[When the airlock opens, you are hammered in the face by an ungodly smell that almost makes you pass out on the spot. You hurriedly close the airlock again and flee back into your own ship. Whatever is on that derelict, you don't want to find out!]]),
-      _([[This derelict has really been beaten up badly. Most of the corridors are blocked by mangled metal, and your scans read depressurized compartments all over the ship. There's not much you can do here, so you decide to leave the derelict alone.]]),
-      _([[The interior of this ship is decorated in a gaudy fashion. There are cute plushies hanging from the doorways, drapes on every viewport, coloured pillows in the corners of most compartments and cheerful graffiti on almost all the walls. A scan of the ship's computer shows that this ship belonged to a trio of adventurous young ladies who decided to have a wonderful trip through space. Sadly, it turned out none of them really knew how to fly a space ship, and so they ended up stranded and had to be rescued. Shaking your head, you return to your own ship.]]),
-      _([[The artificial gravity on this ship has bizarrely failed, managing to somehow reverse itself. As soon as you step aboard you fall upwards and onto the ceiling, getting some nasty bruises in the process. Annoyed, you search the ship, but without result. You return to your ship - but forget about the polarized gravity at the airlock, so you again smack against the deck plates.]]),
-      _([[The cargo hold of this ship contains several heavy, metal chests. You pry them open, but they are empty. Whatever was in them must have been pilfered by other looters already. You decide not to waste any time on this ship, and return to your own.]]),
-      _([[You have attached your docking clamp to the derelict's airlock, but the door refuses to open. A few diagnostics reveal that the other side isn't pressurized. The derelict must have suffered hull breaches over the years. It doesn't seem like there's much you can do here.]]),
-      _([[As you walk through the corridors of the derelict, you can't help but notice the large scratch marks on the walls, the floor and even the ceiling. It's as if something went on a rampage throughout this ship - something big, with a lot of very sharp claws and teeth… You feel it might be best to leave as soon as possible, so you abandon the search of the derelict and disengage your docking clamp.]]),
+   -- neuevent is a table of tables { {title of event, text of event, log of event}, {...}, ... }
+   local neuevent = {
+      {"Empty derelict", _([[You spend some time searching the derelict, but it doesn't appear there are any remaining passengers, nor is there anything of interest to you. You decide to return to your ship.]]), fmt.f(_([[You searched an empty derelict in {sys}.]]), {sys=system.cur()})},
+      {"Distracting derelict", fmt.f(_([[This ship has clearly been abandoned a long time ago. Looters have been here many times and all of the primary and backup systems are down. However, there is one console that is still operational. It appears to be running an ancient computer game about space exploration, trade and combat. Intrigued, you decide to give the game a try, and before long you find yourself hooked on it. You spend many fun periods hauling cargo, upgrading your ship, fighting enemies and exploring the universe. But of course you can't stay here forever and besides the chriping from {shipai} is getting annoying. You regretfully leave the game behind and return to the reality of your everyday life.]]), {shipai=tut.ainame()}), fmt.f(_([[You searched a derelict in {sys} and ended up spending an inordinate amount of time playing an ancient computer game!]]), {sys=system.cur()})},
+      {"Errie derelict", _([[You are exploring the derelict ship when you hear a strange creaking noise. You decide to follow it to see what is causing it, but you never seem to be able to pinpoint the source. After about an hour of fruitlessly opening up panels, pressing your ear against the deck and running hull scans from your own ship, you decide to give up and leave the derelict to its creepy creaking.]]), fmt.f(_([[You searched an empty, creaking derelict in {sys}.]]), {sys=system.cur()})},
+      {"Distracting derelict", fmt.f(_([[While exploring the cockpit of this derelict, you come across the captain's logs. Hoping to find some information that could be of use to you, you decide to play back the most recent entries. Unfortunately, it turns out the captain's logs are little more than recordings of the captain having heated arguments with her co-pilot. It isn't long before you decide you probably aren't going to find anything worthwhile here. Having returned to your ship {shipai} confirms there is little but "emotional human chatter" in the captain's logs.]]), {shipai=tut.ainame()}), fmt.f(_([[You searched a derelict in {sys} but found little but for "emotional human chatter" in the captain's logs.]]), {sys=system.cur()})},
+      {"Wrecked derelict", fmt.f(_([[This derelict is not deserted. The crew are still onboard. Unfortunately for them, they didn't survive whatever wrecked their ship, neither did much of their ship. {shipai} and you decide to give the crew and their ship a decent space burial before moving on.]]), {shipai=tut.ainame()}), fmt.f(_([[You found a wrecked derelict in {sys} and gave it and its crew a decent space burial.]]), {sys=system.cur()})},
+      {"Empty derelict", _([[This derelict seems to have been visited by looters already. You find a message carved into the wall near the airlock. It reads: "I WUS HEAR". Below it is another carved message that says "NO U WASNT". Otherwise, there is nothing of interest left on this ship.]]), fmt.f(_([[You searched an empty derelict in {sys} and found only graffiti.]]), {sys=system.cur()})},
+      {"Not-so-empty derelict", _([[This derelict seems to have been, at one time, used as an illegal casino. There are roulette tables and slot machines set up in the cargo hold. However, it seems the local authorities caught wind of the operation; there are scorch marks on the furniture and walls and assault rifle shells underfoot. You don't reckon you're going to find anything useful here so you leave.]]), fmt.f(_([[You boarded a derelict in {sys} and found an ex-hive of illegal activity.]]), {sys=system.cur()})},
+      {"Not-so-empty derelict", _([[When the airlock opens, you are hammered in the face by an ungodly smell that almost makes you pass out on the spot. You hurriedly close the airlock again and flee back into your own ship. Whatever is on that derelict, you don't want to find out!]]), fmt.f(_([[An ungodly smell stopped you from searching a derelict in {sys}.]]), {sys=system.cur()})},
+      {"Wrecked derelict", fmt.f(_([[This derelict has been really badly beaten up. Most of the corridors are blocked by mangled metal and {shipai} tells you there are depressurized compartments all over the ship. There's not much you can do here, so you decide to leave the derelict to itself.]]), {shipai=tut.ainame()}), fmt.f(_([[You tried to search a wrecked derelict in {sys} but there wasn't much left.]]), {sys=system.cur()})},
+      {"Distracting derelict", _([[The interior of this ship is decorated in a gaudy fashion. There are cute plushies hanging from the doorways, drapes on every viewport, coloured pillows in the corners of most compartments and cheerful graffiti on almost all the walls. A scan of the ship's computer shows that this ship belonged to a trio of adventurous young ladies who decided to have a wonderful trip through space. Sadly, the ship's log tells you none of them really knew how to fly a space ship, so they ended up stranded and had to be rescued. Shaking your head, you return to your own ship.]]), fmt.f(_([[You searched a gaudily decorated derelict in {sys} and found the previous occupants had already been rescued]]), {sys=system.cur()})},
+      {"Errie derelict", _([[The artificial gravity on this ship has bizarrely failed, managing to somehow reverse itself. As soon as you step aboard you fall upwards and onto the ceiling, getting some nasty bruises in the process. Annoyed, you search the ship but without result. You return to your ship - but forget about the polarized gravity at the airlock, so you, again, smack against the deck plates.]]), fmt.f(_([[Having searched a derelict in {sys} you remind youself always to check the gravity before boarding another ship. Ow.]]), {sys=system.cur()})},
+      {"Empty derelict", _([[The cargo hold of this ship contains several heavy, metal chests. You pry them open but they are empty. Whatever was in them must have been pilfered by other looters already. You decide not to waste any time on this ship and return to your own.]]), fmt.f(_([[You found some empty chests on an empty derelict in {sys} system.]]), {sys=system.cur()})},
+      {"Wrecked derelict", fmt.f(_([[You have attached your docking clamp to the derelict's airlock but the door refuses to open. {shipai} tells you that the other side isn't pressurized and the doors are trying to save your life. The derelict must have suffered too many hull breaches over the years. It doesn't seem like there's much you can do here.]]), {shipai=tut.ainame()}), fmt.f(_([[You tried to search an empty derelict in {sys} but your airlock doors and the vacuum of space defeated you!]]), {sys=system.cur()})},
+      {"Errie derelict", fmt.f(_([[As you walk through the corridors of the derelict, you can't help but notice the large scratch marks on the walls, the floor and even the ceiling. It's as if something went on a rampage throughout this ship - something big, with a lot of very sharp claws and teeth… You feel it might be best to leave as soon as possible, despite {shipai}'s assurances of sensing no signs of life onboard, so you abandon the search and swiftly disengage your boardinig clamp.]]), {shipai=tut.ainame()}), fmt.f(_([[You left an empty, torn-up (literally) derelict you found in {sys} system to itself.]]), {sys=system.cur()})},
+      {"Errie derelict", fmt.f(_([[Entering your airlock you see the derelict's own airlock, oddly, spiral open onto a faintly-purple glowing, octagonal corridor. Noting this slightly strange interior design choice you continue along the faintly radiating corridor to find yourself in an octagonal ("Truncated cuboctahedronal" chirps in {shipai} over comms) room eminating a rather stranger purply-green or greeny-purple eldritch colour. What furnishings you can see are angular in a way that makes your eyes water. These design choices go from strange too… "Thump"! You land on the floor(?) as you trip over your gravity confused feet! Seriously!?! They rigged gravity to the outside "walls" of the room!?! You decide it might be better _not_ to discover anything more about this ship without an appropriately equipped boarding party, maybe one with a magician!]]), {shipai=tut.ainame()}), fmt.f(_([[An eldritch, possibly derelict, {shp} in {sys} system unnerved you, its true story is no longer your concern, thankfully!]]), {shp=derelict.ship(), sys=system.cur()})},
+      {"Empty derelict", _([[Your airlock doors slide open starting, what turns out to be, the most uneventful, dull, mudane, entirely-boring and mind-numbingly unhelpful waste of time that any boarding of a derelict ship has ever been, it even tempts you not to do this again on the off chance you run across another such distressingly worthless derelict.]]), fmt.f(_([[You became disenchanted with boarding derelicts on a ship in {sys}… next time better to watch paint dry.]]), {sys=system.cur})},
    }
 
    -- Pick a random message from the list, display it, unboard.
-   derelict_msg( ntitle, ntext[rnd.rnd(1, #ntext)] )
+   chosen=rnd.rnd(1, #neuevent)
+   derelict_msg( neuevent[chosen][1], neuevent[chosen][2], neuevent[chosen][3] )
    destroyevent()
 end
 
@@ -181,7 +186,7 @@ function goodevent()
 
    local goodevent_list = {
       function ()
-         derelict_msg(gtitle, _([[The derelict appears deserted, its passengers long gone. However, they seem to have left behind a small amount of credit chips in their hurry to leave! You decide to help yourself to them, and leave the derelict.]]) )
+         derelict_msg(gtitle, _([[The derelict appears deserted, its passengers long gone. However, they seem to have left behind a small amount of credit chips in their hurry to leave! You decide to help yourself to them and leave the derelict.]]), fmt.f(_([[You found a derelict in {sys}, it was empty but for some scattered credit chips. Lucky you!]]), {sys=system.cur()}))
          player.pay( rnd.rnd(5e3,30e3) )
       end,
       function ()
@@ -222,19 +227,22 @@ function goodevent()
             end
          end
          local rndfact = fcts[ rnd.rnd(1, #fcts) ]
-         derelict_msg(gtitle, fmt.f(_([[This ship looks like any old piece of scrap at a glance, but it is actually an antique, one of the very first of its kind ever produced! Museums all over the galaxy would love to have a ship like this. You plant a beacon on the derelict to mark it for salvaging, and contact the {fct} authorities. Your reputation with them has slightly improved.]]), {fct=rndfact}))
-         faction.modPlayerSingle(rndfact, 3)
+         derelict_msg(gtitle, fmt.f(_([[This ship looks like any old piece of scrap at a glance, but it is actually an antique, one of the very first of its kind ever produced according to {shipai}! Museums all over the galaxy would love to have a ship like this. You plant a beacon on the derelict to mark it for salvaging and contact the {fct} authorities. Your reputation with them has slightly improved.]]), {shipai=tut.ainame, fct=rndfact}), fmt.f(_([[In the {sys} system you found a very rare antique derelict {shp} and reported it to the, happy to hear from you, {fct} authorities.]]), {sys=system.cur(), shp=derelict.ship(), fct=rndfact}))
+         faction.modPlayerSingle(rndfact, 2, "script")
       end,
    }
 
    -- See if we should add maps
    local maps = {
-      ["Map: Dvaered-Soromid trade route"] = _("Dvaered-Soromid trade route"),
-      ["Map: Sirian border systems"] = _("Sirian border systems"),
-      ["Map: Dvaered Core"] = _("Dvaered core systems"),
+      ["Map: Local System Map"]  = _("local system"),
       ["Map: Empire Core"]  = _("Empire core systems"),
-      ["Map: Nebula Edge"]  = _("Sol nebula edge"),
+      ["Map: Za'lek Core"] = _("Za'lek core systems"),
+      ["Map: Dvaered Core"] = _("Dvaered core systems"),
+      ["Map: Dvaered-Soromid trade route"] = _("Dvaered-Soromid trade route"),
+      ["Map: Sirius Core"] = _("Sirius ｃore systems"),
+      ["Map: Sirian border systems"] = _("Sirian border systems"),
       ["Map: The Frontier"] = _("Frontier systems")
+      ["Map: Nebula Edge"]  = _("Imperial Nebula edge"),
    }
    local unknown = {}
    for k,v in pairs(maps) do
@@ -246,7 +254,7 @@ function goodevent()
    if #unknown > 0 then
       table.insert( goodevent_list, function ()
          local choice = unknown[rnd.rnd(1,#unknown)]
-         derelict_msg(gtitle, fmt.f(_([[The derelict is empty, and seems to have been thoroughly picked over by other space buccaneers. However, the ship's computer contains a map of the {mapname}! You download it into your own computer.]]), {mapname=maps[choice]}))
+         derelict_msg(gtitle, fmt.f(_([[The derelict is empty and seems to have been thoroughly picked over by other space buccaneers. However, the ship's computer contains a map of the {smp}! You download it to your own computer.]]), {smp=maps[choice]}), fmt.f(_([[You found a derelict in {sys}, it was empty but the nav system contained a {smp} map! Nice!]]), {sys=system.cur(), smp=maps[choice]}))
          player.outfitAdd(choice, 1)
       end )
    end
@@ -256,7 +264,7 @@ function goodevent()
    local stats = pp:stats()
    if stats.fuel < 2*stats.fuel_consumption then
       table.insert( goodevent_list, function ()
-         derelict_msg(gtitle, _([[The derelict appears deserted, with most everything of value long gone. As explore the ship you suddenly pick up a back-up fuel tank hidden in the walls. The fuel is in good state and you siphon it off to fill your ships fuel tanks.]]) )
+         derelict_msg(gtitle, _([[The derelict appears deserted, with almost everything of value long gone. As you explore the ship your handyscan suddenly picks up a back-up fuel tank hidden in the walls. The fuel is in a good state and you siphon it off to fill your own ship's fuel tanks.]]), fmt.f(_([[A derelict you found in {sys} was empty but for a reserve fuel tank you fortuitously discovered!]]), {sys=system.cur()})))
          pp:setFuel(true)
       end )
    end
@@ -265,7 +273,7 @@ function goodevent()
    local armour, shield = pp:health()
    if armour < 50 and stats.armour_regen <= 0 then
       table.insert( goodevent_list, function ()
-         derelict_msg(gtitle, _([[The derelict is deserted and striped of everything of value, however, you notice that the ship hull is in very good shape. In fact, it is rather suspicious that a ship in such good ship became a derelict. Without thinking much deeper about it you strip hull components and are able to repair your ship's armour.]]) )
+         derelict_msg(gtitle, fmt.f(_([[The derelict is deserted and striped of everything of value, however, you notice that the ship hull is in very good shape. In fact, it is rather suspicious that a ship in such good repair became a derelict. Hushing {shipai} and without thinking too deeply about it you strip some of the hull components and are able to repair your own ship's armour.]]), {shipai=tut.ainame()}), fmt.f(_([[The hull of a derelict you found in {sys} provided you with the resources to repair your own, very useful in the circumstances!]]), {sys=system.cur()})))
          pp:setHealth( 100, shield )
       end )
    end
@@ -280,18 +288,18 @@ function badevent()
    local badevent_list = {
       function ()
          derelict:hookClear() -- So the pilot doesn't end the event by dying.
-         derelict_msg(btitle, _([[The moment you affix your boarding clamp to the derelict ship, it triggers a booby trap! The derelict explodes, severely damaging your ship. You escaped death this time, but it was a close call!]]))
+         derelict_msg(btitle, _([[The moment you affix your boarding clamp to the derelict ship, it triggers a booby trap! The derelict explodes, severely damaging your ship. You escaped death this time, but it was a close call!]]), fmt.f(_([[It was a trap! A derelict you found in {sys} was rigged to explode when your boarding clamp closed! That was a little too close for comfort.]]), {sys=system.cur()})))
          derelict:setHealth(0,0)
          player.pilot():control(true)
          hook.pilot(derelict, "exploded", "derelict_exploded")
       end,
       function ()
-         derelict_msg(btitle, _([[You board the derelict ship and search its interior, but you find nothing. When you return to your ship, however, it turns out there were Space Leeches onboard the derelict - and they've now attached themselves to your ship! You scorch them off with a plasma torch, but it's too late. The little buggers have already drunk all of your fuel. You're not jumping anywhere until you find some more!]]))
+         derelict_msg(btitle, fmt.f(_([[You board the derelict ship and search its interior, but you find nothing. When you return to your ship, however, {shipai} finds there were Space Leeches onboard the derelict - and they've now attached themselves to your ship! You scorch them off with a plasma torch, but it's too late. The little buggers have already drunk all of your fuel. You're not jumping anywhere until you find some more!]]), {shipai=tut.ainame()}), fmt.f(_([[Space Leeches attached to a derelict you found in {sys} sucked your ship empty of jump fuel before you could get rid of them! Rough break.]]), {sys=system.cur()})))
          player.pilot():setFuel(false)
          destroyevent()
       end,
       function ()
-         derelict_msg(btitle, _([[You affix your boarding clamp and walk aboard the derelict ship. You've only spent a couple of hectoseconds searching the interior when there is a proximity alarm from your ship! Pirates are closing on your position! Clearly this derelict was a trap! You run back onto your ship and prepare to unboard, but you've lost precious time. The pirates are already in firing range…]]))
+         derelict_msg(btitle, fmt.f(_([[You affix your boarding clamp and walk aboard the derelict ship. You've only spent a little time searching the interior when {shipai} sounds a proximity alarm from your ship! Pirates are closing on your position! Clearly this derelict was a trap! You run back onto your ship and prepare to undock, but you've lost precious time. The pirates are already in firing range…]]), {shipai=tut.ainame()}), fmt.f(_([[It was a trap! Pirates baited you with a derelict ship in {sys}, fortunately you lived to tell the tale but you'll be more wary next time you board a derelict.]]), {sys=system.cur()})))
 
          local s = player.pilot():ship():size()
          local enemies_tiny = {

--- a/dat/missions/neutral/derelict_rescue.lua
+++ b/dat/missions/neutral/derelict_rescue.lua
@@ -29,7 +29,10 @@ function create ()
    -- See if we got something
    if not mem.destpnt then
       -- Can't find target so just make everyone be dead
-      vntk.msg(_("Empty derelict"), _([[This derelict is not deserted. The crew are still onboard. Unfortunately for them, they didn't survive whatever wrecked their ship. You decide to give them a proper space burial before moving on.]]))
+      vntk.msg(_("Empty derelict"), _([[This derelict is not deserted. The crew are still onboard. Unfortunately for them they didn't survive whatever wrecked their ship. You decide to give them a proper space burial before moving on.]]))
+
+      der.addMiscLog(fmt.f(_([[You gave the crew of a derelict a proper space buriel in {sys}.]]), {sys=system.cur()}))
+
       misn.finish(false)
    end
 
@@ -41,7 +44,7 @@ function create ()
    vn.music( der.sfx.ambient )
    vn.sfx( der.sfx.board )
    vn.transition()
-   vn.na(fmt.f(_("You enter and begin to scour the ship for anything of value. As you make through the hallways you hear a noise. After investigating, you end up finding the entire crew of the ship locked up in a dormitory room. They offer you {credits} to take them to safety to {pnt} in the {sys} system."), {pnt=mem.destpnt, sys=mem.destsys, credits=fmt.credits(mem.reward_amount)}))
+   vn.na(fmt.f(_("You enter and begin to scour the ship for anything of value. As you make your way through the hallways you hear a noise. After investigating, you end up finding the entire crew of the ship locked up in a dormitory room. They offer you {credits} to take them safely to {pnt} in the {sys} system."), {pnt=mem.destpnt, sys=mem.destsys, credits=fmt.credits(mem.reward_amount)}))
    vn.menu{
       { _("Help them out"), "help" },
       { _("Refuse to help"), "refuse" },
@@ -49,6 +52,9 @@ function create ()
 
    vn.label("refuse")
    vn.na(_("You refuse to help them and leave them to the mercy of the stars."))
+
+   der.addMiscLog(fmt.f(_([[You refused to rescue the crew of a derelict ship and left them to float in {sys}.]]), {sys=system.cur()}))
+
    vn.sfx( der.sfx.unboard )
    vn.done()
 
@@ -90,7 +96,7 @@ function land ()
 
    vn.clear()
    vn.scene()
-   vn.na(_([[Soon after you land the crew you rescued from the derelict burst out of the ship in joy. After a while, the captain comes over you and gives you the credits you were promised.]])
+   vn.na(_([[Soon after you land the crew you rescued from the derelict burst out of the ship in joy. After a short while the captain comes over to you and gives you the credits you were promised.]])
       .. "\n\n"
       .. fmt.reward(mem.reward_amount))
    vn.func( function ()
@@ -99,7 +105,7 @@ function land ()
    vn.sfxVictory()
    vn.run()
 
-   der.addMiscLog(_("You rescued the crew of a derelict ship."))
+   der.addMiscLog(fmt.f(_([[You rescued the crew of a derelict ship and returned them safely to {pnt} ({sys}).]]), {pnt=mem.destpnt, sys=mem.destsys}))
 
    misn.finish( true )
 end
@@ -108,9 +114,15 @@ end
 function abort ()
    if player.isLanded() then
       vntk.msg(nil, _("You inform the crew you rescued from the derelict that you won't be taking them any further. They thank you and depart your ship."))
+
+      der.addMiscLog(fmt.f(_([[You rescued the crew of a derelict ship and dumped them at {pnt} ({sys}).]]), {pnt, sys=spob.cur()}))
+
    else
       vntk.msg(nil, _("You jettison the crew you rescued from the derelict out of the airlock."))
       misn.cargoJet( mem.civs )
+
+      der.addMiscLog(fmt.f(_([[You rescued the crew of a derelict ship and jetisoned them in {sys}.]]), {sys=system.cur()}))
+
    end
    misn.finish(false)
 end

--- a/dat/missions/neutral/spacefamily.lua
+++ b/dat/missions/neutral/spacefamily.lua
@@ -98,7 +98,9 @@ function land()
     Inside the box, you find a sum of credits and a note written in neat, feminine handwriting that says, "Sorry for the trouble."]]) ) -- Final message
          player.pay( reward )
          misn.cargoJet(mem.carg_id)
-         neu.addMiscLog( _([[You rescued a bad-tempered man and his family who were stranded aboard their ship. After a lot of annoying complaints, the man and his family finally left your ship, the man's wife leaving a generous payment for the trouble.]]) )
+
+         der.addMiscLog(fmt.f(_([[You rescued a bad-tempered man and his family who were stranded aboard their ship. After a lot of annoying complaints, the man and his family finally left your ship on {pnt} ({sys}), the man's wife leaving a generous payment for the trouble.]]), {pnt, sys=spob.cur()}))
+
          misn.finish(true)
       else
          mem.nextstop = mem.nextstop + 1
@@ -150,8 +152,12 @@ end
 function abort ()
    if mem.inspace then
       tk.msg(_("A parting of ways"), _([[You unceremoniously shove your passengers out of the airlock and into the coldness of space. You're done playing taxi; it's time to get back to important things!]]))
+
+      der.addMiscLog(fmt.f(_([[You rescued a bad-tempered man and his family who were stranded aboard their ship. After a lot of annoying complaints, you dumped the family out of the airlock in {sys}!]]), {sys=system.cur()}))
    else
       tk.msg(_("A parting of ways"), _([[You unceremoniously shove your passengers out of the airlock, leaving them to their fate on this planet. You're done playing taxi; it's time to get back to important things!]]))
+
+      der.addMiscLog(fmt.f(_([[You rescued a bad-tempered man and his family who were stranded aboard their ship. After a lot of annoying complaints, you turfed the family out on {pnt} ({sys})!]]), {pnt, sys=spob.cur()}))
    end
    misn.cargoJet(mem.carg_id)
    misn.finish(true)

--- a/dat/missions/pirate/blackcat.lua
+++ b/dat/missions/pirate/blackcat.lua
@@ -51,7 +51,8 @@ function create ()
    local cat = vn.Character.new( _("Black Cat"), {image=cat_image, color=cat_colour} )
    vn.transition()
    vn.na(_([[You make your way through the derelict, each step you take resonating throughout the vacuous vessel. As your traverse a hallway you notice a peculiar texture on one of the walls. As your light illuminates the wall, you can make out a hastily written graffiti. Although it is hard to read, you can make out the following text "#rBEW-RE OF C-T#0". What could it mean?]]))
-   vn.na(_([[You eventually reach the command room when your ship suddenly informs you that there is a life form present on the ship. Not only that, it's very close! You frantically ready your weapons and prepare for the worst…
+   vn.na(_([[You eventually reach the command room when your ship suddenly informs you that there is a life form present on the ship. Not only that, it's very close! You frantically ready for a fight
+ and prepare for the worst…
 
 It's right on top of you!]]))
    vn.sfx( meow )
@@ -59,8 +60,8 @@ It's right on top of you!]]))
    cat(_([[You make out two glowing eyes glinting in the darkness. As you shine your light on them, a dark shape emerges from the shadows.
 "Meow."]]))
    cat(fmt.f(_([[In front of you is what {shipai} confirms to be a Felis catus or domesticated house cat. It looks at you with expressionless eyes with a gaze that seems to pierce your soul.
-After what seems an eternity with you holding your breath, the cat stands up, and walks past you.]]),{shipai=tut.ainame()}))
-   cat(_([[You follow the cat throughout the ship as it leads you to… the airlock you came in from.
+After what seems an eternity with you holding your breath, the cat stands up and walks past you.]]),{shipai=tut.ainame()}))
+   cat(_([[You follow the cat throughout the ship as it leads you to… the airlock you came in from!
 It seems like it wants to come back with you. What do you do?]]))
    vn.menu{
       {_("Take the cat with you"), "takecat"},
@@ -70,12 +71,12 @@ It seems like it wants to come back with you. What do you do?]]))
    vn.sfx( meow )
    vn.func( function () tookcat = true end )
    cat(_([[You open the airlock and the cat enters your ship, only to immediately turn around and start scratching the airlock again. You open the airlock again and it goes back into the derelict. Soon after, you hear scratching on the other side of the door. You let out a big sigh and the cat walks into your ship again. Not wanting to get stuck in an infinite loop, you gently prod the cat so it goes into your ship.]]))
-   cat(_([[The cat struts around and behaves like it owns the place. You're going to have to figure out what to do with it. Your ship is no place for a cat to live in.]]))
+   cat(_([[The cat struts around and behaves like it owns the place. You're going to have to figure out what to do with it. Your ship is no place for a cat to live.]]))
    vn.sfx( der.sfx.unboard )
    vn.done()
 
    vn.label("leavecat")
-   vn.na(_("Are you sure you want to abandon the cat to its fate aboard the sinister derelict ship?"))
+   vn.na(_("Are you sure you want to abandon the cat to its fate aboard the sinister, derelict ship?"))
    vn.menu{
       {_("Take the cute cat with you"), "takecat"},
       {_("Definitely let the beast be"), "leavecatdef"},
@@ -87,6 +88,8 @@ It seems like it wants to come back with you. What do you do?]]))
    vn.run()
 
    if not tookcat then
+      der.addMiscLog(fmt.f(_([[You left a sinister black cat on an abandoned derelict ship in {sys}.]]), {sys=system.cur()}))
+
       misn.finish(false)
       return
    end
@@ -129,7 +132,7 @@ local event_list = {
       local pp = player.pilot()
       meow:play()
       if islucky() then
-         player.msg(_("Black cat hair has clogs the radiators but burns up before overheating the ship."), true)
+         player.msg(_("Black cat hair has clogged the radiators but burns up before overheating the ship."), true)
          return
       end
       local t = pp:temp()
@@ -137,13 +140,13 @@ local event_list = {
       player.msg(_("Black cat hair has clogged the radiators and overheated the ship!"), true)
       player.autonavReset()
    end,
-   function () -- Temporary disable
+   function () -- Temporarily disable
       local pp = player.pilot()
       local _a, _s, _st, dis = pp:health()
       if dis then return end -- Already disabled
       meow:play()
       if islucky() then
-         player.msg(_("The black cat accidently hit the ship restart button, but nothing happens."), true)
+         player.msg(_("The black cat accidentally hit the ship restart button, but nothing happens."), true)
          return
       end
       pp:disable( true )
@@ -175,7 +178,7 @@ local function event ()
          _("You hear weird noises from the black cat freaking out over nothing."),
          _("The black cat suddenly sprints through the ship."),
          _("The black cat curls up and falls asleep on top of the control panel."),
-         _("The black cat shows you its belly, but bites you when you pet it."),
+         _("The black cat shows you its belly, but bites you when you try to pet it."),
          _("The black cat uses the commander chair as a scratching post."),
          _("The black cat bumps into your ship's self-destruct button, but you manage to abort it in time."),
       }
@@ -271,7 +274,7 @@ function owner_hail ()
 
    vn.label("catno")
    vn.sfx( meow )
-   vn.na(_([[Just as you utter the word "No", the black cat drowns out your reply with a resonating "meow", that is clearly heard on the other side of the communication channel.]]))
+   vn.na(_([[Just as you utter the word "No", the black cat drowns out your reply with a resonating "Meow", that is clearly heard on the other side of the communication channel.]]))
    vn.jump("catyes")
 
    vn.label("catyes")
@@ -299,20 +302,20 @@ function owner_board ()
    vn.sfx( der.sfx.board )
    vn.transition()
    vn.na(fmt.f(_("Your ship locks its boarding clamps on the {plt}, and the airlock opens up revealing some strangely musty air and pitch black darkness. How odd."),{plt=owner}))
-   vn.na(_("You realize the cat is no where to be seen, and start to search for it to bring it over. Funny how it always seems to be where you don't want it and when you need it you can't find it."))
+   vn.na(_("You realize the cat is nowhere to be seen and start to search for it to bring it over. Funny how it always seems to be where you don't want it and when you need it you can't find it."))
    vn.sfx( meow )
    vn.na(_("You scour the ship and end up going back to the commander chair. As you are about to look behind it, you hear a sonorous meow and a black shadow flies past you towards the airlock."))
    vn.sfx( der.sfx.unboard )
    vn.na(_("You run to try to catch it, but hear the sound of the airlock closing and detaching of the locking clamps. You run back to your command chair to see what the other ship is doing, but you can not find it anywhere. They seem to have a knack for fleeing."))
    vn.na(fmt.f(_("You sit resigned and outwitted at your command chair when you notice a credit chip with {credits} on the floor. It looks like it has cat bite marks too."),{credits=fmt.credits(credit_reward)}))
    vn.sfxVictory()
-   vn.na(_("You then get around to cleaning up the copious amounts of cat hair invading every last corner of your ship. With the amount collected you make a cute black cat doll. It's like a tiny version of the real thing without the assholeness."))
+   vn.na(_("You then get around to cleaning up the copious amounts of cat hair invading every last corner of your ship. With the amount collected you make a cute black cat doll. It's like a tiny version of the real thing without the assholiness."))
    vn.run()
 
    player.pay( credit_reward )
    player.outfitAdd( "Black Cat Doll" )
 
-   pir.addMiscLog(_("You rescued a black cat from a derelict ship and safely delivered it to its owner, who was flying a Wild Ones pirate ship."))
+   der.addMiscLog(_([[You rescued a black cat from a derelict ship and safely delivered it to its owner, who was flying a Wild Ones pirate ship.]]))
    faction.get("Wild Ones"):modPlayerSingle(3)
 
    player.unboard()
@@ -325,6 +328,9 @@ function owner_gone ()
 end
 
 function abort ()
-   vntk.msg(_("No cat in sight…"), _("You go to get rid of the black cat, but can not find it in sight. After a long search you reach the only logical conclusion that it vanished. Guess you can forget about it for now."))
+   vntk.msg(_("No cat in sight…"), _("You go to get rid of the black cat, but can not find it anywhere. After a long search you reach the only logical conclusion; that it vanished into thin air. Guess you can forget about it for now."))
+
+   der.addMiscLog(fmt.f(_([[You rescued a black cat from a derelict ship only to have it disappear into thin air in {sys}.]]), {sys=system.cur()}))
+
    misn.finish(false)
 end

--- a/dat/outfits/maps/map_dvaeredsoromid_trade_route.xml
+++ b/dat/outfits/maps/map_dvaeredsoromid_trade_route.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<outfit name="Map: Dvaered-Soromid trade route">
+<outfit name="Map: Dvaered-Soromid Trade Route">
  <general>
   <rarity>0</rarity>
   <mass>0</mass>
   <price>30000</price>
-  <description>This map contains the main route between Dvaered and Soromid controlled space.</description>
+  <description>This map contains the main trade route between Dvaered and Soromid controlled space.</description>
   <gfx_store>map.webp</gfx_store>
  </general>
  <specific type="map">


### PR DESCRIPTION
As far as I can tell I didn't fluff any of the coding so I hope that the adding of logs and shipai cameos to the derelict events and missions was okay... I also redirected the blackcat and spacefamily mission logs to be ones related to derelicts given that that's how they start. I expect this is not the best solution for neutral events but it makes it clearer for other people to add new ones to the bottom.