### PR TITLE
Ensure "an" is used before "Ass" in Dvaered warlord insults

### DIFF
--- a/dat/ai/advertiser.lua
+++ b/dat/ai/advertiser.lua
@@ -115,7 +115,7 @@ function create ()
       local sponsor = lords[ rnd.rnd(1,#lords) ]
       local params = {butthead=butthead, badword=badwords[rnd.rnd(1,#badwords)], sponsor=sponsor, article="a"}
       if params.badword == "Ass" then
-         params.article = "an";
+         params.article = "an"
       end
       table.insert(msg, fmt.f(_("I hereby declare {butthead} is {article} {badword}. -{sponsor}"), params))
       table.insert(msg, fmt.f(_("Let it be known that {butthead} is {article} {badword}. -{sponsor}"), params))

--- a/dat/ai/advertiser.lua
+++ b/dat/ai/advertiser.lua
@@ -113,9 +113,12 @@ function create ()
       local butthead = lords[r]
       table.remove( lords, r )
       local sponsor = lords[ rnd.rnd(1,#lords) ]
-      local params = {butthead=butthead, badword=badwords[rnd.rnd(1,#badwords)], sponsor=sponsor}
-      table.insert(msg, fmt.f(_("I hereby declare {butthead} is a {badword}. -{sponsor}"), params))
-      table.insert(msg, fmt.f(_("Let it be known that {butthead} is a {badword}. -{sponsor}"), params))
+      local params = {butthead=butthead, badword=badwords[rnd.rnd(1,#badwords)], sponsor=sponsor, article="a"}
+      if params.badword == "Ass" then
+         params.article = "an";
+      end
+      table.insert(msg, fmt.f(_("I hereby declare {butthead} is {article} {badword}. -{sponsor}"), params))
+      table.insert(msg, fmt.f(_("Let it be known that {butthead} is {article} {badword}. -{sponsor}"), params))
    end
 
    -- Soromid messages


### PR DESCRIPTION
![image](https://github.com/naev/naev/assets/74448738/551dd946-2239-454b-9af5-41bbdd4e1919)

As it says in the title.