### PR TITLE
Improve autonav when boarding a derelict.

### DIFF
--- a/dat/autonav.lua
+++ b/dat/autonav.lua
@@ -306,15 +306,16 @@ local function autonav_approach_vel( pos, vel, radius )
    local pp = player.pilot()
    local turn = math.rad(pp:turn()) -- TODO probably change the code
 
-   local timeFactor = math.pi/turn + pp:speed() / pp:thrust()
+   local rvel = vel - pp:vel()
+   local timeFactor = math.pi/turn + rvel:mod() / pp:thrust() / 2
 
    local Kp = 10
-   local Kd = math.max( 5, 10.84*timeFactor-10.82 )
+   local Kd = math.max( 5, 10*timeFactor )
 
    local angle = math.pi + vel:angle()
 
    local point = pos + vec2.newP( radius, angle )
-   local dir = (point-pp:pos())*Kp + (vel-pp:vel())*Kd
+   local dir = (point-pp:pos())*Kp + rvel*Kd
 
    local off = ai.face( dir:angle() )
    if math.abs(off) < math.rad(10) and dir:mod() > 300 then


### PR DESCRIPTION
With autonav, it takes a long time for fast ships to board a derelict because autonav estimates too much value as the distance to stop the ships. This PR makes autonav estimate smaller and more relevant value.

How to estimate the distance to stop in this PR:
```
distance_to_stop = velocity**2 / (2 * ship_thrust)

because
mass * ship_thrust * distance_to_stop = 1/2 * mass * velocity**2
```

How to estimate the distance to stop in the current version:
```
10 * distance_to_stop = velocity * (10.84 * ship_speed / ship_thrust - 10.82)
```
The equation doesn't fully consider the slowing down of the ship for breaking.

I don't grasp the meanings of the coefficients 10.84 and -10.82, but it seems to work fine without the margins.

I tested it with some light, medium, and heavy ships. The light ships have room to reduce the time to stop yet for some reasons I don't know.