### PR TITLE
Fixed so that stealth is improved instead of damaged

### DIFF
--- a/dat/outfits/intrinsic/machiavellian_fortune.xml
+++ b/dat/outfits/intrinsic/machiavellian_fortune.xml
@@ -11,7 +11,7 @@
  </general>
  <specific type="modification">
   <ew_track>10</ew_track>
-  <ew_stealth_timer>10</ew_stealth_timer>
+  <ew_stealth_timer>-10</ew_stealth_timer>
  </specific>
  <tags>
   <tag>lucky</tag>


### PR DESCRIPTION
Machiavellian Fortune has a presumed typo making the stealth timer shorter/faster instead of slower. Changed to make consistent with other Machiavellian intrinsics, which are unambiguously upgrades.