### PR TITLE
Red Star Cargo hulls

### DIFF
--- a/dat/outfits/core_hull/large/rs_large_cargo_hull.xml
+++ b/dat/outfits/core_hull/large/rs_large_cargo_hull.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Red Star Large Cargo Hull">
+ <general>
+  <typename>Core Systems (Hull)</typename>
+  <slot prop="hull">structure</slot>
+  <size>large</size>
+  <priority>7</priority>
+  <mass>550</mass>
+  <price>1200000</price>
+  <description>This cargo hull from the Red Star Organisation makes use of state-of-the-art defensive alloys, which allows it to free up even more space for cargo without sacrificing too much durability. Along with the increased space, their (in)famous electromagnetic shockwave absorbtion generator comes built in, turning CPU power and a little more obviousness into missile james, tracking zero-points and reduced secondary splash damage, turtling has never been safer.</description>
+  <gfx_store>cargo_hull_l.webp</gfx_store>
+  <cpu>-160</cpu>
+ </general>
+ <specific type="modification">
+  <cargo>600</cargo>
+  <absorb>58</absorb>
+  <armour>1100</armour>
+  <cargo_inertia>-10</cargo_inertia>
+  <cargo_mod>10</cargo_mod>
+  <ew_hide>-20</ew_hide>
+  <ew_evade>10</ew_evade>
+  <jam_chance>42</jam_chance>
+ </specific>
+</outfit>

--- a/dat/outfits/core_hull/medium/rs_medium_cargo_hull.xml
+++ b/dat/outfits/core_hull/medium/rs_medium_cargo_hull.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Red Star Medium Cargo Hull">
+ <general>
+  <typename>Core Systems (Hull)</typename>
+  <slot prop="hull">structure</slot>
+  <size>medium</size>
+  <priority>7</priority>
+  <mass>140</mass>
+  <price>360000</price>
+  <description>The Red Star Organisation have developed a hull modification that provides both ample cargo space and protection for their own work and have now started selling it to others. Deciding "in for a penny, in for a pound", an electromagnetic shockwave absorbtion generator was added, typically this makes the hull rather pointy and scanner obvious but since the hull is already rather lumpy due to the cargo pods... on the other hand, for the price of some CPU power, missile jams, tracking zero-points and reduced secondary splash damage are all achieved making this hull rather more resiliant.</description>
+  <gfx_store>cargo_hull_m.webp</gfx_store>
+  <cpu>-64</cpu>
+ </general>
+ <specific type="modification">
+  <cargo>80</cargo>
+  <absorb>20</absorb>
+  <armour>180</armour>
+  <cargo_inertia>-10</cargo_inertia>
+  <cargo_mod>10</cargo_mod>
+  <ew_hide>-20</ew_hide>
+  <ew_evade>10</ew_evade>
+  <jam_chance>42</jam_chance>
+ </specific>
+</outfit>

--- a/dat/outfits/core_hull/small/rs_small_cargo_hull.xml
+++ b/dat/outfits/core_hull/small/rs_small_cargo_hull.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Red Star Small Cargo Hull">
+ <general>
+  <typename>Core Systems (Hull)</typename>
+  <slot prop="hull">structure</slot>
+  <size>small</size>
+  <priority>7</priority>
+  <mass>40</mass>
+  <price>140000</price>
+  <description>Expensive though they are the Red Star Organisation started producing these hulls to provide more cargo space but also provide better protection to their ships involved in relief efforts during wars and working in less savoury parts of the galaxy. Since the extra bulk and protrusions from the cargo sections make it easier to detect anyway, the Organisation went ahead and added an eletromagnetic shockwave absorbtion generator that, though also increasing the hull signature and CPU usage also causes missile jams, reduces the hulls tracability and reduces splash damage from weapon strikes.</description>
+  <gfx_store>cargo_hull_s.webp</gfx_store>
+  <cpu>-24</cpu>
+ </general>
+ <specific type="modification">
+  <cargo>20</cargo>
+  <absorb>6</absorb>
+  <armour>60</armour>
+  <cargo_inertia>-10</cargo_inertia>
+  <cargo_mod>10</cargo_mod>
+  <ew_hide>-20</ew_hide>
+  <ew_evade>10</ew_evade>
+  <jam_chance>42</jam_chance>
+ </specific>
+</outfit>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -208,17 +208,20 @@
   <item>S&amp;K Ultralight Combat Plating</item>
   <item>S&amp;K Light Combat Plating</item>
   <item>Nexus Light Stealth Plating</item>
+  <item>Red Star Small Cargo Hull</item>
   <item>S&amp;K Small Cargo Hull</item>
   <item>Patchwork Medium Plating</item>
   <item>Unicorp D-12 Medium Plating</item>
   <item>Unicorp D-24 Medium Plating</item>
   <item>S&amp;K Medium Combat Plating</item>
   <item>Nexus Medium Stealth Plating</item>
+  <item>Red Star Medium Cargo Hull</item>
   <item>S&amp;K Medium Cargo Hull</item>
   <item>S&amp;K Medium-Heavy Combat Plating</item>
   <item>Patchwork Heavy Plating</item>
   <item>Unicorp D-48 Heavy Plating</item>
   <item>Unicorp D-68 Heavy Plating</item>
+  <item>Red Star Large Cargo Hull</item>
   <item>S&amp;K Large Cargo Hull</item>
   <item>S&amp;K Heavy Combat Plating</item>
   <item>S&amp;K Superheavy Combat Plating</item>
@@ -402,6 +405,15 @@
   <item>Grave Lance</item>
   <item>Grave Beam</item>
   <item>Ragnarok Beam</item>
+ </tech>
+ <tech name="Mining 1">
+  <item>Mining Lance MK1</item>
+  <item>S&amp;K Plasma Drill</item>
+ </tech>
+ <tech name="Mining 2">
+  <item>Mining Lance MK2</item>
+  <item>Nexus Drill Lance</item>
+  <item>S&amp;K Heavy Plasma Drill</item>
  </tech>
 
  <!-- Generic Outfits -->
@@ -635,6 +647,11 @@
  <tech name="Criminal Outfits">
   <item>Camouflage Burster</item>
  </tech>
+ <tech name="Mining Outfits">
+  <item>Asteroid Scanner</item>
+  <item>Medium Weapon License</item>
+  <item>Milspec Impacto-Plastic Coating</item>
+ </tech>
  <tech name="Star Maps">
   <item>Map: Nebula Edge</item>
   <item>Map: Dvaered-Soromid Trade Route</item>
@@ -728,6 +745,14 @@
   <item>Pirate Hyena Bay</item>
   <item>Counterfeit Heavy Weapon License</item>
   <item>Counterfeit Heavy Combat Vessel License</item>
+ </tech>
+ <tech name="Cargo Trader Outfits">
+  <item>Small Cargo Pod</item>
+  <item>Medium Cargo Pod</item>
+  <item>Large Cargo Pod</item>
+  <item>Engines Cargo</item>
+  <item>Hulls Cargo</item>
+  <item>Large Civilian Vessel License</item>
  </tech>
 
  <!-- outfits -->
@@ -968,6 +993,14 @@
   <item>Unicorp D-48 Heavy Plating</item>
   <item>Unicorp D-68 Heavy Plating</item>
  </tech>
+ <tech name="Hulls Cargo">
+  <item>Red Star Small Cargo Hull</item>
+  <item>Red Star Medium Cargo Hull</item>
+  <item>Red Star Large Cargo Hull</item>
+  <item>S&amp;K Small Cargo Hull</item>
+  <item>S&amp;K Medium Cargo Hull</item>
+  <item>S&amp;K Large Cargo Hull</item>
+ </tech>
  <tech name="Hulls Medium">
   <item>Unicorp D-2 Light Plating</item>
   <item>Unicorp D-4 Light Plating</item>
@@ -975,9 +1008,7 @@
   <item>Unicorp D-24 Medium Plating</item>
   <item>Unicorp D-48 Heavy Plating</item>
   <item>Unicorp D-68 Heavy Plating</item>
-  <item>S&amp;K Small Cargo Hull</item>
-  <item>S&amp;K Medium Cargo Hull</item>
-  <item>S&amp;K Large Cargo Hull</item>
+  <item>Hulls Cargo</item>
  </tech>
  <tech name="Hulls High">
   <item>S&amp;K Ultralight Combat Plating</item>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -762,10 +762,12 @@
  <!-- Ships -->
  <tech name="Basic Civilian Ships">
   <item>Ancestor</item>
-  <item>Gawain</item>
   <item>Hyena</item>
-  <item>Llama</item>
   <item>Schroedinger</item>
+ </tech>
+ <tech name="Yachts">
+  <item>Gawain</item>
+  <item>Llama</item>
  </tech>
  <tech name="Basic Trade Ships">
   <item>Koala</item>
@@ -1007,7 +1009,12 @@
   <item>Unicorp D-24 Medium Plating</item>
   <item>Unicorp D-48 Heavy Plating</item>
   <item>Unicorp D-68 Heavy Plating</item>
-  <item>Hulls Cargo</item>
+  <item>Red Star Small Cargo Hull</item>
+  <item>Red Star Medium Cargo Hull</item>
+  <item>Red Star Large Cargo Hull</item>
+  <item>S&amp;K Small Cargo Hull</item>
+  <item>S&amp;K Medium Cargo Hull</item>
+  <item>S&amp;K Large Cargo Hull</item>
  </tech>
  <tech name="Hulls High">
   <item>S&amp;K Ultralight Combat Plating</item>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -650,7 +650,6 @@
  <tech name="Mining Outfits">
   <item>Asteroid Scanner</item>
   <item>Medium Weapon License</item>
-  <item>Milspec Impacto-Plastic Coating</item>
  </tech>
  <tech name="Star Maps">
   <item>Map: Nebula Edge</item>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -129,6 +129,7 @@ dat/outfits/core_engine/small/unicorp_hawk_350_engine.xml
 dat/outfits/core_engine/small/zalek_test_engine.xml
 dat/outfits/core_hull/dummy_plating.xml
 dat/outfits/core_hull/large/patchwork_heavy_plating.xml
+dat/outfits/core_hull/large/rs_large_cargo_hull.xml
 dat/outfits/core_hull/large/sk_heavy_combat_plating.xml
 dat/outfits/core_hull/large/sk_large_cargo_hull.xml
 dat/outfits/core_hull/large/sk_superheavy_combat_plating.xml
@@ -136,6 +137,7 @@ dat/outfits/core_hull/large/unicorp_d48_heavy_plating.xml
 dat/outfits/core_hull/large/unicorp_d68_heavy_plating.xml
 dat/outfits/core_hull/medium/nexus_medium_stealth_plating.xml
 dat/outfits/core_hull/medium/patchwork_medium_plating.xml
+dat/outfits/core_hull/medium/rs_medium_cargo_hull.xml
 dat/outfits/core_hull/medium/sk_medium_cargo_hull.xml
 dat/outfits/core_hull/medium/sk_medium_combat_plating.xml
 dat/outfits/core_hull/medium/sk_mediumheavy_combat_plating.xml
@@ -143,6 +145,7 @@ dat/outfits/core_hull/medium/unicorp_d12_medium_plating.xml
 dat/outfits/core_hull/medium/unicorp_d24_medium_plating.xml
 dat/outfits/core_hull/small/nexus_light_stealth_plating.xml
 dat/outfits/core_hull/small/patchwork_light_plating.xml
+dat/outfits/core_hull/small/rs_small_cargo_hull.xml
 dat/outfits/core_hull/small/sk_light_combat_plating.xml
 dat/outfits/core_hull/small/sk_small_cargo_hull.xml
 dat/outfits/core_hull/small/sk_ultralight_combat_plating.xml


### PR DESCRIPTION
So I've reduce the missile jam a little, reduced the cargo space by a third, reduced the cargo mod and inertia benefits from 25 to 10 and made these hulls more expensive. I hope this is a reasonable tradeoff, especially as the CPU costs are just as high and detection is still as high as it was before.
I also added into lore that the Red Star organisation created hem for their humanitarian work since it seems appropriate that an aid agency would do this if necessary given the higher risks their work poses and that (in theory) they shouldn't be being targeted but stray laser shots don't recognise international symbols! ;)
I should note that there are also a couple of changes to tech.xml to allow for future use in the guild stuff but which should probably be there now anyway.

This is a replacement request for #2122 as it appears my git interface (git desktop) doesn't have the ability to force push :/ ??