### PR TITLE
Replace broken/duplicate Nyx with appropriate unused outfit

### DIFF
--- a/dat/scripts/bioship/intrinsics.lua
+++ b/dat/scripts/bioship/intrinsics.lua
@@ -295,9 +295,9 @@ intrinsics["Soromid Nyx"] = {
       },
    },
    {
-      name = _("Gene Drive Growth I"),
-      outfit = "Largus Gene Drive II",
-      slot = "genedrive",
+      name = _("Cortex Growth II"),
+      outfit = "Largus Cortex III",
+      slot = "shell",
    },
    {
       name = _("Weapon Organ Growth II"),


### PR DESCRIPTION
Nyx Destroyer has 2 instances of "Gene Drive Growth I", placing the requisite drive place in the tree. "Cortex Growth II" and its associated outfit, "Largus Cortex III" are absent. 

Replaces the duplicate entry with presumably correct one.