### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/naev_ci.yml
+++ b/.github/workflows/naev_ci.yml
@@ -2,8 +2,12 @@ on: [push, pull_request]
 
 name: CI
 
+permissions: {}
 jobs:
   "Package_Source":
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/naev/naev-release:latest"

--- a/.github/workflows/naev_nightly.yml
+++ b/.github/workflows/naev_nightly.yml
@@ -5,8 +5,12 @@ on:
 
 name: Nightly Release
 
+permissions: {}
 jobs:
   "Package_Source":
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+
     runs-on: ubuntu-latest
 
     container:
@@ -255,6 +259,9 @@ jobs:
           path: build/dist/steam-ndata.tar.xz
 
   "Upload_Naev_Release":
+    permissions:
+      contents: write  #  to generate pre-release (marvinpinto/action-automatic-releases)
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/naev_prerelease.yml
+++ b/.github/workflows/naev_prerelease.yml
@@ -8,8 +8,12 @@ on:
 
 name: Pre-Release
 
+permissions: {}
 jobs:
   "Package_Source":
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+
     runs-on: ubuntu-latest
 
     container:
@@ -266,6 +270,9 @@ jobs:
           path: build/dist/steam-ndata.tar.xz
 
   "Upload_Naev_Release":
+    permissions:
+      contents: write  #  to create a release (ncipollo/release-action)
+
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/naev_release.yml
+++ b/.github/workflows/naev_release.yml
@@ -9,8 +9,12 @@ on:
 
 name: Release
 
+permissions: {}
 jobs:
   "Package_Source":
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+
     runs-on: ubuntu-latest
 
     container:
@@ -327,6 +331,9 @@ jobs:
           if-no-files-found: error
 
   "Upload_Naev_Release":
+    permissions:
+      contents: write  #  to create a release (ncipollo/release-action)
+
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.