### PR TITLE
Fix jump detection to also be affected by ew_detect

### DIFF
--- a/src/pilot_ew.c
+++ b/src/pilot_ew.c
@@ -362,10 +362,10 @@ int pilot_inRangeJump( const Pilot *p, int i )
    if (hide==0.)
       return 1;
 
-   sense = EW_JUMPDETECT_DIST * p->stats.ew_jump_detect;
+   sense = EW_JUMPDETECT_DIST * p->stats.ew_jump_detect * p->stats.ew_detect;
    /* Handle hidden jumps separately, as they use a special range parameter. */
    if (jp_isFlag(jp, JP_HIDDEN))
-      sense *= p->stats.misc_hidden_jump_detect;
+      sense *= p->stats.misc_hidden_jump_detect * p->stats.ew_detect;
 
    /* Get distance. */
    d = vec2_dist2( &p->solid->pos, &jp->pos );


### PR DESCRIPTION
Jump detection is currently only affected by the ew_jump_detect (or misc_hidden_jump_detect) stats.

Per dev remarks, general detection buffs such as those from sensor array should also improve jump detection. This should implement that.

I'm _reasonably_ certain this won't break hidden jump detection, but you might want to double-check that. I didn't look too hard at how that workss