### PR TITLE
Fix a wrong system name in the event "Kidnapped."

### DIFF
--- a/dat/events/neutral/kidnapped.lua
+++ b/dat/events/neutral/kidnapped.lua
@@ -29,7 +29,7 @@ local ccomm = require "common.comm"
 local vn = require "vn"
 local fmt = require "format"
 
-local pnt1, sys3 = spob.getS("Praxis")
+local pnt1, sys3 = spob.getS("Waterhole's Moon")
 
 local panma, yohail -- Non-persistent state
 


### PR DESCRIPTION
The said system name was inconsistent with the mission "Kidnapped."
