### PR TITLE
Fix some typos in the mission "Capricorn Pirates."

### DIFF
--- a/dat/events/neutral/capricorn_pirates.lua
+++ b/dat/events/neutral/capricorn_pirates.lua
@@ -115,7 +115,7 @@ function pir_gone ()
    lmisn.sfxVictory()
    player.msg(fmt.f(_("You have cleared the blockade on {spb}!"),{spb=mainspb}))
    player.landAllow( true )
-   diff.apply( "Capricorn Safe" ) -- Removes 'restricted' tag
+   diff.apply( "Durea Safe" ) -- Removes 'restricted' tag
    evt.finish(true)
 end
 

--- a/dat/events/neutral/capricorn_pirates_epilogue.lua
+++ b/dat/events/neutral/capricorn_pirates_epilogue.lua
@@ -1,11 +1,11 @@
 --[[
 <?xml version='1.0' encoding='utf8'?>
-<event name="Durea Pirates Epilogue">
+<event name="Capricorn Pirates Epilogue">
  <unique/>
  <location>land</location>
  <chance>100</chance>
  <spob>Durea</spob>
- <cond>player.evtDone("Durea Pirates")</cond>
+ <cond>player.evtDone("Capricorn Pirates")</cond>
 </event>
 --]]
 --[[


### PR DESCRIPTION
In the current version, eliminating the pirates in "Capricorn" seemed to cause nothing. The PR fixes it.

You mean the pirates lock down the system "Capricorn" and removing "restricted" tag from the SPOB "Durea", don't you?