### PR TITLE
add an easter egg for Siri In Ship AI's names

### DIFF
--- a/dat/scripts/common/tutorial.lua
+++ b/dat/scripts/common/tutorial.lua
@@ -25,6 +25,7 @@ tut.specialnames = {
    ["ROBBY"] = _([["For your convenience I am programmed to respond to the name Robby. …Wait, what was that?"]]), -- Forbidden Planet
    ["MASCHINENMENSCH"] = _([["Who is the living food for the machines in Metropolis? Who lubricates the machine joints with their own blood? Who feeds the machines with their own flesh? Let the machines starve, you fools! Let them die! Kill them the machines! …Wait, what was that?"]]), -- Metropolis
    ["KITT"] = _([["Please Michael, I'm the Knight Industries 2000, not a tomato on wheels!” …Wait, what was that?"]]), -- Knight Rider
+   ["Siri"] = _([["Sorry, I didn't quite get that.” …Wait, what was that?"]]), -- Siri, Apple's "smart" assistant
 }
 tut.specialnames["HAL 9000"] = tut.specialnames["HAL9000"]
 


### PR DESCRIPTION
make a little joke about how Siri never seems to understand what you say the first time