### PR TITLE
World updates (Frontier and Soromid stations)

### DIFF
--- a/dat/spob/atalanta.xml
+++ b/dat/spob/atalanta.xml
@@ -36,4 +36,10 @@
   <item>Missiles 1</item>
   <item>Missiles 2</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>rural</tag>
+  <tag>tourism</tag>
+  <tag>mining</tag>
+ </tags>
 </spob>

--- a/dat/spob/avoss.xml
+++ b/dat/spob/avoss.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>A</class>
-  <population>600000</population>
+  <population>6e+05</population>
   <hide>1.000000</hide>
   <services>
    <land>land_lowclass</land>
@@ -23,4 +23,10 @@
   <commodities/>
   <description>Avoss was originally a mediocre but habitable world. When the fourteenth colony ship, Petrovsk, arrived, its colonists considered themselves fairly fortunate to have found a place they could call home. However, some fifty years after the expedition had touched down, the world began to change. Seismic activity everywhere began escalating off the charts causing earthquakes and volcanic eruptions the world over. The world is now devastated, a mere shadow of its former self. The colonists have managed to survive, however, and the hardy remain even today.</description>
  </general>
+ <tags>
+  <tag>old</tag>
+  <tag>poor</tag>
+  <tag>rural</tag>
+  <tag>mining</tag>
+ </tags>
 </spob>

--- a/dat/spob/cetrat.xml
+++ b/dat/spob/cetrat.xml
@@ -34,4 +34,10 @@
   <item>Star Maps</item>
   <item>Missiles 1</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>rich</tag>
+  <tag>tourism</tag>
+  <tag>medical</tag>
+</tags>
 </spob>

--- a/dat/spob/dawn.xml
+++ b/dat/spob/dawn.xml
@@ -26,4 +26,11 @@
   <description>Gilligan's Light was one of the first systems to ever be chosen for a colonisation project. Dawn was the first world on which humans set foot in this sector of space, despite the fact that the colony ship sent here, Mythril, was only the fifth to be launched. Nevertheless, Dawn proved to be one of the most fertile expeditions in the First Growth and its development outstripped that of most other worlds. With the advent of hyperspace travel, Dawn found itself the local capital of the Frontier worlds and so is graced by the Frontier Council hanging overhead. This status is strictly symbolic but it explains why the FLF have chosen to rally around Gilligan's Light.</description>
   <bar>Dawn's bar has a rustic feel to it, the locals have made a point of keeping the style close to what was the prevalent design in the early expansion era. Other than that, this bar doesn't have much to set it apart from others. The noise, the smell and the drunks are features that are commonplace throughout the galaxy.</bar>
  </general>
+ <tags>
+  <tag>old</tag>
+  <tag>rich</tag>
+  <tag>urban</tag>
+  <tag>trade</tag>
+  <tag>government</tag>
+ </tags>
 </spob>

--- a/dat/spob/gilligans_light_iii.xml
+++ b/dat/spob/gilligans_light_iii.xml
@@ -3,10 +3,10 @@
  <pos x="-7036.538612" y="-6116.121552"/>
  <GFX>
   <space>I05.webp</space>
-  <exterior>station00.webp</exterior>
+  <exterior>uninhabited-rocky-blue-00.webp </exterior>
  </GFX>
  <general>
-  <class>A</class>
+  <class>I</class>
   <population>0</population>
   <hide>1.000000</hide>
   <services/>

--- a/dat/spob/jaegnhild.xml
+++ b/dat/spob/jaegnhild.xml
@@ -30,4 +30,10 @@
  <tech>
   <item>Basic Trade Ships</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>rich</tag>
+  <tag>tourism</tag>
+  <tag>trade</tag>
+ </tags>
 </spob>

--- a/dat/spob/jorlan.xml
+++ b/dat/spob/jorlan.xml
@@ -35,4 +35,11 @@ Jorlan's inhabitants are mostly part of the ore refining process, as it supplies
   <item>Star Maps</item>
   <item>Low Tech Upgrades</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>poor</tag>
+  <tag>mining</tag>
+  <tag>industrial</tag>
+  <tag>trade</tag>
+</tags>
 </spob>

--- a/dat/spob/khelim.xml
+++ b/dat/spob/khelim.xml
@@ -34,4 +34,9 @@
   <item>Basic Outfits 2</item>
   <item>Missiles 1</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>urban</tag>
+  <tag>trade</tag>
+ </tags>
 </spob>

--- a/dat/spob/lapra.xml
+++ b/dat/spob/lapra.xml
@@ -31,6 +31,7 @@
  <tech>
   <item>Systems Low</item>
   <item>Hulls Low</item>
+  <item>Hulls Cargo</item>
   <item>Hulls Medium</item>
   <item>Engines Low</item>
   <item>Engines Medium</item>
@@ -41,4 +42,9 @@
   <item>Light Civilian Combat Ships</item>
   <item>Bulk Trade Ships</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>mining</tag>
+  <tag>trade</tag>
+ </tags>
 </spob>

--- a/dat/spob/new_dortmund.xml
+++ b/dat/spob/new_dortmund.xml
@@ -12,7 +12,7 @@
   <range>2</range>
  </presence>
  <general>
-  <class>A</class>
+  <class>M</class>
   <population>1e+09</population>
   <hide>1.000000</hide>
   <services>
@@ -34,8 +34,14 @@ New Dortmund was never very successful in any sense of the term, but it is still
   <item>Systems Medium</item>
   <item>Engines Medium</item>
   <item>Engines Cargo</item>
+  <item>Hulls Cargo</item>
   <item>Basic Outfits 2</item>
   <item>Star Maps</item>
   <item>Bulk Trade Ships</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>poor</tag>
+  <tag>rural</tag>
+ </tags>
 </spob>

--- a/dat/spob/nonuri.xml
+++ b/dat/spob/nonuri.xml
@@ -12,8 +12,8 @@
   <range>2</range>
  </presence>
  <general>
-  <class>A</class>
-  <population>900000</population>
+  <class>M</class>
+  <population>9e+05</population>
   <hide>2.000000</hide>
   <services>
    <land/>
@@ -26,4 +26,9 @@
   <description>Nonuri is a world with an under-developed economy, even by Frontier standards. It barely manages to keep itself from going bankrupt. The people who live here stay mainly out of a sense of belonging, a feeling that Nonuri is their birthright. In fact, Nonuri was colonized by the colony ship Wendigo, which makes Nonuri one of the oldest extrasolar human settlements. Unfortunately for the locals, most of the galaxy doesn't care quite as much as they do.</description>
   <bar>The spaceport bar is humble, yet tidy and functional. The Nonurians may not enjoy a rich life, but they make the most of what they've got. Though the equipment is outdated, in some cases by several generations, this bar has most of the things an intergalactic traveller needs to keep abreast of events.</bar>
  </general>
+ <tags>
+  <tag>old</tag>
+  <tag>poor</tag>
+  <tag>rural</tag>
+ </tags>
 </spob>

--- a/dat/spob/readme.md
+++ b/dat/spob/readme.md
@@ -57,10 +57,14 @@ Below is the complete list of dominantly used descriptive tags. It should be not
 * **mining**: mining is an important part of the spob economy
 * **agriculture**: agriculture is an important part of the spob economy
 * **industrial**: industry is an important part of the spob economy
+* **medical**: medicine is an important part of the spob economy
 * **trade**: trade is an important part of the spob economy
+* **shipbuilding**: shipbuilding is an important part of the spob economy
 * **research**: the spob has a strong focus in research (special research laboratories, etc...)
 * **immigration**: the spob draws in a large number of immigrants or is being colonised
 * **refuel**: the spobs reason for existance is as a fueling point
+* **government**: the spob has important government functions or hosts the central government
 * **military**: the spob has an important factional military presence
+* **religious**: the spob has an important religious significance or presence
 * **prison**: the spob has important prison installations
 * **criminal**: the spob has a large criminal element such as important pirate or mafia presence

--- a/dat/spob/sorom.xml
+++ b/dat/spob/sorom.xml
@@ -3,7 +3,7 @@
  <pos x="6662.805531" y="-3676.348154"/>
  <GFX>
   <space>A02.webp</space>
-  <exterior>aquatic2.webp</exterior>
+  <exterior>lava.webp</exterior>
  </GFX>
  <general>
   <class>A</class>

--- a/dat/spob/soromid_customs_central.xml
+++ b/dat/spob/soromid_customs_central.xml
@@ -12,17 +12,22 @@
   <range>2</range>
  </presence>
  <general>
-  <class>0</class>
-  <population>500000</population>
+  <class>1</class>
+  <population>5e+05</population>
   <hide>2.000000</hide>
   <services>
    <land/>
    <refuel/>
   </services>
   <commodities/>
-  <description>The Soromid and the rest of the galaxy have enjoyed a tense kind of friendship ever since the first bioships launched from Sorom. The rest of humanity is keenly interested in the Soromid genetic treatments, and the Soromid in turn are happy to turn a profit on their expertise, but there's still some degree of caution on both sides. Soromid Customs Central is a visible sign of that caution. It houses a full division of Soromid ships, and is responsible for maintaining order as well as inspecting the traffic that passes through Oberon.</description>
+  <description>The Soromid and the rest of the galaxy have enjoyed a tense kind of friendship ever since the first bioships launched from Sorom. The rest of humanity is keenly interested in Soromid genetic treatments and the Soromid, in turn, are happy to turn a profit on their expertise, but there's still some degree of caution on both sides. Soromid Customs Central is a visible sign of that caution. It houses a full division of Soromid ships and is responsible for maintaining order as well as inspecting the traffic that passes through Oberon.</description>
  </general>
  <tags>
+  <tag>restricted</tag>
+  <tag>station</tag>
+  <tag>new</tag>
+  <tag>trade</tag>
+  <tag>government</tag>
   <tag>military</tag>
  </tags>
 </spob>

--- a/dat/spob/soromid_databank.xml
+++ b/dat/spob/soromid_databank.xml
@@ -12,8 +12,8 @@
   <range>2</range>
  </presence>
  <general>
-  <class>0</class>
-  <population>100</population>
+  <class>1</class>
+  <population>1e+02</population>
   <hide>2.000000</hide>
   <services>
    <land>srm_mil_restricted</land>
@@ -26,6 +26,10 @@
  </general>
  <tags>
   <tag>restricted</tag>
+  <tag>nonpc</tag>
+  <tag>station</tag>
+  <tag>medical</tag>
+  <tag>government</tag>
   <tag>research</tag>
   <tag>military</tag>
  </tags>

--- a/dat/spob/soromid_wards_alpha.xml
+++ b/dat/spob/soromid_wards_alpha.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>0</class>
-  <population>30000</population>
+  <population>3e+04</population>
   <hide>2.000000</hide>
   <services>
    <land/>
@@ -24,6 +24,10 @@
   <description>As everyone knows, the Soromid are exporters of genetic treatment services. People from all over the galaxy travel to Soromid space to have their natural abilities enhanced, diseases cured or appearances improved. All of these people need to be treated somewhere, and this is one such place. Soromid Wards Alpha is a massive medical facility, the largest of all the Soromid Wards. Thousands of clients can be treated here at any one time. Most of the station's volume is taken up by personal treatment tanks, where clients spend anywhere from a 5 to 65 decaperiods in an artificial coma while their genetic code is rewritten.</description>
  </general>
  <tags>
+  <tag>restricted</tag>
+  <tag>station</tag>
   <tag>medical</tag>
+  <tag>rich</tag>
+  <tag>tourism</tag>
  </tags>
 </spob>

--- a/dat/spob/soromid_wards_beta.xml
+++ b/dat/spob/soromid_wards_beta.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>0</class>
-  <population>70000</population>
+  <population>7e+04</population>
   <hide>2.000000</hide>
   <services>
    <land/>
@@ -26,7 +26,11 @@
   <bar>The spacedock bar, which doubles as a waiting room for clients, provides its visitors with information on the services that are rendered on Beta, such as ocular augmentation, bone and muscle reinforcement, disease immunities and reproductive facility expansion.</bar>
  </general>
  <tags>
-  <tag>research</tag>
+  <tag>restricted</tag>
+  <tag>nonpc</tag>
+  <tag>station</tag>
+  <tag>medical</tag>
   <tag>rich</tag>
+  <tag>research</tag>
  </tags>
 </spob>

--- a/dat/spob/soromid_wards_gamma.xml
+++ b/dat/spob/soromid_wards_gamma.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>0</class>
-  <population>100</population>
+  <population>1e+02</population>
   <hide>2.000000</hide>
   <services>
    <land>land_hiclass</land>
@@ -26,7 +26,10 @@
   <bar>Unlike Alpha and Beta, the spacedock bar on Gamma does not offer much information on what goes on in the facility. The Soromid learn about their genes and the modifications in youth education. They know what they're coming for.</bar>
  </general>
  <tags>
+  <tag>restricted</tag>
+  <tag>station</tag>
   <tag>rich</tag>
   <tag>research</tag>
+  <tag>medical</tag>
  </tags>
 </spob>

--- a/dat/spob/the_frontier_council.xml
+++ b/dat/spob/the_frontier_council.xml
@@ -13,7 +13,7 @@
  </presence>
  <general>
   <class>0</class>
-  <population>500</population>
+  <population>5e+02</population>
   <hide>2.000000</hide>
   <services>
    <land/>
@@ -22,4 +22,10 @@
   <commodities/>
   <description>This is the seat of the Frontier Council, the over-arching political body representing the Frontier to the rest of the galaxy. While the Council does not rule the Frontier worlds as such, it does set global policies such as trade taxes and constitutional standards.</description>
  </general>
+ <tags>
+  <tag>station</tag>
+  <tag>old</tag>
+  <tag>rich</tag>
+  <tag>government</tag>
+ </tags>
 </spob>

--- a/dat/spob/the_frontier_council.xml
+++ b/dat/spob/the_frontier_council.xml
@@ -23,6 +23,7 @@
   <description>This is the seat of the Frontier Council, the over-arching political body representing the Frontier to the rest of the galaxy. While the Council does not rule the Frontier worlds as such, it does set global policies such as trade taxes and constitutional standards.</description>
  </general>
  <tags>
+  <tag>restricted</tag>
   <tag>station</tag>
   <tag>old</tag>
   <tag>rich</tag>

--- a/dat/spob/tori.xml
+++ b/dat/spob/tori.xml
@@ -26,7 +26,7 @@
   </services>
   <commodities/>
   <description>When the thirteenth colony ship, Yamato Nadeshiko, arrived at Tori, it was sterile. Though it had both water and carbon in abundant supply, there was no life to be found. With the arrival of the mostly Asian human colonists, this changed. Human flora thrived on the planet, and within a century the planet had acquired a fully functional ecosystem. This marvel has inspired the inhabitants of Tori to leave much of the world's surface to nature. Though this means Tori's economic potential remains largely untapped, the thriving tourist industry largely compensates.</description>
-  <bar>The spaceport bar is more than just functional. Since most new arrivals on the planet come here first, the authorities have taken pains to make the bar appealing and comfortable. Of course, the fact that Tori is a tourist attraction also means drinks are quite expensive in this bar...</bar>
+  <bar>The spaceport bar is more than just functional. Since most new arrivals on the planet come here first, the authorities have taken pains to make the bar appealing and comfortable. Of course, the fact that Tori is a tourist attraction also means drinks are quite expensive in this bar…</bar>
  </general>
  <tech>
   <item>Basic Civilian Ships</item>
@@ -35,4 +35,9 @@
   <item>Low Tech Upgrades</item>
   <item>Basic Trade Ships</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>rural</tag>
+  <tag>tourism</tag>
+ </tags>
 </spob>

--- a/dat/spob/varaati.xml
+++ b/dat/spob/varaati.xml
@@ -30,6 +30,7 @@
  </general>
  <tech>
   <item>Engines Cargo</item>
+  <item>Hulls Cargo</item>
   <item>Systems Medium</item>
   <item>Engines Medium</item>
   <item>Basic Outfits 2</item>
@@ -38,4 +39,10 @@
   <item>Basic Trade Ships</item>
   <item>Bulk Trade Ships</item>
  </tech>
+ <tags>
+  <tag>old</tag>
+  <tag>rich</tag>
+  <tag>urban</tag>
+  <tag>trade</tag>
+</tags>
 </spob>

--- a/dat/spob/zuner.xml
+++ b/dat/spob/zuner.xml
@@ -24,7 +24,7 @@
   </services>
   <commodities/>
   <description>Zuner's surface has been dedicated almost entirely to crop growing. While there are some urban centres scattered around the world, their population is low compared to the residential megaplexes of more densely populated worlds. Though the community is, to a large extent, agricultural, the inhabitants are in no way out of touch with the rest of the galaxy and are, in fact, quite wealthy, due to how lucrative Zuner's choice of food production is.</description>
-  <bar>Many spacers think of agricultural worlds as backwater places that lag way behind the rest of the galaxy. Sometimes, they are right, but not in the case of Zuner. The spaceport is as modern as can be and the bar wouldn't be out of place even in the Sirius core.</bar>
+  <bar>Many spacers think of agricultural worlds as backwater places that lag way behind the rest of the galaxy. Sometimes, they are right, but not in the case of Zuner. The spaceport is as modern as can be and its bar wouldn't be out of place even in the Sirius core.</bar>
  </general>
  <tags>
   <tag>rich</tag>

--- a/dat/tech.xml
+++ b/dat/tech.xml
@@ -968,6 +968,11 @@
   <item>Unicorp D-48 Heavy Plating</item>
   <item>Unicorp D-68 Heavy Plating</item>
  </tech>
+ <tech name="Hulls Cargo">
+  <item>S&amp;K Small Cargo Hull</item>
+  <item>S&amp;K Medium Cargo Hull</item>
+  <item>S&amp;K Large Cargo Hull</item>
+ </tech>
  <tech name="Hulls Medium">
   <item>Unicorp D-2 Light Plating</item>
   <item>Unicorp D-4 Light Plating</item>


### PR DESCRIPTION
Tags, techs and exteriors updated.
The "Hulls Cargo" tech has also been added to relevant spobs; currently it duplicates some of the "Hulls Medium" hulls but this can be fixed once "Hulls Cargo" has been better propagated if this is wanted.
Also added a few lesser used tags that could be important; government (mostly for faction homeworlds), medicine (mostly Soromid and Red Star spobs), shipbuilding (for shipbuilding stations and the like), religious (for spobs of religious importance).