### PR TITLE
Fixes off-by-one error in mission id calculation

### DIFF
--- a/src/pilot_cargo.c
+++ b/src/pilot_cargo.c
@@ -236,7 +236,7 @@ unsigned int pilot_addMissionCargo( Pilot* pilot, const Commodity* cargo, int qu
    id = ++mission_cargo_id;
 
    /* Check for collisions with pilot and set ID generator to the max. */
-   max_id = 0;
+   max_id = 1;
    for (int i=0; i<array_size(pilot->commodities); i++)
       if (pilot->commodities[i].id > max_id)
          max_id = pilot->commodities[i].id;


### PR DESCRIPTION
Pilot cargo logic assumes that anything with mission id 0 is a non-mission cargo item, but the first mission item that is added becomes a mission item with id 0. This is an off-by-one error where regular commodities and mission commodities can get mixed up, but you will for instance find that if you have only one mission of 10 diamonds to be moved and buy 30 diamonds of commodities (before accepting the mission), those 30 "normal" diamonds will be locked while you are in space, and you will not be able to jettison them.

This PR rectifies the error by setting the minimum mission id to 1 (by setting the variable `max_id` to 1).

There might be other ways to achieve the same effect, but IMHO, a `max_id` for mission ids can never be 0 because the minimum mission id is 1 for all valid mission ids.