### PR TITLE
fix boarding hook edge case

### DIFF
--- a/dat/board.lua
+++ b/dat/board.lua
@@ -424,6 +424,7 @@ local function board_close ()
 end
 
 function board( plt )
+   if not plt:exists() then return end
    der.sfx.board:play()
    board_plt = plt
    loot_mod = player.pilot():shipstat("loot_mod", true)


### PR DESCRIPTION
if you board a pilot that is removed in a boarding hook, this line prevents the error that would have occurred when trying to reference the invalid pilot.