### PR TITLE
Proteron landing messages changed.

### DIFF
--- a/dat/spob/lua/proteron_mil_restricted.lua
+++ b/dat/spob/lua/proteron_mil_restricted.lua
@@ -11,7 +11,7 @@ function init( spb )
          _([["You are not authorized to land here."]]),
       },
       msg_cantbribe = {
-         _([["We Proteron don't take kindly to bribery."]]),
+         _([["The Sovereign Proteron Autarchy does not take bribes."]]),
       },
    } )
 end


### PR DESCRIPTION
Old messages used short form, seemed less formal. Changed it to be consistent with adoption of SPA and made it more formal.