### PR TITLE
Fix a bug that causes use-after-free in player_swapShip().

### DIFF
--- a/src/pilot.c
+++ b/src/pilot.c
@@ -3561,6 +3561,7 @@ void pilot_free( Pilot *p )
    /* Clear some useful things. */
    pilot_clearHooks(p);
    effect_cleanup( p->effects );
+   p->effects = NULL;
    pilot_cargoRmAll( p, 1 );
    escort_freeList(p);
 


### PR DESCRIPTION
The bug may cause an error at exit Test of Enlightenment.

Address Sanitizer Log at reading:
```
==17874==ERROR: AddressSanitizer: heap-use-after-free on address 0x607000262218 at pc 0x5555556fe73a bp 0x7fffffffc9b0 sp 0x7fffffffc9a8
READ of size 8 at 0x607000262218 thread T0
    #0 0x5555556fe739 in array_size ../src/array.h:179
    #1 0x5555556fe739 in effect_add ../src/effect.c:304
    #2 0x5555559e82fd in pilotL_effectAdd ../src/nlua_pilot.c:3794
    #3 0x7ffff7271a25  (/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0xaa25) (BuildId: a830ebc39000d33ae7f9ec2765d28f863b94489d)
    #4 0x7ffff72cc1ed in lua_pcall (/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x651ed) (BuildId: a830ebc39000d33ae7f9ec2765d28f863b94489d)
    #5 0x5555558073c1 in nlua_pcall ../src/nlua.c:881
    #6 0x555555899878 in pilot_outfitLInit ../src/pilot_outfit.c:1387
    #7 0x555555898a4e in pilot_outfitLInitAll ../src/pilot_outfit.c:1288
    #8 0x5555558810cf in pilot_setPlayer ../src/pilot.c:3461
    #9 0x5555558aab22 in player_swapShip ../src/player.c:575
    #10 0x5555559f7a31 in playerL_shipSwap ../src/nlua_player.c:1509
snip
```

Log at freeing (may be the beginning of Test of Enlightenment?):
```
0x607000262218 is located 8 bytes inside of 72-byte region [0x607000262210,0x607000262258)
freed by thread T0 here:
    #0 0x7ffff78d7298 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55555567b5a3 in _array_free_helper ../src/array.c:100
    #2 0x55555570001b in effect_cleanup ../src/effect.c:494
    #3 0x55555588278e in pilot_free ../src/pilot.c:3563
    #4 0x5555558aadcc in player_swapShip ../src/player.c:596
    #5 0x5555559f7a31 in playerL_shipSwap ../src/nlua_player.c:1509
    #6 0x7ffff7271a25  (/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0xaa25) (BuildId: a830ebc39000d33ae7f9ec2765d28f863b94489d)
```

This PR fixes it.

I notice that the engine trails of all ships are not shown after leaving Test of Enlightenment, but I guess the cause isn't this PR...