### PR TITLE
Fixed some issues of translation. (key names and start_* functions)

### DIFF
--- a/src/gettext.c
+++ b/src/gettext.c
@@ -296,3 +296,16 @@ double gettext_languageCoverage( const char* lang )
    array_free( paths );
    return (double)translated / gettext_nstrings;
 }
+
+
+/* The function is almost the same as p_() but msgctxt and msgid can be string variables.
+ */
+const char* pgettext_var( const char* msgctxt, const char* msgid )
+{
+   char *lookup = NULL;
+   const char* trans;
+   asprintf( &lookup, "%s" GETTEXT_CONTEXT_GLUE "%s", msgctxt, msgid );
+   trans = gettext_pgettext_impl( lookup, msgid );
+   free( lookup );
+   return trans;
+}

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -61,3 +61,7 @@ FORMAT_ARG(1) static inline const char* n_( const char* msgid, const char* msgid
  * The letter 'p' stands for 'particular' or 'special'.
  */
 #define p_( msgctxt, msgid )          gettext_pgettext_impl( msgctxt GETTEXT_CONTEXT_GLUE msgid, msgid )
+
+/** The function is almost the same as p_() but \p msgctxt and \p msgid can be string variables.
+ */
+const char* pgettext_var( const char* msgctxt, const char* msgid );

--- a/src/input.c
+++ b/src/input.c
@@ -478,7 +478,7 @@ void input_getKeybindDisplay( const char *keybind, char *buf, int len )
          if (key < 0x100 && isalpha(key))
             p += scnprintf( &buf[p], len-p, "%c", toupper(key) );
          else
-            p += scnprintf( &buf[p], len-p, "%s", _(SDL_GetKeyName(key)) );
+            p += scnprintf( &buf[p], len-p, "%s", pgettext_var("keyname", SDL_GetKeyName(key)) );
          break;
       }
 

--- a/src/naev.c
+++ b/src/naev.c
@@ -1018,7 +1018,7 @@ static void window_caption (void)
    }
 
    /* Set caption. */
-   asprintf( &buf, APPNAME" - %s", start_name() );
+   asprintf( &buf, APPNAME" - %s", _(start_name()) );
    SDL_SetWindowTitle( gl_screen.window, buf );
    SDL_SetWindowIcon( gl_screen.window, naev_icon );
    free( buf );

--- a/src/nlua.c
+++ b/src/nlua.c
@@ -121,10 +121,7 @@ static int nlua_pgettext( lua_State *L )
 {
    const char *msgctxt = luaL_checkstring(L, 1);
    const char *msgid = luaL_checkstring(L, 2);
-   char *lookup = NULL;
-   asprintf( &lookup, "%s" GETTEXT_CONTEXT_GLUE "%s", msgctxt, msgid );
-   lua_pushstring(L, gettext_pgettext_impl( lookup, msgid ) );
-   free( lookup );
+   lua_pushstring(L, pgettext_var( msgctxt, msgid ) );
    return 1;
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -686,6 +686,7 @@ static void menuKeybinds_genList( unsigned int wid )
    /* Create the list. */
    str = malloc( sizeof( char * ) * input_numbinds );
    for (int j = 0; j < input_numbinds; j++) {
+      const char *short_desc = _(keybind_info[j][1]);
       l = 128; /* GCC deduces 68 because we have a format string "%s <%s%c>"
                 * where "char mod_text[64]" is one of the "%s" args.
                 * (that plus brackets plus %c + null gets to 68.
@@ -696,50 +697,50 @@ static void menuKeybinds_genList( unsigned int wid )
          case KEYBIND_KEYBOARD:
             /* Generate mod text. */
             if (mod == NMOD_ANY)
-               snprintf( mod_text, sizeof(mod_text), "any+" );
+               snprintf( mod_text, sizeof(mod_text), _("any+") );
             else {
                p = 0;
                mod_text[0] = '\0';
                if (mod & NMOD_SHIFT)
-                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, "shift+" );
+                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, _("shift+") );
                if (mod & NMOD_CTRL)
-                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, "ctrl+" );
+                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, _("ctrl+") );
                if (mod & NMOD_ALT)
-                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, "alt+" );
+                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, _("alt+") );
                if (mod & NMOD_META)
-                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, "meta+" );
+                  p += scnprintf( &mod_text[p], sizeof(mod_text)-p, _("meta+") );
                (void)p;
             }
 
             /* Print key. Special-case ASCII letters (use uppercase, unlike SDL_GetKeyName.). */
             if (key < 0x100 && isalpha(key))
-               snprintf(str[j], l, "%s <%s%c>", keybind_info[j][1], mod_text, toupper(key) );
+               snprintf(str[j], l, "%s <%s%c>", short_desc, mod_text, toupper(key) );
             else
-               snprintf(str[j], l, "%s <%s%s>", keybind_info[j][1], mod_text, SDL_GetKeyName(key) );
+               snprintf(str[j], l, "%s <%s%s>", short_desc, mod_text, pgettext_var("keyname", SDL_GetKeyName(key)) );
             break;
          case KEYBIND_JAXISPOS:
-            snprintf(str[j], l, "%s <ja+%d>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <ja+%d>", short_desc, key);
             break;
          case KEYBIND_JAXISNEG:
-            snprintf(str[j], l, "%s <ja-%d>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <ja-%d>", short_desc, key);
             break;
          case KEYBIND_JBUTTON:
-            snprintf(str[j], l, "%s <jb%d>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <jb%d>", short_desc, key);
             break;
          case KEYBIND_JHAT_UP:
-            snprintf(str[j], l, "%s <jh%d-up>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <jh%d-up>", short_desc, key);
             break;
          case KEYBIND_JHAT_DOWN:
-            snprintf(str[j], l, "%s <jh%d-down>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <jh%d-down>", short_desc, key);
             break;
          case KEYBIND_JHAT_LEFT:
-            snprintf(str[j], l, "%s <jh%d-left>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <jh%d-left>", short_desc, key);
             break;
          case KEYBIND_JHAT_RIGHT:
-            snprintf(str[j], l, "%s <jh%d-right>", keybind_info[j][1], key);
+            snprintf(str[j], l, "%s <jh%d-right>", short_desc, key);
             break;
          default:
-            snprintf(str[j], l, "%s", keybind_info[j][1]);
+            snprintf(str[j], l, "%s", short_desc);
             break;
       }
    }
@@ -783,7 +784,7 @@ static void menuKeybinds_update( unsigned int wid, const char *name )
    /* Remove the excess. */
    keybind = keybind_info[selected][0];
    opt_selectedKeybind = keybind;
-   window_modifyText( wid, "txtName", keybind );
+   window_modifyText( wid, "txtName", _(keybind_info[selected][1]) );
 
    /* Get information. */
    desc = input_getKeybindDescription( keybind );
@@ -805,7 +806,7 @@ static void menuKeybinds_update( unsigned int wid, const char *name )
             snprintf(binding, sizeof(binding), _("keyboard:   %s%s%s"),
                   (mod != KMOD_NONE) ? input_modToText(mod) : "",
                   (mod != KMOD_NONE) ? " + " : "",
-                  SDL_GetKeyName(key));
+                  pgettext_var("keyname", SDL_GetKeyName(key)));
          break;
       case KEYBIND_JAXISPOS:
          snprintf(binding, sizeof(binding), _("joy axis pos:   <%d>"), key );

--- a/src/player.c
+++ b/src/player.c
@@ -319,12 +319,12 @@ static int player_newMake (void)
 
    /* Try to create the pilot, if fails reask for player name. */
    ship = ship_get( start_ship() );
-   shipname = start_shipname();
+   shipname = _(start_shipname());
    if (ship==NULL) {
       WARN(_("Ship not properly set by module."));
       return -1;
    }
-   acquired = start_acquired();
+   acquired = _(start_acquired());
    /* Setting a default name in the XML prevents naming prompt. */
    ps = player_newShip( ship, shipname, 0, acquired, (shipname==NULL) ? 0 : 1 );
    if (ps == NULL) {

--- a/src/start.c
+++ b/src/start.c
@@ -164,7 +164,7 @@ void start_cleanup (void)
  */
 const char* start_name (void)
 {
-   return _(start_data.name);
+   return start_data.name;
 }
 
 /**
@@ -182,7 +182,7 @@ const char* start_ship (void)
  */
 const char* start_shipname (void)
 {
-   return _(start_data.shipname);
+   return start_data.shipname;
 }
 
 /**
@@ -191,7 +191,7 @@ const char* start_shipname (void)
  */
 const char* start_acquired (void)
 {
-   return _(start_data.acquired);
+   return start_data.acquired;
 }
 
 /**


### PR DESCRIPTION
- Make the key names and the keybind panel translatable.
- start_* function returns an untranslated text now