### PR TITLE
Fix some errors in the mission Seek And Destroy.

### DIFF
--- a/dat/missions/neutral/seek_n_destroy.lua
+++ b/dat/missions/neutral/seek_n_destroy.lua
@@ -202,7 +202,7 @@ function create ()
 #nTarget:#0 {plt} ({shipclass}-class ship)
 #nWanted:#0 Dead or Alive
 #nLast Seen:#0 {sys} system]]),
-         {target_faction=mem.target_faction, plt=mem.name, paying_faction=mem.paying_faction, sys=mem.mysys[1], shipclass=_(ship.get(mem.aship):classDisplay())} )
+         {target_faction=mem.target_faction, plt=mem.name, paying_faction=mem.paying_faction, sys=mem.mysys[1], shipclass=_(ship.get(mem.tgtship):classDisplay())} )
    if not mem.paying_faction:static() then
       desc = desc.."\n"..fmt.f(_([[#nReputation Gained:#0 {fct}]]),
          {fct=mem.paying_faction})
@@ -509,7 +509,7 @@ function space_clue( target )
       p(_("How much money do you have?"))
       vn.menu( function ()
          return {
-            {fmt.f(_([[Pay {amount}]]), mem.price), "pay"},
+            {fmt.f(_([[Pay {amount}]]), {amount=fmt.credits(mem.price)}), "pay"},
             {_([[Give up]]), "giveup"},
             {_([[Threaten the pilot]]), "threaten"},
          }


### PR DESCRIPTION
- The mission computer indicates the class of the target ship, instead of the ambush's.
- Fix a script error.
