### PR TITLE
Add a space after the outfit class.

### DIFF
--- a/src/map_find.c
+++ b/src/map_find.c
@@ -675,7 +675,7 @@ static void map_showOutfitDetail( unsigned int wid, const char* wgtname, int x, 
 
    window_modifyImage( wid, "imgOutfit", outfit->gfx_store, 128, 128 );
    l = outfit_getNameWithClass( outfit, buf, sizeof(buf) );
-   l += scnprintf( &buf[l], sizeof(buf)-l, "%s", pilot_outfitSummary( player.p, outfit, 0 ) );
+   l += scnprintf( &buf[l], sizeof(buf)-l, " %s", pilot_outfitSummary( player.p, outfit, 0 ) );
    window_modifyText( wid, "txtDescShort", buf );
    th = gl_printHeightRaw( &gl_smallFont, 280, buf );
 

--- a/src/map_system.c
+++ b/src/map_system.c
@@ -616,7 +616,7 @@ static void map_system_array_update( unsigned int wid, const char* str )
       snprintf( buf_mass, sizeof(buf_mass), n_( "%d t", "%d t", (int)round( mass ) ), (int)round( mass ) );
 
       l += outfit_getNameWithClass( outfit, &infobuf[l], sizeof(infobuf)-l );
-      l += scnprintf( &infobuf[l], sizeof(infobuf)-l, "%s\n\n", pilot_outfitDescription( player.p, outfit ) );
+      l += scnprintf( &infobuf[l], sizeof(infobuf)-l, "\n%s\n\n", pilot_outfitDescription( player.p, outfit ) );
 
       /* FIXME: The point of this misery is to split desc_short into a 2-column layout.
        * It works poorly, but if we don't do this, check out e.g. the TeraCom Medusa Launcher in a 720p window. */


### PR DESCRIPTION
I use a NL instead of a space because the system map has enough vertical space.