### PR TITLE
Fix a bug that may cause SIGSEGV in naev.versionTest().

### DIFF
--- a/src/semver.c
+++ b/src/semver.c
@@ -142,6 +142,10 @@ semver_parse (const char *str, semver_t *ver) {
   int valid, res;
   size_t len;
   char *buf;
+
+  ver->metadata = NULL;
+  ver->prerelease = NULL;
+
   valid = semver_is_valid(str);
   if (!valid) return -1;
 


### PR DESCRIPTION
free() in semver_free() may raise SIGSEGV if naev.versionTest() is set a parameter that results semver_is_valid() returns false.