### PR TITLE
Proofed spobs starting with W, X and Y

### DIFF
--- a/dat/spob/readme.md
+++ b/dat/spob/readme.md
@@ -45,7 +45,8 @@ Below are a set of tags that change the behaviour of some core mechanics.
 
 Below is the complete list of dominantly used descriptive tags. It should be noted that tagging is incomplete at present and it is possible that none of these tags will apply to many spobs (e.g. uninhabited, average, uninteresting or deserted spobs). Most others will only have one or two tags - they are supposed to represent important facets of the spob in its own estimation, not minor elements e.g. while the (temporary) Imperial Homeworld has many criminals and military personnel neither tag applies since its defining tags would be rich, urban and maybe tourism or trade.
 
-* **station**: the spob is a space station
+* **station**: the spob is a space station or gas giant spaceport
+* **wormhole**: the spob is a wormhole
 * **new**: recently colonised worlds / recently built stations (definitely post-Incident)
 * **old**: long-time colonised worlds / old stations (definitely pre-Incident)
 * **rich**: the population living on the spob is rich by the standards of the faction
@@ -59,6 +60,7 @@ Below is the complete list of dominantly used descriptive tags. It should be not
 * **trade**: trade is an important part of the spob economy
 * **research**: the spob has a strong focus in research (special research laboratories, etc...)
 * **immigration**: the spob draws in a large number of immigrants or is being colonised
+* **refuel**: the spobs reason for existance is as a fueling point
 * **military**: the spob has an important factional military presence
 * **prison**: the spob has important prison installations
 * **criminal**: the spob has a large criminal element such as important pirate or mafia presence

--- a/dat/spob/wagenni.xml
+++ b/dat/spob/wagenni.xml
@@ -3,7 +3,7 @@
  <pos x="-5791.124494" y="-1722.738390"/>
  <GFX>
   <space>moon-G00.webp</space>
-  <exterior>mining.webp</exterior>
+  <exterior>mining4.webp</exterior>
  </GFX>
  <presence>
   <faction>Sirius</faction>
@@ -33,4 +33,8 @@
   <item>Star Maps</item>
   <item>Missiles 1</item>
  </tech>
+ <tags>
+  <tag>poor</tag>
+  <tag>rural</tag>
+ </tags>
 </spob>

--- a/dat/spob/wahri.xml
+++ b/dat/spob/wahri.xml
@@ -12,7 +12,7 @@
   <range>0</range>
  </presence>
  <general>
-  <class>A</class>
+  <class>C</class>
   <population>30000</population>
   <hide>2.000000</hide>
   <services>
@@ -39,6 +39,9 @@
   <item>Ion 1</item>
  </tech>
  <tags>
+  <tag>poor</tag>
+  <tag>rural</tag>
   <tag>mining</tag>
+  <tag>refuel</tag>
  </tags>
 </spob>

--- a/dat/spob/wahri_iii.xml
+++ b/dat/spob/wahri_iii.xml
@@ -3,10 +3,10 @@
  <pos x="-5869.866578" y="-4297.102761"/>
  <GFX>
   <space>C01.webp</space>
-  <exterior>station02.webp</exterior>
+  <exterior>mining3.webp</exterior>
  </GFX>
  <general>
-  <class>A</class>
+  <class>C</class>
   <population>0</population>
   <hide>1.000000</hide>
   <services/>

--- a/dat/spob/wahri_iv.xml
+++ b/dat/spob/wahri_iv.xml
@@ -3,7 +3,7 @@
  <pos x="-7488.713024" y="14174.177838"/>
  <GFX>
   <space>J02.webp</space>
-  <exterior>traderoom.webp</exterior>
+  <exterior>gas.webp</exterior>
  </GFX>
  <general>
   <class>I</class>

--- a/dat/spob/wakan.xml
+++ b/dat/spob/wakan.xml
@@ -24,6 +24,7 @@
   <description>Wa'kan is a mining world where the mines are solely worked by prisoners. There is a guard detail posted and a small degree of Za'lek researchers here working on criminal justice programs.</description>
  </general>
  <tags>
+  <tag>poor</tag>
   <tag>prison</tag>
   <tag>mining</tag>
  </tags>

--- a/dat/spob/waldar.xml
+++ b/dat/spob/waldar.xml
@@ -40,4 +40,9 @@
   <item>High Tech Upgrades 1</item>
   <item>Sirius Elite Outfits</item>
  </tech>
+ <tags>
+  <tag>rich</tag>
+  <tag>rural</tag>
+  <tag>immigration</tag>
+ </tags>
 </spob>

--- a/dat/spob/wardens_end.xml
+++ b/dat/spob/wardens_end.xml
@@ -26,7 +26,7 @@
   </services>
   <commodities/>
   <description>Warden's End exists as a place for less-than-legal wares to be bought and sold. Known as one of the few truly "free" markets, many of the less reputable merchants in the galaxy come here to peddle their wares. Many a merchant has gained - and lost - a fortune here. The station itself is made out of the welded-together ships of merchants who became destitute.</description>
-  <bar>Many of the denizens of Warden's End are richer and the bar caters to this with a bit more of a posh appearance. The usually rowdy pirates are kept in check by the small armies that seem to surround every seedy merchant, keeping the place quiet and, tensely, stable.</bar>
+  <bar>Many of the denizens of Warden's End are richer and the bar caters to this with a bit more of a posh appearance. The usually rowdy pirates are kept in check by the small armies that seem to surround every seedy merchant, keeping the place quieter and, tensely, stable.</bar>
  </general>
  <tech>
   <item>Pirate Maps</item>
@@ -48,6 +48,9 @@
   <item>Criminal Outfits</item>
  </tech>
  <tags>
+  <tag>station</tag>
+  <tag>old</tag>
+  <tag>trade</tag>
   <tag>criminal</tag>
  </tags>
 </spob>

--- a/dat/spob/warei.xml
+++ b/dat/spob/warei.xml
@@ -24,7 +24,7 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>Part of the reason why Warei's surface is permanently frozen is because the planet's core is cold. This is a fascinating aberration from the standard planetary model, but more than that it offers great economical possibilities as there are vast amounts of raw minerals to be had under the crust. The Soromid have taken to set up a parts and ship manufacturing complex here.</description>
+  <description>Part of the reason why Warei's surface is permanently frozen is because the planet's core is cold. This is a fascinating aberration from the standard planetary model but, more than that, it offers great economic possibilities as there are vast amounts of raw minerals to be had under the crust. The Soromid have set up a parts and ship manufacturing complex here.</description>
   <bar>Even the Soromid need protection from the cold climate, but they're certainly more resistant to it than normal humans. Most non-Soromid traders visiting Warei complain about the cold - the ambient temperature in the bar is far from comfortable.</bar>
  </general>
  <tech>
@@ -33,6 +33,7 @@
   <item>Soromid Ships Small</item>
  </tech>
  <tags>
+  <tag>mining</tag>
   <tag>industrial</tag>
  </tags>
 </spob>

--- a/dat/spob/warnecke.xml
+++ b/dat/spob/warnecke.xml
@@ -55,6 +55,8 @@
   <item>Za'lek Outfits High</item>
  </tech>
  <tags>
+  <tag>station</tag>
+  <tag>poor</tag>
   <tag>mining</tag>
   <tag>research</tag>
   <tag>military</tag>

--- a/dat/spob/warnecke_i.xml
+++ b/dat/spob/warnecke_i.xml
@@ -3,7 +3,7 @@
  <pos x="1395.547217" y="-381.846862"/>
  <GFX>
   <space>D07.webp</space>
-  <exterior>oceanic2.webp</exterior>
+  <exterior>mining4.webp</exterior>
  </GFX>
  <general>
   <class>D</class>

--- a/dat/spob/warnecke_ii.xml
+++ b/dat/spob/warnecke_ii.xml
@@ -3,7 +3,7 @@
  <pos x="-105.345516" y="-6.449725"/>
  <GFX>
   <space>moon-J00.webp</space>
-  <exterior>station03.webp</exterior>
+  <exterior>gas.webp</exterior>
  </GFX>
  <general>
   <class>J</class>

--- a/dat/spob/waterhole.xml
+++ b/dat/spob/waterhole.xml
@@ -6,7 +6,7 @@
   <exterior>oceanic2.webp</exterior>
  </GFX>
  <general>
-  <class>A</class>
+  <class>O</class>
   <population>0</population>
   <hide>1.000000</hide>
   <services/>

--- a/dat/spob/waterholes_moon.xml
+++ b/dat/spob/waterholes_moon.xml
@@ -3,7 +3,7 @@
  <pos x="-5089.422980" y="-1733.131108"/>
  <GFX>
   <space>moon-G00.webp</space>
-  <exterior>oceanic2.webp</exterior>
+  <exterior>desertic3.webp</exterior>
  </GFX>
  <presence>
   <faction>Empire</faction>
@@ -12,7 +12,7 @@
   <range>2</range>
  </presence>
  <general>
-  <class>A</class>
+  <class>G</class>
   <population>50000</population>
   <hide>2.000000</hide>
   <services>
@@ -27,6 +27,9 @@
   <bar>Waterhole's Moon wouldn't be Waterhole's Moon if its bar wasn't called The Waterhole. Though the place is open to visitors from all origins and walks of life, the majority of the clientele is Imperial in nature. It seems that nothing creates a longing for home like being away from it for prolonged periods of time.</bar>
  </general>
  <tags>
+  <tag>old</tag>
+  <tag>poor</tag>
   <tag>rural</tag>
+  <tag>refuel</tag>
  </tags>
 </spob>

--- a/dat/spob/wayline.xml
+++ b/dat/spob/wayline.xml
@@ -20,6 +20,11 @@
    <refuel/>
   </services>
   <commodities/>
-  <description>Wayline is a barely inhabited ball of ice. The almost sole reason for its existence is serving as a stopover point in the southern regions.The Dvaered use it as a prison planet as well, due to its remoteness. Few people like coming here, and the most common stopovers are Dvaered prison-ships.</description>
+  <description>Wayline is a barely inhabited ball of ice. Almost the sole reason for its existence is serving as a stopover point in the southern regions. The Dvaered use it as a prison planet as well, due to its remoteness. Few people like coming here and the most common stopovers are Dvaered prison-ships.</description>
  </general>
+ <tags>
+  <tag>poor</tag>
+  <tag>prison</tag>
+  <tag>refuel</tag>
+ </tags>
 </spob>

--- a/dat/spob/wayline_m1.xml
+++ b/dat/spob/wayline_m1.xml
@@ -3,10 +3,10 @@
  <pos x="-895.436882" y="481.579500"/>
  <GFX>
   <space>moon-P00.webp</space>
-  <exterior>mining2.webp</exterior>
+  <exterior>snow.webp</exterior>
  </GFX>
  <general>
-  <class>A</class>
+  <class>P</class>
   <population>0</population>
   <hide>1.000000</hide>
   <services/>

--- a/dat/spob/wayline_m2.xml
+++ b/dat/spob/wayline_m2.xml
@@ -3,10 +3,10 @@
  <pos x="-263.363789" y="1256.621507"/>
  <GFX>
   <space>moon-C01.webp</space>
-  <exterior>forest.webp</exterior>
+  <exterior>mining2.webp</exterior>
  </GFX>
  <general>
-  <class>A</class>
+  <class>C</class>
   <population>0</population>
   <hide>1.000000</hide>
   <services/>

--- a/dat/spob/wellen.xml
+++ b/dat/spob/wellen.xml
@@ -24,8 +24,8 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>Wellen is a good example of how the individual planetary management policy of the Empire can go wrong. Started as a prestigious project, the world was to be a perfect society with good housing and facilities for everyone, lots of greenery and no pollution. However, the goals were too ambitious, the funds too short, the leadership inadequate. Today Wellen is a slum of run-down, oftentimes half-finished buildings.</description>
-  <bar>The spaceport was the first facility to be constructed on the planet when it was colonized, as is often the case. As such it is well-built and polished. The spaceport bar is quite respectable, as spaceport bars go. It's only when you leave the terminal and enter the urban areas that the squalor begins to become apparent.</bar>
+  <description>Wellen is a good example of how the individual planetary management policy of the Empire can go wrong. Started as a prestigious project, the world was to be a perfect society with good housing and facilities for everyone, lots of greenery and no pollution. However, the goals were too ambitious, the funds too short and the leadership inadequate. Today Wellen is a slum of run-down, oftentimes half-finished, buildings.</description>
+  <bar>The spaceport was the first facility to be constructed on the planet when it was colonized, as is often the case. As such, it is well-built and polished. The spaceport bar is quite respectable, as spaceport bars go. It's only when you leave the terminal and enter the urban areas that the squalor begins to become apparent.</bar>
  </general>
  <tech>
   <item>Hulls Low</item>

--- a/dat/spob/werlen.xml
+++ b/dat/spob/werlen.xml
@@ -3,7 +3,7 @@
  <pos x="1553.027775" y="1774.888885"/>
  <GFX>
   <space>moon-D02.webp</space>
-  <exterior>mining.webp</exterior>
+  <exterior>mining5.webp</exterior>
  </GFX>
  <presence>
   <faction>Soromid</faction>
@@ -24,7 +24,7 @@
   </services>
   <commodities/>
   <description>Werlen is a world devoted to the cultivation of the raw materials the Soromid use to fabricate their ships. The world is off-limits to casual traffic, and only those trusted by the Soromid are permitted access.</description>
-  <bar>Virtually spotless despite being situated on a mining colony, this bar is an anomaly. Its cleanliness appears to be thanks in large part to an automated cleaning apparatus, the sides of which are covered in dire warning labels. The other patrons appear to be giving the machine a wide berth.</bar>
+  <bar>Virtually spotless despite being situated on a mining colony, this bar is an anomaly. Its cleanliness appears to be thanks, in large part, to an automated cleaning apparatus, the sides of which are covered in dire warning labels. The other patrons appear to be giving the machine a wide berth.</bar>
  </general>
  <tags>
   <tag>restricted</tag>

--- a/dat/spob/westeros_station.xml
+++ b/dat/spob/westeros_station.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>0</class>
-  <population>12500</population>
+  <population>1200</population>
   <hide>3.000000</hide>
   <services>
    <land/>
@@ -23,9 +23,10 @@
   </services>
   <commodities/>
   <description>Serving as an auxiliary trading platform for the nearby mining colony of Ahmed, Westeros Station allows for merchants to not have to brave the atmosphere of the nearby planetoid, making bulk transfers far easier.</description>
-  <bar>Being a station primarily for merchants, the bar is posh, with comforting seats looking out over big views of the planetary system.</bar>
+  <bar>Being a station primarily for bulk merchants, the bar is posh, with comfortable seats looking out over big views of the planetary system.</bar>
  </general>
  <tags>
+  <tag>station</tag>
   <tag>trade</tag>
  </tags>
 </spob>

--- a/dat/spob/wigheta.xml
+++ b/dat/spob/wigheta.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>O</class>
-  <population>200</population>
+  <population>222</population>
   <hide>1.000000</hide>
   <services>
    <land>srm_mil_restricted</land>
@@ -23,7 +23,7 @@
   </services>
   <commodities/>
   <description>While the main line of Soromid military ship production is located on Heronus in Uridhrion, there is a secondary ship plant here on Wigheta. Wigheta does not grow the regular models, however. Instead, the world acts as a research facility for bioships, where new designs and growth methods are invented and tested. It's a slow and expensive process, and Wigheta only produces a useful result once every few cycles, but without the work done here the Soromid bioship technology will never evolve.</description>
-  <bar>Wigheta's spaceport bar is located close to the actual landing docks of the spaceport. The research done on Wigheta is top-secret, so every precaution is being taken to prevent visitors from wandering into places they shouldn't.</bar>
+  <bar>Wigheta's spaceport bar is located very close to the actual landing docks of the spaceport. The research done on Wigheta is top-secret, so every precaution is being taken to prevent visitors from wandering into places they shouldn't.</bar>
  </general>
  <tags>
   <tag>restricted</tag>

--- a/dat/spob/wikon.xml
+++ b/dat/spob/wikon.xml
@@ -25,7 +25,7 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>Wikon is a high-profile Sirian world, one of the driving economical forces in the core of Sirius space. With planetary characteristics fairly close to ideal class M, it is both attractive for habitation and industry. Land values are rather high, and the population tends toward the Serra class.</description>
+  <description>Wikon is a high-profile Sirian world, one of the driving economic forces in the core of Sirius space. With planetary characteristics fairly close to ideal Class M, it is both attractive for habitation and industry. Land values are rather high, and the population tends toward the Serra class.</description>
   <bar>A better name for the spaceport bar would be "spaceport lounge". The establishment is luxurious even by non-spaceport standards, offering various recreational facilities in addition to the standard ones. It is possible to dine here too, and the menu is far from modest. Of course all this comes with a considerable price tag, but the economic climate allows for that.</bar>
  </general>
  <tech>
@@ -46,4 +46,9 @@
   <item>Engines High</item>
   <item>Sirius Elite Outfits</item>
  </tech>
+ <tags>
+  <tag>rich</tag>
+  <tag>trade</tag>
+  <tag>industrial</tag>
+ </tags>
 </spob>

--- a/dat/spob/wildwood_station.xml
+++ b/dat/spob/wildwood_station.xml
@@ -12,7 +12,7 @@
   <range>0</range>
  </presence>
  <general>
-  <class>0</class>
+  <class>1</class>
   <population>130</population>
   <hide>2.000000</hide>
   <services>
@@ -22,10 +22,12 @@
    <missions/>
   </services>
   <commodities/>
-  <description>Almost anyone who seeks to travel from Dvaered to Soromid space, or the other way around, stops by Wildwood on the way. It's a long haul, and Wildwood is one of the sparse providers of refuel along the route. While mainly a commercially oriented installation, Wildwood is also home to a small Soromid military outpost. The ships stationed here provide a bare minimum of protection to the traffic that passes through the system.</description>
-  <bar>Ships need fuel, and so do their captains. Wildwood's spacedock bar, though modest, offers captains stopping by a respectable choice in beverages and pastimes before they have to move on.</bar>
+  <description>Almost anyone who seeks to travel from Dvaered to Soromid space, or the other way around, stops by Wildwood on the way. It's a long haul and Wildwood is one of the sparse providers of refueling along the route. While mainly a commercially oriented installation, Wildwood is also home to a small Soromid military outpost. The ships stationed here provide a bare minimum of protection to the traffic that passes through the system.</description>
+  <bar>Ships need fuel, so do their captains. Wildwood's spacedock bar, though modest, offers visiting captains a respectable choice in beverages and pastimes before they have to move on.</bar>
  </general>
  <tags>
+  <tag>station</tag>
   <tag>military</tag>
+  <tag>refuel</tag>
  </tags>
 </spob>

--- a/dat/spob/wolf_i.xml
+++ b/dat/spob/wolf_i.xml
@@ -3,7 +3,7 @@
  <pos x="-989.152184" y="-1058.162801"/>
  <GFX>
   <space>moon-A00.webp</space>
-  <exterior>aquatic2.webp</exterior>
+  <exterior>lava.webp</exterior>
  </GFX>
  <general>
   <class>A</class>

--- a/dat/spob/wolf_ii.xml
+++ b/dat/spob/wolf_ii.xml
@@ -3,10 +3,10 @@
  <pos x="3714.113093" y="1291.286631"/>
  <GFX>
   <space>moon-P02.webp</space>
-  <exterior>oceanic2.webp</exterior>
+  <exterior>snow.webp</exterior>
  </GFX>
  <general>
-  <class>J</class>
+  <class>P</class>
   <population>0</population>
   <hide>2.000000</hide>
   <services/>

--- a/dat/spob/wolf_vii.xml
+++ b/dat/spob/wolf_vii.xml
@@ -2,8 +2,8 @@
 <spob name="Wolf VII">
  <pos x="-4406.557961" y="-11646.599861"/>
  <GFX>
-  <space>K02.webp</space>
-  <exterior>mining.webp</exterior>
+  <space>J02.webp</space>
+  <exterior>gas.webp</exterior>
  </GFX>
  <general>
   <class>J</class>

--- a/dat/spob/wonclock.xml
+++ b/dat/spob/wonclock.xml
@@ -43,6 +43,7 @@
   <item>Soromid Elite Outfits</item>
  </tech>
  <tags>
+  <tag>rich</tag>
   <tag>research</tag>
  </tags>
 </spob>

--- a/dat/spob/worgen.xml
+++ b/dat/spob/worgen.xml
@@ -3,7 +3,7 @@
  <pos x="-6032.011259" y="-654.104609"/>
  <GFX>
   <space>D00.webp</space>
-  <exterior>desertic4.webp</exterior>
+  <exterior>mining6.webp</exterior>
  </GFX>
  <general>
   <class>D</class>

--- a/dat/spob/wormhole_ngc13674.xml
+++ b/dat/spob/wormhole_ngc13674.xml
@@ -14,4 +14,7 @@
    <uninhabited/>
   </services>
  </general>
+ <tags>
+  <tag>wormhole</tag>
+ </tags>
 </spob>

--- a/dat/spob/wormhole_ngc15670.xml
+++ b/dat/spob/wormhole_ngc15670.xml
@@ -14,4 +14,7 @@
    <uninhabited/>
   </services>
  </general>
+ <tags>
+  <tag>wormhole</tag>
+ </tags>
 </spob>

--- a/dat/spob/wormhole_ngc1931.xml
+++ b/dat/spob/wormhole_ngc1931.xml
@@ -14,4 +14,7 @@
    <uninhabited/>
   </services>
  </general>
+ <tags>
+  <tag>wormhole</tag>
+ </tags>
 </spob>

--- a/dat/spob/wormhole_ngc4087.xml
+++ b/dat/spob/wormhole_ngc4087.xml
@@ -14,4 +14,7 @@
    <uninhabited/>
   </services>
  </general>
+ <tags>
+  <tag>wormhole</tag>
+ </tags>
 </spob>

--- a/dat/spob/worscha.xml
+++ b/dat/spob/worscha.xml
@@ -43,4 +43,7 @@
   <item>Hulls Elite</item>
   <item>Sirius Elite Outfits</item>
  </tech>
+ <tags>
+  <tag>rich</tag>
+ </tags>
 </spob>

--- a/dat/spob/wsthvn_d1.xml
+++ b/dat/spob/wsthvn_d1.xml
@@ -3,7 +3,7 @@
  <pos x="2699.310180" y="979.886572"/>
  <GFX>
   <space>D07.webp</space>
-  <exterior>lava.webp</exterior>
+  <exterior>mining2.webp</exterior>
  </GFX>
  <general>
   <class>D</class>

--- a/dat/spob/wsthvn_p1.xml
+++ b/dat/spob/wsthvn_p1.xml
@@ -3,7 +3,7 @@
  <pos x="-2939.659716" y="-3642.219900"/>
  <GFX>
   <space>P02.webp</space>
-  <exterior>lava.webp</exterior>
+  <exterior>snow.webp</exterior>
  </GFX>
  <general>
   <class>P</class>

--- a/dat/spob/xavier.xml
+++ b/dat/spob/xavier.xml
@@ -3,7 +3,7 @@
  <pos x="-1725.191997" y="2044.671996"/>
  <GFX>
   <space>X00.webp</space>
-  <exterior>aquatic2.webp</exterior>
+  <exterior>methane.webp</exterior>
  </GFX>
  <general>
   <class>X</class>

--- a/dat/spob/yak_station.xml
+++ b/dat/spob/yak_station.xml
@@ -12,7 +12,7 @@
   <range>2</range>
  </presence>
  <general>
-  <class>0</class>
+  <class>1</class>
   <population>1000</population>
   <hide>2.000000</hide>
   <services>
@@ -25,6 +25,7 @@
   <bar>Most of the people in this bar are Soromid soldiers. There are few officers, since they have their own facility elsewhere on the station.</bar>
  </general>
  <tags>
+  <tag>station</tag>
   <tag>restricted</tag>
   <tag>military</tag>
  </tags>

--- a/dat/spob/yaroslav_farming_station.xml
+++ b/dat/spob/yaroslav_farming_station.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>0</class>
-  <population>1000</population>
+  <population>2222</population>
   <hide>2.000000</hide>
   <services>
    <land/>
@@ -22,6 +22,10 @@
   </services>
   <commodities/>
   <description>This farming facility provides the nearby systems with food. Some of the produce is shipped to the nearby world of Boowoy, but the majority is traded out of system.</description>
-  <bar>Most visitors in this spaceport bar are here for the same reason. They want to buy food so they can sell it at a planet that imports it for a profit. Some merchants time their purchase right after one of the harvests that happen once every dozen decaperiods or so, to get the lowest prices possible.</bar>
+  <bar>Most visitors to this spaceport bar are here for the same reason. They want to buy food so they can sell it at a planet that imports it for a profit. Some merchants time their purchase right after one of the harvests that happen once every dozen decaperiods or so to get the lowest prices possible.</bar>
  </general>
+ <tags>
+  <tag>station</tag>
+  <tag>agriculture</tag>
+ </tags>
 </spob>

--- a/dat/spob/yrina.xml
+++ b/dat/spob/yrina.xml
@@ -26,4 +26,7 @@
   <description>Yrina is a resource world that's being strip-mined by the Sirii. The climate is harsh and almost all of the planet's surface is frozen, but in some cases that is actually desirable, as substances that would normally be fluid are now solid, and therefore mined more easily. Yrina supplies mostly Aesir, but some of the more exotic elements are exported to other parts of Sirius space, and beyond.</description>
   <bar>The bar has various displays that provide the patrons with details about the mining process, and the current state of the operation in various areas. Though to most visitors it is of passing interest at best, you've got to at least hand it to the Sirius that they take an informative approach to their operation here.</bar>
  </general>
+ <tags>
+  <tag>mining</tag>
+ </tags>
 </spob>


### PR DESCRIPTION
Tags, proofreading, planetary class / station class and exterior shots all jigged to better match the descriptions and make them better. Also added two more tags; refuel - for refueling stops since they have nothing else to recommend them despite being busy (for the location) but having near zero other use, wormhole - for wormholes.
I should note that I have used the station tag also for gas giant spaceports but the class is left to refer to the Gas Giant itself... this also happens for a couple of other spobs where a station is tied to its planet (including a pirate clan homeworld).
Oh, also changed a few of the populations that seemed a little odd - a major argiculture station with barely anyone onboard seems odd given the exponential need for support services once you have even a "small" group of specialists working in a place, for example :)

Also: Are there any special values for population? I was wondering if it might be more appropriate to list military spobs as having classified population (and maybe other things) but then again maybe it would be better to keep the spob.xml with the actual data and use the military tag to restrict this information unless you have a high enough standing with the owning faction?