### PR TITLE
Use `SDL_ConvertSurfaceFormat` to fix rendering of indexed color pngs

### DIFF
--- a/src/opengl_tex.c
+++ b/src/opengl_tex.c
@@ -368,9 +368,11 @@ static GLuint gl_loadSurface( SDL_Surface* surface, unsigned int flags, int free
    }
    else {
       *vmax = 1.;
-      glPixelStorei( GL_UNPACK_ALIGNMENT, MIN( surface->pitch&-surface->pitch, 8 ) );
+      SDL_Surface *s = SDL_ConvertSurfaceFormat( surface, SDL_PIXELFORMAT_ARGB8888, 0 );
+      glPixelStorei( GL_UNPACK_ALIGNMENT, MIN( s->pitch&-surface->pitch, 8 ) );
       glTexImage2D( GL_TEXTURE_2D, 0, GL_SRGB_ALPHA,
-            surface->w, surface->h, 0, surface->format->Amask ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, surface->pixels );
+            s->w, s->h, 0, s->format->Amask ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, s->pixels );
+      SDL_FreeSurface(s);
    }
    SDL_UnlockSurface( surface );
 


### PR DESCRIPTION
The other branch of this `if` statement already did conversion. It makes sense that it would be needed for indexed color in either case.

I guess conversion should only be done if the existing format cannot be used? Instead of always calling this.

This issue occurred on Fedora Rawhide, but not other Linux installs. I'm guessing that would be related to the version of `SDL2_Image` or `libpng`.