### PR TITLE
Remove erroneous lua script call

### DIFF
--- a/dat/outfits/unique/veil_of_penelope.xml
+++ b/dat/outfits/unique/veil_of_penelope.xml
@@ -12,7 +12,6 @@
   <cpu>0</cpu>
  </general>
  <specific type="modification">
-  <lua>outfits/unique/poi_data.lua</lua>
   <ew_stealth_timer>-50</ew_stealth_timer>
  </specific>
 </outfit>


### PR DESCRIPTION
The outfit currently is defined by the poi_data script, which is not relevant to its function. This tricks the game into thinking the outfit is activated by the script and causes it not to function.

Removes the <lua> line, fixing the outfit.