### PR TITLE
Made mission markers point to planets where appropriate - fixes #2115

### DIFF
--- a/dat/missions/dvaered/assault_on_unicorn.lua
+++ b/dat/missions/dvaered/assault_on_unicorn.lua
@@ -50,7 +50,6 @@ function create ()
    misn.setDesc(fmt.f(_("It is time to put a dent in the pirates' forces. We have detected a strong pirate presence in the system of Unicorn. We are offering a small sum for each pirate killed. The maximum we will pay you is {credits}."), {credits=fmt.credits(mem.max_payment)} ))
 
    mem.marker = misn.markerAdd( misn_target_sys, "computer" )
-   mem.marker2 = misn.markerAdd( misn_return_sys, "low" )
 end
 
 function accept ()
@@ -60,6 +59,7 @@ function accept ()
       -- Makes sure only one copy of the mission can run.
       var.push( "assault_on_unicorn_check", true)
       mem.planet_start = spob.cur()
+      mem.marker2 = misn.markerAdd( mem.planet_start, "low" )
       mem.pirates_killed = 0
       mem.bounty_earned = 0
       mem.misn_stage = 0

--- a/dat/missions/dvaered/assault_on_unicorn.lua
+++ b/dat/missions/dvaered/assault_on_unicorn.lua
@@ -25,7 +25,7 @@ local dv  = require "common.dvaered"
 
 -- Mission constants
 local misn_target_sys = system.get("Unicorn")
-local misn_return_sys = system.get("Amaroq")
+-- local misn_return_sys = system.get("Amaroq")
 
 -- luacheck: globals death jumpin land (Hook functions passed by name)
 

--- a/dat/missions/neutral/commodity_run.lua
+++ b/dat/missions/neutral/commodity_run.lua
@@ -97,7 +97,7 @@ function create ()
 
    -- Set Mission Details
    misn.setTitle( fmt.f( mem.misn_title, {cargo=comm} ) )
-   misn.markerAdd( system.cur(), "computer" )
+   misn.markerAdd( mem.misplanet, "computer" )
    misn.setDesc( fmt.f( mem.misn_desc, {pnt=mem.misplanet, cargo=comm} ) )
    misn.setReward( fmt.f(_("{credits} per tonne"), {credits=fmt.credits(mem.price)} ) )
 end

--- a/dat/missions/neutral/drunkard.lua
+++ b/dat/missions/neutral/drunkard.lua
@@ -65,7 +65,7 @@ function accept ()
       mem.pickedup = false
       mem.droppedoff = false
 
-      mem.marker = misn.markerAdd( mem.pickupSys, "low" )  -- pickup
+      mem.marker = misn.markerAdd( mem.pickupWorld, "low" )  -- pickup
       -- OSD
       misn.osdCreate( _("Help the Drunkard"), {
          fmt.f(_("Go pick up some goods at {pnt} in the {sys} system"), {pnt=mem.pickupWorld, sys=mem.pickupSys}),
@@ -93,7 +93,7 @@ function land ()
          mem.cargoID = misn.cargoAdd( c, 45 )  -- adds cargo
          mem.pickedup = true
 
-         misn.markerMove( mem.marker, mem.delivSys )  -- destination
+         misn.markerMove( mem.marker, mem.delivWorld )  -- destination
 
          misn.osdActive(2)  --OSD
       end

--- a/dat/missions/sirius/heretic/heretic0.lua
+++ b/dat/missions/sirius/heretic/heretic0.lua
@@ -53,7 +53,7 @@ function accept()
     You shake his sticky hand and walk off, content that you've made an easy buck.]]), {pnt=mem.targetasset}))
    misn.setDesc(fmt.f(_("You are to deliver a shipment to {pnt} in the {sys} system for a strange man you met at a bar, avoiding Sirius ships."), {pnt=mem.targetasset, sys=mem.targetsystem}))
    misn.accept()
-   misn.markerAdd(mem.targetsystem, "high")
+   misn.markerAdd(mem.targetasset, "high")
    misn.osdCreate(_("The Gauntlet"), {
       fmt.f(_("Deliver the shipment to {pnt} in the {sys} system"), {pnt=mem.targetasset, sys=mem.targetsystem}),
    })
@@ -77,7 +77,7 @@ function land ()
       misn.cargoRm(mem.small_arms) --this mission was an act against Sirius, and we want Sirius to not like us a little bit.
       faction.modPlayer("Nasin",3) --Nasin reputation is used in mission rewards, and I am trying to avoid having the pay skyrocket.
       var.push("heretic_misn_tracker",1) --using "misn_tracker", as later on in-game, i plan on having multiple arcs to the ending.
-      srs.addHereticLog( _([[You helped a rough-looking man deliver an illegal shipment. After you completed the delivery, another man told you that there may be another mission opportunity and that you should meet some commander in the bar on Margot if you're interested.]]) )
+      srs.addHereticLog( fmt.f(_([[You helped a rough-looking man deliver an illegal shipment. After you completed the delivery, another man told you that there may be another mission opportunity and that you should meet some commander in the bar on {pnt} ({sys} system) if you're interested.]]), {pnt=mem.targetasset, sys=mem.targetsystem} ) )
       misn.finish( true )
    end
 end


### PR DESCRIPTION
I was only able to check the first six pages of results for misn.markerAdd as git wasn't happy listing more than the sixth page?!?
Also heretic0.lua has a couple of comments - is contraband doable now? If so this mission is supposed to use it - also apparently the author would like to reduce Sirius reputation while increasing Nasin reputation... but the code isn't included for this (only something that probably need to be removed!) Should I go ahead and implement this or was it removed with good reason?

This pull request fixes #2115