### PR TITLE
asteroids collide properly with polygons and do spin

### DIFF
--- a/src/asteroid.c
+++ b/src/asteroid.c
@@ -55,6 +55,7 @@ static int asteroid_creating = 0;
 /* Prototypes. */
 static int asttype_cmp( const void *p1, const void *p2 );
 static int asttype_parse( AsteroidType *at, const char *file );
+static int asteroid_loadPLG( AsteroidType *temp, const char *buf );
 static int astgroup_cmp( const void *p1, const void *p2 );
 static int astgroup_parse( AsteroidTypeGroup *ag, const char *file );
 static int asttype_load (void);
@@ -146,6 +147,9 @@ void asteroids_update( double dt )
          /* Update position. */
          a->pos.x += a->vel.x * dt;
          a->pos.y += a->vel.y * dt;
+
+         /* Update angle. */
+         a->ang += a->spin * dt;
 
          /* Update scanned state if necessary. */
          if (a->scanned) {
@@ -303,7 +307,7 @@ static int asteroid_init( Asteroid *ast, const AsteroidAnchor *field )
 {
    double mod, theta, wmax, r, r2;
    AsteroidType *at = NULL;
-   int outfield;
+   int outfield, id;
    int attempts = 0;
 
    ast->parent  = field->id;
@@ -349,14 +353,18 @@ static int asteroid_init( Asteroid *ast, const AsteroidAnchor *field )
       break;
    }
 
-   /* Randomly init the gfx ID */
+   /* Randomly init the gfx ID, and associated polygon */
+   id = RNG(0, array_size(at->gfxs)-1);
+   ast->gfx = at->gfxs[ id ];
+   ast->polygon = &at->polygon[ id ];
+
    ast->type = at;
-   ast->gfx = at->gfxs[ RNG(0, array_size(at->gfxs)-1) ];
    ast->armour = at->armour_min + RNGF() * (at->armour_max-at->armour_min);
 
-   /* And a random velocity */
-   theta = RNGF()*2.*M_PI;
-   mod   = RNGF()*field->maxspeed;
+   /* And a random velocity/spin */
+   theta     = RNGF()*2.*M_PI;
+   ast->spin = (1-2*RNGF())*field->maxspin;
+   mod       = RNGF()*field->maxspeed;
    vec2_pset( &ast->vel, mod, theta );
 
    /* Fade in stuff. */
@@ -554,6 +562,7 @@ static int asttype_parse( AsteroidType *at, const char *file )
    /* Set up the element. */
    memset( at, 0, sizeof(AsteroidType) );
    at->gfxs       = array_create( glTexture* );
+   at->polygon    = array_create( CollPoly );
    at->material   = array_create( AsteroidReward );
    at->damage     = 100;
    at->penetration = 100.;
@@ -581,6 +590,7 @@ static int asttype_parse( AsteroidType *at, const char *file )
 
       if (xml_isNode(node,"gfx")) {
          array_push_back( &at->gfxs, xml_parseTexture( node, SPOB_GFX_SPACE_PATH"asteroid/%s", 1, 1,  OPENGL_TEX_MAPTRANS | OPENGL_TEX_MIPMAPS ) );
+         asteroid_loadPLG( at, xml_get(node) );
          continue;
       }
       else if (xml_isNode(node,"commodity")) {
@@ -636,6 +646,62 @@ if (o) WARN(_("Asteroid Type '%s' missing/invalid '%s' element"), at->name, s) /
    MELEMENT(at->armour_max <= 0.,"armour_max");
 #undef MELEMENT
 
+   return 0;
+}
+
+/**
+ * @brief Loads the collision polygon for an asteroid type.
+ *
+ *    @param temp AsteroidType to load into.
+ *    @param buf Name of the file.
+ */
+static int asteroid_loadPLG( AsteroidType *temp, const char *buf )
+{
+   char file[PATH_MAX];
+   CollPoly *polygon;
+   xmlDocPtr doc;
+   xmlNodePtr node;
+
+   snprintf( file, sizeof(file), "%s%s.xml", ASTEROID_POLYGON_PATH, buf );
+
+   /* There is only one polygon per gfx, but it has to be added to all the other polygons */
+   /* associated to each gfx of current AsteroidType. */
+   /* In case it fails to load for some reason, its size will be set to 0. */
+   polygon = &array_grow( &temp->polygon );
+   polygon->npt = 0;
+
+   /* See if the file does exist. */
+   if (!PHYSFS_exists(file)) {
+      WARN(_("%s xml collision polygon does not exist!\n \
+               Please use the script 'polygon_from_sprite.py'\n \
+               This file can be found in Naev's artwork repo."), file);
+      return 0;
+   }
+
+   /* Load the XML. */
+   doc  = xml_parsePhysFS( file );
+   if (doc == NULL)
+      return 0;
+
+   node = doc->xmlChildrenNode; /* First polygon node */
+   if (node == NULL) {
+      xmlFreeDoc(doc);
+      WARN(_("Malformed %s file: does not contain elements"), file);
+      return 0;
+   }
+
+   do { /* load the polygon data */
+      if (xml_isNode(node,"polygons")) {
+         xmlNodePtr cur = node->children;
+         do {
+            if (xml_isNode(cur,"polygon")) {
+               LoadPolygon( polygon, cur );
+            }
+         } while (xml_nextNode(cur));
+      }
+   } while (xml_nextNode(node));
+
+   xmlFreeDoc(doc);
    return 0;
 }
 
@@ -850,6 +916,13 @@ void asteroids_free (void)
       for (int j=0; j<array_size(at->gfxs); j++)
          gl_freeTexture(at->gfxs[j]);
       array_free(at->gfxs);
+
+      /* Free collision polygons. */
+      for (int j=0; j<array_size(at->polygon); j++) {
+         free(at->polygon[j].x);
+         free(at->polygon[j].y);
+      }
+      array_free(at->polygon);
    }
    array_free(asteroid_types);
    asteroid_types = NULL;

--- a/src/asteroid.h
+++ b/src/asteroid.h
@@ -5,6 +5,7 @@
 
 #include "space_fdecl.h"
 
+#include "collision.h"
 #include "commodity.h"
 #include "opengl.h"
 #include "physics.h"
@@ -13,6 +14,7 @@
 
 #define ASTEROID_DEFAULT_DENSITY    1.  /**< Default density of an asteroid field. */
 #define ASTEROID_DEFAULT_MAXSPEED   20. /**< Max speed of asteroids in an asteroid field. */
+#define ASTEROID_DEFAULT_MAXSPIN    M_PI/5 /**< Max spin of asteroids in an asteroid field. */
 #define ASTEROID_DEFAULT_THRUST     1.  /**< Thrust applied when asteroid leaves asteroid field. */
 
 #define ASTEROID_REF_AREA     250e3    /**< The "density" value in an asteroid field means 1 rock per this area. */
@@ -46,6 +48,7 @@ typedef struct AsteroidType_ {
    char *name;          /**< Name of the asteroid type. */
    char *scanned_msg;   /**< Scanned message. */
    glTexture **gfxs;    /**< asteroid possible gfxs. */
+   CollPoly *polygon;   /**< Collision polygons associated to gfxs. */
    AsteroidReward *material; /**< Materials contained in the asteroid. */
    double armour_min;   /**< Minimum "armour" of the asteroid. */
    double armour_max;   /**< Maximum "armour" of the asteroid. */
@@ -77,11 +80,13 @@ typedef struct Asteroid_ {
    int state;     /**< State of the asteroid. */
    const AsteroidType *type; /**< Type of the asteroid. */
    const glTexture *gfx; /**< Graphic of the asteroid. */
+   CollPoly *polygon;   /**< Collision polygon associated to gfx. */
    double armour; /**< Current "armour" of the asteroid. */
    /* Movement. */
    vec2 pos;      /**< Position. */
    vec2 vel;      /**< Velocity. */
    double ang;    /**< Angle. */
+   double spin;   /**< Spin. */
    /* Stats. */
    double timer;  /**< Internal timer for animations. */
    double timer_max; /**< Internal timer initial value. */
@@ -105,6 +110,7 @@ typedef struct AsteroidAnchor_ {
    double *groupsw;/**< Weight of the groups of asteroids. */
    double groupswtotal;/**< Sum of the weights of the groups. */
    double maxspeed;/**< Maxmimum speed the asteroids can have in the field. */
+   double maxspin;/**< Maxmimum spin the asteroids can have in the field. */
    double thrust; /**< Thrust applied when out of radius towards center. */
    double margin; /**< Extra margin to use when doing distance computations. */
 } AsteroidAnchor;

--- a/src/collision.c
+++ b/src/collision.c
@@ -316,6 +316,41 @@ int CollidePolygon( const CollPoly* at, const vec2* ap,
 }
 
 /**
+ * @brief Rotates a polygon.
+ *
+ *    @param[out] rpolygon Rotated polygon.
+ *    @param[in] ipolygon Imput polygon.
+ *    @param[in] theta Rotation angle (radian).
+ */
+void RotatePolygon( CollPoly* rpolygon, CollPoly* ipolygon, float theta )
+{
+   float ct, st, d;
+
+   rpolygon->npt = ipolygon->npt;
+   rpolygon->x = malloc( ipolygon->npt*sizeof(float) );
+   rpolygon->y = malloc( ipolygon->npt*sizeof(float) );
+   rpolygon->xmin = 0;
+   rpolygon->xmax = 0;
+   rpolygon->ymin = 0;
+   rpolygon->ymax = 0;
+
+   ct = cos( theta );
+   st = sin( theta );
+
+   for (int i=0; i<=rpolygon->npt-1; i++) {
+      d = ipolygon->x[i] * ct - ipolygon->y[i] * st;
+      rpolygon->x[i] = d;
+      rpolygon->xmin = MIN( rpolygon->xmin, d );
+      rpolygon->xmax = MAX( rpolygon->xmax, d );
+
+      d = ipolygon->x[i] * st + ipolygon->y[i] * ct ;
+      rpolygon->y[i] = d;
+      rpolygon->ymin = MIN( rpolygon->ymin, d );
+      rpolygon->ymax = MAX( rpolygon->ymax, d );
+   }
+}
+
+/**
  * @brief Checks whether or not a point is inside a polygon.
  *
  *    @param[in] at Polygon a.

--- a/src/collision.h
+++ b/src/collision.h
@@ -23,6 +23,9 @@ typedef struct CollPoly_ {
 /* Loads a polygon data from xml. */
 void LoadPolygon( CollPoly* polygon, xmlNodePtr node );
 
+/* Rotates a polygon. */
+void RotatePolygon( CollPoly* rpolygon, CollPoly* ipolygon, float theta );
+
 /* Returns 1 if collision is detected */
 int CollideSprite( const glTexture* at, const int asx, const int asy, const vec2* ap,
       const glTexture* bt, const int bsx, const int bsy, const vec2* bp,

--- a/src/ndata.h
+++ b/src/ndata.h
@@ -21,7 +21,8 @@
 #define COMMODITY_GFX_PATH       "gfx/commodity/" /**< Path to commodities graphics. */
 #define MAP_DECORATOR_GFX_PATH   "gfx/map/"
 #define SHIP_POLYGON_PATH        "gfx/ship_polygon/" /**< Path to ship's collision polygon. */
-#define OUTFIT_POLYGON_PATH      "gfx/outfit/space_polygon/" /**< Path to ship's collision polygon. */
+#define OUTFIT_POLYGON_PATH      "gfx/outfit/space_polygon/" /**< Path to outfit collision polygon. */
+#define ASTEROID_POLYGON_PATH    "gfx/spob/space/asteroid_polygon/" /**< Path to asteroid collision polygon. */
 
 #define FACTION_DATA_PATH        "factions/" /**< Path to factions. */
 #define MISSION_DATA_PATH        "missions/" /**< Path to missions XML. */

--- a/src/space.c
+++ b/src/space.c
@@ -2675,6 +2675,7 @@ static int system_parseAsteroidField( const xmlNodePtr node, StarSystem *sys )
    a->groupsw  = array_create( double );
    a->radius   = 0.;
    a->maxspeed = ASTEROID_DEFAULT_MAXSPEED;
+   a->maxspin  = ASTEROID_DEFAULT_MAXSPIN;
    a->thrust   = ASTEROID_DEFAULT_THRUST;
 
    /* Parse label if available. */


### PR DESCRIPTION
Asteroids have polygons and use them to detect collision with all kinds of weapons.
When an ammo is suspected to hit the asteroid (from a distance check), the polygon is rotated on the fly to match the asteroid's angle, and then collision is tested.
As a bonus, asteroids do spin (their angle changes with time)

I had mentioned the possibility to get them to change speed and spin when hit by bolt weapons, but for speed, it raises the rather complicated question of preventing impacts to push an asteroid out of the field (interaction with thrust potentially complicated)

Rmk: there is a merge conflict, probably due to artwork. Can we solve it there or I should rather solve it on my own branch?