### PR TITLE
Make stat adjustments additive, not multiplicative

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,13 +4,14 @@
    * Quality of Life
       * Added colourblind correction mode
       * Exposed more colourblind options to the user
-      * Can modify game speed directly instead of using a slowmode difficulty for accessibility
+      * Can modify game speed directly instead of using a slow mode difficulty for accessibility
       * Messages get folded instead of repeating
       * Asteroids no longer fade out if close to the player
       * Display fuel consumption for ships in the equipment overlay
       * Added option to match speed with slowest ship in the fleet (on by default)
    * Engine
-      * Try to merge saves if multiple directories correpsond to the same player
+      * Stats are now additive instead of multiplicative
+      * Try to merge saves if multiple directories correspond to the same player
       * Faster handling of asteroids with large exclusion areas
       * Added fuel_usage_mod ship stat.
       * Fixed player losing navigation targets when unidiff is applied

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,7 +10,7 @@
       * Display fuel consumption for ships in the equipment overlay
       * Added option to match speed with slowest ship in the fleet (on by default)
    * Engine
-      * Stats are now additive instead of multiplicative
+      * Stats (except inverted stats) are now additive instead of multiplicative
       * Try to merge saves if multiple directories correspond to the same player
       * Faster handling of asteroids with large exclusion areas
       * Added fuel_usage_mod ship stat.

--- a/dat/outfits/accessory/rackham_razor.lua
+++ b/dat/outfits/accessory/rackham_razor.lua
@@ -7,9 +7,8 @@ end
 
 function init( p, po )
    if pir.isPirateShip( p ) then
-      -- It's multiplicative so we add a bonus such that multiplied by the base bonus we get double the original amount
-      po:set( "loot_mod", 120/1.1-100 )
-      po:set( "jam_chance", 120/1.1-100 )
+      po:set( "loot_mod", 10 )
+      po:set( "jam_chance", 10 )
    else
       po:clear()
    end

--- a/dat/outfits/intrinsic/gauntlet_supreme.lua
+++ b/dat/outfits/intrinsic/gauntlet_supreme.lua
@@ -14,8 +14,7 @@ function init( p, po )
 
    -- Doubles effect
    if hasunguided then
-      -- It's multiplicative so we add a bonus such that multiplied by the base bonus we get double the original amount
-      po:set( "launch_damage", 110/1.05-100 )
+      po:set( "launch_damage", 5 )
    else
       po:clear()
    end

--- a/src/shipstats.c
+++ b/src/shipstats.c
@@ -541,42 +541,11 @@ static void ss_adjustDoubleStat(double* statptr, double adjustment, int inverted
 {
    double currstat = *statptr;
    /*
-    * For inverted stats, we first invert the stat, apply the adjustment, and then reinvert the stat
-    *
-    * This is because for inverted stats "infinitely good" = 0. We don't want to be able to get
-    * "infinitely good" with a finite improvement. So we first invert the current stat,
-    * so like normal stats "infinitely good" is actually infinity. Then we apply the adjustment
-    * (we need to subtract the adjustment as the inverting has flipped the direction of "good" and "bad")
-    * and then reinvert to get back to the real value.
-    *
-    * For example, consider a "cargo inertia" penalty of 20%, when our current cargo interia is 125%.
-    *
-    * We invert 125% to get 80%, subtract 20% to get 60%, and then invert to get 166.67%.
-    *
-    * The way to think of this is to imagine "cargo inertia" was a "positive stat"
-    * called say "cargo goodness". Lets say a "cargo goodness" of 200% made cargo mass only have 50% effect.
-    *
-    * Then one could assume "cargo goodness" of 80% would make cargo have a 125% effect.
-    *
-    * Basically you invert the "cargo goodness" to get the "cargo inertia".
-    *
-    * In this case, lowering the "cargo goodness" by another 20% would take the "cargo goodness" to 60%,
-    * making cargo have a 166.67% effect, namely the inverse of 60%.
-    *
-    * With non-inverted stats, adding 100% makes the stat "twice as good", but you only have to remove 50%
-    * to make it "half as good". Removing 100% from a non-inverted stat makes your ship non-functional.
-    *
-    * Stat inversion is just for readability's sake, because "jump time" or "cargo inertia" is easier to
-    * understand than "jump fastness" or "cargo goodness". But it should still work the same.
-    * A 100% improvement in jump time should half the jump time, and a 50% loss should double jump time.
-    *
-    * We don't actually get that holding true without doing this inversion before applying adjustments.
-    *
-    * In the formula used in the code, we actually do the following rearrangement, which saves one division:
-    *
-    * 1 / (1 / currstat - adjustment)) = currstat / (1 - currstat * adjustment)
+    * Normal stats are additive, as having them multiplicative resulted in rediculous positive values for stacked builds
+    * Inverted stats remain multiplicative, for the same reason as above, except in this case we want to avoid
+    * excessively low stats due to stacking, and making the inverted stats multiplicative achieves this.
     */
-   *statptr = (inverted) ? (currstat / (1. - currstat * adjustment)) : (currstat + adjustment);
+   *statptr = (inverted) ? (currstat * (1 + adjustment)) : (currstat + adjustment);
 }
 
 /**


### PR DESCRIPTION
In the case of inverted stats, where the value of 0 is essentially "infinitely good", we instead invert the stat first, then apply the adjustment, then "un"invert the stat.