### PR TITLE
Fix a bug that a lua code ai.face(-jmp:angle()) might cause a reverse rotation.

### DIFF
--- a/src/physics.c
+++ b/src/physics.c
@@ -18,10 +18,10 @@
 static double angle_cleanup( double a )
 {
    if (FABS(a) >= 2.*M_PI) {
-      double na = fmod(a, 2.*M_PI);
-      if (a < 0.)
-         na += 2.*M_PI;
-      return  na;
+      a = fmod(a, 2.*M_PI);
+   }
+   if (a < 0.) {
+       a += 2.*M_PI;
    }
    return a;
 }


### PR DESCRIPTION
angle_cleanup() should return a value in the range [0, +2PI) instead of (-2PI, +2PI) if angle_diff() is supposed  to return (-PI, +PI).