### PR TITLE
Fix a bug that makes the mission "Seek And Destroy" impossible to complete.

### DIFF
--- a/dat/missions/neutral/seek_n_destroy.lua
+++ b/dat/missions/neutral/seek_n_destroy.lua
@@ -283,7 +283,7 @@ function enter ()
          mem.death_hook = hook.pilot( target_ship, "death", "target_death" )
          mem.board_hook = hook.pilot( target_ship, "board", "target_board" )
          mem.pir_jump_hook = hook.pilot( target_ship, "jump", "target_flee" )
-         mem.pir_land_hook = hook.pilot( target_ship, "land", "target_land" )
+         mem.pir_land_hook = hook.pilot( target_ship, "land", "target_flee" )
          mem.jumpout = hook.jumpout( "player_flee" )
 
          -- If the target is weaker, runaway
@@ -692,6 +692,7 @@ function player_flee ()
    vntk.msg( _("You're not going to kill anybody like that"), fmt.f( _("You had a chance to neutralize {plt}, and you wasted it! Now you have to start all over. Maybe some other pilots in {sys} know where your target is going."), {plt=mem.name, sys=system.cur()} ) )
    mem.stage = 0
    misn.osdActive( 1 )
+   clear_target_hook()
 end
 
 function target_flee ()
@@ -701,10 +702,12 @@ function target_flee ()
    pilot.toggleSpawn(true)
    mem.stage = 0
    misn.osdActive( 1 )
+   clear_target_hook()
 end
 
 function target_death ()
    mem.stage = 4
+   clear_target_hook()
 
    misn.osdActive( 3 )
    misn.markerRm(mem.marker)
@@ -713,6 +716,7 @@ end
 
 function target_board( p )
    mem.stage = 4
+   clear_target_hook()
 
    vntk.msg( _("Target captured"), _("You board the ship and, after a short but intense firefight, are able to take the wanted outlaw alive. Time to hand them in to the authorities.") )
    p:disable() -- Permanently disable
@@ -724,4 +728,12 @@ function target_board( p )
    pilot.toggleSpawn(true)
 
    player.unboard()
+end
+
+function clear_target_hook ()
+   hook.rm(mem.death_hook)
+   hook.rm(mem.board_hook)
+   hook.rm(mem.pir_jump_hook)
+   hook.rm(mem.pir_land_hook)
+   hook.rm(mem.jumpout)
 end


### PR DESCRIPTION
The narrator says that the player wasted the chance when the player jumps out after destroying the target. This PR fixes the bug, which seems to be introduced by c42999c10.

I would also replace the hook function "target_land" with "target_flee" since there isn't the function "target_land" in the mission "Seek And Destroy", though I couldn't test the situation to call the hook.