### PR TITLE
reynir.lua: fix off-by-one

### DIFF
--- a/dat/missions/neutral/reynir.lua
+++ b/dat/missions/neutral/reynir.lua
@@ -9,7 +9,10 @@
    local count = 0
    for i, p in pairs(system.cur():spobs()) do
       if p:services()["inhabited"] then
-         return true
+         count=count+1
+      end
+      if count == 2 then
+          return true
       end
    end
    return false


### PR DESCRIPTION
An off by one error was introduced in 8153ed2a0d2d27bc0fd5d31aad73e83981c849c9. The comment further down says "make sure there are at least two planets" so presumably one is not enough.