### PR TITLE
Fix a bug that the bioship can lose fuel, shield, and energy.

### DIFF
--- a/dat/scripts/bioship.lua
+++ b/dat/scripts/bioship.lua
@@ -199,6 +199,7 @@ end
 
 function bioship.setstage( p, stage )
    local _skills, intrinsics, _maxtier = _getskills( p )
+   local fuel = p:fuel()
 
    -- Reset biostage as necessary
    local curstage = p:shipvarPeek("biostage") or 1
@@ -215,6 +216,11 @@ function bioship.setstage( p, stage )
       end
    end
    p:shipvarPush("biostage",stage)
+
+   -- Heal up and restore fuel
+   p:setHealth( 100, 100 )
+   p:setEnergy( 100 )
+   p:setFuel( fuel )
 end
 
 local function _skill_count( skills )


### PR DESCRIPTION
The bioship can lose fuel, shield, and energy on landing. It causes a real problem only when the player lands on a planet where has no refuel facility, but the player can notice the shield and energy bar on the GUI and the remaining fuel on the system map.