### PR TITLE
Fix problems that cause omission of some shipstats in Japanese language.

### DIFF
--- a/src/equipment.c
+++ b/src/equipment.c
@@ -1500,9 +1500,9 @@ static void equipment_genShipList( unsigned int wid )
    /* Ship stats in alt text. */
    for (int i=0; i<nships; i++) {
       s  = player_getShip( cships[i].caption );
-      cships[i].alt = malloc( STRMAX_SHORT );
-      l  = snprintf( &cships[i].alt[0], STRMAX_SHORT, _("Ship Stats\n") );
-      l  = equipment_shipStats( &cships[i].alt[0], STRMAX_SHORT-l, s, 1, 1 );
+      cships[i].alt = malloc( STRMAX );
+      l  = snprintf( &cships[i].alt[0], STRMAX, _("Ship Stats\n") );
+      l  = equipment_shipStats( &cships[i].alt[0], STRMAX-l, s, 1, 1 );
       if (l == 0) {
          free( cships[i].alt );
          cships[i].alt = NULL;

--- a/src/ship.c
+++ b/src/ship.c
@@ -44,7 +44,7 @@
 #define BUTTON_WIDTH  80 /**< Button width in ship view window. */
 #define BUTTON_HEIGHT 30 /**< Button height in ship view window. */
 
-#define STATS_DESC_MAX 256 /**< Maximum length for statistics description. */
+#define STATS_DESC_MAX 512 /**< Maximum length for statistics description. */
 
 static Ship* ship_stack = NULL; /**< Stack of ships available in the game. */
 


### PR DESCRIPTION
This PR extends the buffers which are insufficient.

Actually 1.5 times of the current sizes are enough in Japanese language, so STRMAX may be too big.