### PR TITLE
Fix some translation issues in the system's map.

### DIFF
--- a/src/dev_uniedit.c
+++ b/src/dev_uniedit.c
@@ -1997,7 +1997,7 @@ static void uniedit_editSys (void)
    y -= gl_defFont.h + 15;
    l = scnprintf( buf, sizeof(buf), "#n%s#0", _("Tags: ") );
    for (int i=0; i<array_size(sys->tags); i++)
-      l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", (i==0)?"":_(", "), sys->tags[i] );
+      l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", (i==0)?"":", ", sys->tags[i] );
    window_addText( wid, x, y, UNIEDIT_EDIT_WIDTH-40, 20, 0, "txtTags", NULL, NULL, buf );
 
    /* Load values */
@@ -2274,7 +2274,7 @@ static void uniedit_btnTagsClose( unsigned int wid, const char *unused )
    StarSystem *s = uniedit_sys[0];
    int l = scnprintf( buf, sizeof(buf), "#n%s#0", _("Tags: ") );
    for (int i=0; i<array_size(s->tags); i++)
-      l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", ((i>0) ? _(", ") : ""), s->tags[i] );
+      l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", ((i>0) ? ", " : ""), s->tags[i] );
    window_modifyText( uniedit_widEdit, "txtTags", buf );
 
    window_close( wid, unused );

--- a/src/land.c
+++ b/src/land.c
@@ -886,7 +886,7 @@ void land_updateMainTab (void)
    if (conf.devmode) {
       l += scnprintf( &buf[l], sizeof(buf)-l, "\n%s", "" );
       for (int i=0; i<array_size(land_spob->tags); i++)
-         l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", ((i>0) ? _(", ") : ""), _(land_spob->tags[i]) );
+         l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", ((i>0) ? ", " : ""), land_spob->tags[i] );
    }
 
    window_modifyText( land_windows[0], "txtDInfo", buf );

--- a/src/load.c
+++ b/src/load.c
@@ -349,12 +349,12 @@ static int load_compatibilityTest( const nsave_t *ns )
          buf[0] = '\0';
          l = 0;
          for (int i=0; i<array_size(ns->plugins); i++)
-            l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", (l>0)?_(", "):"#r", ns->plugins[i] );
+            l += scnprintf( &buf[l], sizeof(buf)-l, "%s%s", (l>0)?p_("plugins", ", "):"#r", ns->plugins[i] );
          l += scnprintf( &buf[l], sizeof(buf)-l, "#0" );
          buf2[0] = '\0';
          l = 0;
          for (int i=0; i<array_size(plugins); i++)
-            l += scnprintf( &buf2[l], sizeof(buf2)-l, "%s%s", (l>0)?_(", "):"", plugin_name(&plugins[i]) );
+            l += scnprintf( &buf2[l], sizeof(buf2)-l, "%s%s", (l>0)?p_("plugins", ", "):"", plugin_name(&plugins[i]) );
          if (!dialogue_YesNo( _("Save game plugin mismatch"),
                _("Save game '%s' plugins do not match loaded plugins:\n"
                "   Save plugins: %s\n"

--- a/src/map.c
+++ b/src/map.c
@@ -811,7 +811,7 @@ static void map_update( unsigned int wid )
          if (!spob_isKnown(spob))
             continue;
          if (buf[0] != '\0')
-            p += scnprintf(&buf[p], sizeof(buf)-p, _(", "));
+            p += scnprintf(&buf[p], sizeof(buf)-p, p_("system features", ", "));
          p += scnprintf(&buf[p], sizeof(buf)-p, "%s", _(spob->feature));
       }
 
@@ -825,20 +825,20 @@ static void map_update( unsigned int wid )
       }
       if (found) {
          if (buf[0] != '\0')
-            p += scnprintf(&buf[p], sizeof(buf)-p, _(", "));
+            p += scnprintf(&buf[p], sizeof(buf)-p, p_("system features", ", "));
          p += scnprintf(&buf[p], sizeof(buf)-p, "#g%s#0", _("Trade Lane") );
       }
 
       /* Nebula. */
       if (sys->nebu_density > 0.) {
          if (buf[0] != '\0')
-            p += scnprintf(&buf[p], sizeof(buf)-p, _(", "));
+            p += scnprintf(&buf[p], sizeof(buf)-p, p_("system features", ", "));
 
          /* Density. */
          if (sys->nebu_density > 700.)
-            adj = _("Dense ");
+            adj = p_("adj Nebula", "Dense ");
          else if (sys->nebu_density < 300.)
-            adj = _("Light ");
+            adj = p_("adj Nebula", "Light ");
          else
             adj = "";
 
@@ -863,7 +863,7 @@ static void map_update( unsigned int wid )
       /* Interference. */
       if (sys->interference > 0.) {
          if (buf[0] != '\0')
-            p += scnprintf(&buf[p], sizeof(buf)-p, _(", "));
+            p += scnprintf(&buf[p], sizeof(buf)-p, p_("system features", ", "));
 
          itf = sys->interference;
          if (sys->interference > 700.) {
@@ -885,7 +885,7 @@ static void map_update( unsigned int wid )
          double density = sys->asteroid_density;
 
          if (buf[0] != '\0')
-            p += scnprintf(&buf[p], sizeof(buf)-p, _(", "));
+            p += scnprintf(&buf[p], sizeof(buf)-p, p_("system features", ", "));
 
          if (density >= 1000.) {
             p += scnprintf(&buf[p], sizeof(buf)-p, "#o" );

--- a/src/map_system.c
+++ b/src/map_system.c
@@ -402,26 +402,26 @@ static void map_system_render( double bx, double by, double w, double h, void *d
          /* Volatility */
          if (dmg > 50.) {
             col = 'r';
-            sdmg = _("Volatile");
+            sdmg = p_("nebula", "Volatile");
          }
          else if (sys->nebu_volatility > 20.) {
             col = 'o';
-            sdmg = _("Dangerous");
+            sdmg = p_("nebula", "Dangerous");
          }
          else if (sys->nebu_volatility > 0.) {
             col = 'y';
-            sdmg = _("Unstable");
+            sdmg = p_("nebula", "Unstable");
          }
          else {
             col = '0';
-            sdmg = _("Stable");
+            sdmg = p_("nebula", "Stable");
          }
 
          /* Density */
          if (sys->nebu_density > 700.)
-            adj = _("Dense ");
+            adj = p_("nebula", "Dense ");
          else if (sys->nebu_density < 300.)
-            adj = _("Light ");
+            adj = p_("nebula", "Light ");
          else
             adj = "";
 
@@ -435,15 +435,15 @@ static void map_system_render( double bx, double by, double w, double h, void *d
          char col;
          if (itf > 700.) {
             col = 'r';
-            sint = _("Dense");
+            sint = p_("interference", "Dense");
          }
          else if (itf > 300.) {
             col = 'o';
-            sint = _("Medium");
+            sint = p_("interference", "Medium");
          }
          else {
             col = 'y';
-            sint = _("Light");
+            sint = p_("interference", "Light");
          }
          cnt += scnprintf( &buf[cnt], sizeof(buf)-cnt, _("#nInterference: #%c%s (%.0f%%)#0\n"), col, sint, itf );
       }
@@ -458,7 +458,7 @@ static void map_system_render( double bx, double by, double w, double h, void *d
       }
       /* Other features. */
       if (sys->features != NULL)
-         cnt += scnprintf( &buf[cnt], sizeof(buf)-cnt, _("#nOther:#0 %s\n"), sys->features );
+         cnt += scnprintf( &buf[cnt], sizeof(buf)-cnt, _("#nOther:#0 %s\n"), _(sys->features) );
       /* Faction */
       f = -1;
       for (i=0; i<array_size(sys->spobs); i++) {


### PR DESCRIPTION
This PR adds some msgctxts to distinguish the different contexts, and makes some texts translatable.

It also makes the commas in the lists of the tags untranslatable since the tags have no need to translate.

I don't come to mind a same translated word of two "Dense" in "Dense Volatile Nebula" and "Nebula: Dense Volatile"... so I would add the different contexts to it.