### PR TITLE
Fix a missing translation mark.

### DIFF
--- a/dat/events/neutral/baron_flintley.lua
+++ b/dat/events/neutral/baron_flintley.lua
@@ -19,7 +19,7 @@ local fmt = require "format"
 -- luacheck: globals flintley (NPC functions passed by name)
 
 function create ()
-    evt.npcAdd("flintley", "Flintley", "neutral/unique/flintley.webp", _("Flintley is here. He nervously sips from his drink, clearly uncomfortable in this environment."), 5)
+    evt.npcAdd("flintley", _("Flintley"), "neutral/unique/flintley.webp", _("Flintley is here. He nervously sips from his drink, clearly uncomfortable in this environment."), 5)
 end
 
 function flintley()


### PR DESCRIPTION
"Flintley" is not translatable at one place.