### PR TITLE
Improved Cargo hull cores

### DIFF
--- a/dat/outfits/core_hull/large/sk_large_cargo_hull.xml
+++ b/dat/outfits/core_hull/large/sk_large_cargo_hull.xml
@@ -7,14 +7,18 @@
   <priority>7</priority>
   <mass>550</mass>
   <price>1100000</price>
-  <description>This cargo hull from Schafer &amp; Kane Industries makes use of state-of-the-art defensive alloys, which allows it to free up even more space for cargo without sacrificing too much durability.</description>
+  <description>This cargo hull from Schafer &amp; Kane Industries makes use of state-of-the-art defensive alloys, which allows it to free up even more space for cargo without sacrificing too much durability. Along with the increased space their (in)famous electromagnetic shockwve absorbtion generator comes built in, turning CPU power and a little more obviousness into missile james, tracking zero-points and reduced secondary splash damage, turtling has never been safer.</description>
   <gfx_store>cargo_hull_l.webp</gfx_store>
+  <cpu>-160</cpu>
  </general>
  <specific type="modification">
   <cargo>400</cargo>
-  <absorb>42</absorb>
+  <absorb>58</absorb>
   <armour>1100</armour>
   <cargo_inertia>-25</cargo_inertia>
   <cargo_mod>25</cargo_mod>
+  <ew_hide>-20</ew_hide>
+  <ew_evade>10</ew_evade>
+  <jam_chance>50</jam_chance>
  </specific>
 </outfit>

--- a/dat/outfits/core_hull/medium/sk_medium_cargo_hull.xml
+++ b/dat/outfits/core_hull/medium/sk_medium_cargo_hull.xml
@@ -7,14 +7,18 @@
   <priority>7</priority>
   <mass>140</mass>
   <price>320000</price>
-  <description>Schafer &amp; Kane Industries have developed a hull modification that provides both ample cargo space and protection.</description>
+  <description>Schafer &amp; Kane Industries have developed a hull modification that provides both ample cargo space and protection. Also deciding "in for a penny, in for a pound", an electromagnetic shockwave absorbtion generator was added, typically this increases greatly but since the hull is already rather lumpy due to the cargo pods... on the other hand, for the price of some CPU power, missile jams, tracking zero-points and reduced secondary splash damage are all achieved making this hull rather more resiliant.</description>
   <gfx_store>cargo_hull_m.webp</gfx_store>
+  <cpu>-64</cpu>
  </general>
  <specific type="modification">
   <cargo>120</cargo>
-  <absorb>12</absorb>
+  <absorb>20</absorb>
   <armour>180</armour>
   <cargo_inertia>-25</cargo_inertia>
   <cargo_mod>25</cargo_mod>
+  <ew_hide>-20</ew_hide>
+  <ew_evade>10</ew_evade>
+  <jam_chance>50</jam_chance>
  </specific>
 </outfit>

--- a/dat/outfits/core_hull/small/sk_small_cargo_hull.xml
+++ b/dat/outfits/core_hull/small/sk_small_cargo_hull.xml
@@ -7,14 +7,18 @@
   <priority>7</priority>
   <mass>40</mass>
   <price>120000</price>
-  <description>Though a pricey investment for small couriers, this hull modification from Schafer &amp; Kane Industries provides an impressive amount of cargo space without compromising the hull's integrity.</description>
+  <description>Though a pricey investment for small couriers, this hull modification from Schafer &amp; Kane Industries provides an impressive amount of cargo space without compromising the hull's integrity. Since the extra bulk and protrusions from the hull make it easier to detect anyway, S&amp;K went ahead and added an eletromagnetic shockwave absorbtion generator that, though also increasing the hull signature and CPU usage also causes missile jams, reduces the hulls tracability and reduces splash damage from weapon strikes.</description>
   <gfx_store>cargo_hull_s.webp</gfx_store>
+  <cpu>-24</cpu>
  </general>
  <specific type="modification">
   <cargo>30</cargo>
-  <absorb>2</absorb>
-  <armour>55</armour>
+  <absorb>6</absorb>
+  <armour>60</armour>
   <cargo_inertia>-25</cargo_inertia>
   <cargo_mod>25</cargo_mod>
+  <ew_hide>-20</ew_hide>
+  <ew_evade>10</ew_evade>
+  <jam_chance>50</jam_chance>
  </specific>
 </outfit>


### PR DESCRIPTION
This is a response to #2119 that doesn't involve improving collision detection but trys to improve and differentiate traders from combat (and stealth) ships... think turtles :)
It may well also work alongside #2121 but maybe both might have to be reduced in effectiveness if PD turrets happen, otherwise trader might become impenitrable... we want the pirates to have some chance before security turns up... if security turns up! ;)

I've added a secondary function to the cargo hulls to make them rather more resistant to damage at the expense of CPU and detection. Traders wanting the largest possible cargo holds are generally not going to worry about CPU (they're not trying to enter combat) and they are cargo ships... being detected quicker makes it easier for security to find and help them and they were unlikely to hide that well anyway. At least this way they can better stand a beating before popping!
I also feel that this sort of higher defense a the cost to potential offense (CPU usage makes more weapons harder) might be a good way to differentiate trader ships from simply being bad combat ships. It also affords them protection without sacrificing cargo.