### PR TITLE
Add map revealing jump point between Kretogg and NGC-14549 to Kretogg stores

### DIFF
--- a/dat/outfits/maps/map_kretogg_hypergate.xml
+++ b/dat/outfits/maps/map_kretogg_hypergate.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<outfit name="Map: Lotus Hypergate">
+<outfit name="Map: Kretogg - NGC-14549">
  <general>
   <rarity>2</rarity>
   <mass>0</mass>
   <price>500000</price>
-  <description>This map reveals the path to the secret Black Lotus hypergate.</description>
+  <description>A map revealing a hidden jump point from Kretogg to NGC-14549. It's not entirely clear why this would be useful to know.</description>
   <gfx_store>map_sector_04.webp</gfx_store>
  </general>
  <specific type="map">
@@ -13,7 +13,6 @@
   </sys>
   <sys name="NGC-14549">
    <jump>Kretogg</jump>
-   <spob>Hypergate NGC-14549</spob>
   </sys>
  </specific>
 </outfit>

--- a/dat/outfits/maps/map_kretogg_hypergate.xml
+++ b/dat/outfits/maps/map_kretogg_hypergate.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<outfit name="Map: Lotus Hypergate">
+ <general>
+  <rarity>2</rarity>
+  <mass>0</mass>
+  <price>500000</price>
+  <description>This map reveals the path to the secret Black Lotus hypergate.</description>
+  <gfx_store>map_sector_04.webp</gfx_store>
+ </general>
+ <specific type="map">
+  <sys name="Kretogg">
+   <jump>NGC-14549</jump>
+  </sys>
+  <sys name="NGC-14549">
+   <jump>Kretogg</jump>
+   <spob>Hypergate NGC-14549</spob>
+  </sys>
+ </specific>
+</outfit>

--- a/dat/tech/kretog_maps.xml
+++ b/dat/tech/kretog_maps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tech name="Kretogg Maps">
  <item>Map: Kretogg's Secrets</item>
- <item>Map: Lotus Hypergate</item> 
+ <item>Map: Kretogg - NGC-14549</item> 
 </tech>

--- a/dat/tech/kretog_maps.xml
+++ b/dat/tech/kretog_maps.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tech name="Kretogg Maps">
  <item>Map: Kretogg's Secrets</item>
+ <item>Map: Lotus Hypergate</item> 
 </tech>


### PR DESCRIPTION
What it says on the tin. Probably best to have this be a reward for building Black Lotus hypergate or somesuch when that's a thing, but should be fine for now.