### PR TITLE
Changes to time presentation in race_qex mission

### DIFF
--- a/dat/missions/neutral/race_qex.lua
+++ b/dat/missions/neutral/race_qex.lua
@@ -84,7 +84,7 @@ end
 
 local function display_time( time )
    return fmt.f(_("{1:02.0f}:{2:02.0f}.{3:.0f}"),{
-      math.floor( time / 60 ),
+      math.floor(math.abs( time / 60 )),
       math.floor(math.fmod( time, 60 ) ),
       math.floor(math.fmod( time, 1 )*10),
    })
@@ -353,14 +353,14 @@ They hand you one of those fake oversized cheques for the audience, and then a c
          player.pay(reward)
       end )
    elseif best_improved then
-      vn.na(fmt.f(_("You finished the race in {elapsed}, but were {short} of the goal time. This is your new best time! Keep trying!"), {
+      vn.na(fmt.f(_("You finished the race in {elapsed}, but were {short} over the goal time. This is your new best time! Keep trying!"), {
          elapsed="#g"..display_time( elapsed_time ).."#0",
-         short="#r"..display_time( mem.track.goaltime - elapsed_time ).."#0",
+         short="#r"..display_time( -mem.track.goaltime + elapsed_time ).."#0",
       }))
    else
-      vn.na(fmt.f(_("You finished the race in {elapsed}, but were {short} of the goal time. Keep trying!"), {
+      vn.na(fmt.f(_("You finished the race in {elapsed}, but were {short} over the goal time. Keep trying!"), {
          elapsed="#g"..display_time( elapsed_time ).."#0",
-         short="#r"..display_time( mem.track.goaltime - elapsed_time ).."#0",
+         short="#r"..display_time( -mem.track.goaltime + elapsed_time ).."#0",
       }))
    end
 

--- a/dat/missions/neutral/race_qex.lua
+++ b/dat/missions/neutral/race_qex.lua
@@ -83,10 +83,11 @@ function create ()
 end
 
 local function display_time( time )
+   local abs_time = math.abs(time)
    return fmt.f(_("{1:02.0f}:{2:02.0f}.{3:.0f}"),{
-      (time > 0 and 1 or -1)*math.floor(math.abs( time / 60 )),
-      math.floor(math.fmod( math.abs(time), 60 ) ),
-      math.floor(math.fmod( math.abs(time), 1 )*10),
+      (time > 0 and 1 or -1)*math.floor( abs_time / 60 ),
+      math.floor(math.fmod( abs_time, 60 ) ),
+      math.floor(math.fmod( abs_time, 1 )*10),
    })
 end
 
@@ -355,12 +356,12 @@ They hand you one of those fake oversized cheques for the audience, and then a c
    elseif best_improved then
       vn.na(fmt.f(_("You finished the race in {elapsed}, but were {short} over the goal time. This is your new best time! Keep trying!"), {
          elapsed="#g"..display_time( elapsed_time ).."#0",
-         short="#r"..display_time( -mem.track.goaltime + elapsed_time ).."#0",
+         short="#r"..display_time( elapsed_time - mem.track.goaltime ).."#0",
       }))
    else
       vn.na(fmt.f(_("You finished the race in {elapsed}, but were {short} over the goal time. Keep trying!"), {
          elapsed="#g"..display_time( elapsed_time ).."#0",
-         short="#r"..display_time( -mem.track.goaltime + elapsed_time ).."#0",
+         short="#r"..display_time( elapsed_time - mem.track.goaltime ).."#0",
       }))
    end
 

--- a/dat/missions/neutral/race_qex.lua
+++ b/dat/missions/neutral/race_qex.lua
@@ -84,9 +84,9 @@ end
 
 local function display_time( time )
    return fmt.f(_("{1:02.0f}:{2:02.0f}.{3:.0f}"),{
-      math.floor(math.abs( time / 60 )),
-      math.floor(math.fmod( time, 60 ) ),
-      math.floor(math.fmod( time, 1 )*10),
+      (time > 0 and 1 or -1)*math.floor(math.abs( time / 60 )),
+      math.floor(math.fmod( math.abs(time), 60 ) ),
+      math.floor(math.fmod( math.abs(time), 1 )*10),
    })
 end
 


### PR DESCRIPTION
- Fixed problem where display_time would display the minutes wrong for negative times (problem was `floor(-0.1)=-1`).
- Changed message when goal time is not met to be the time over the goal time (meaning the aforementioned fix isn't actually used but could still be handy in the future) i.e. instead of displaying `goal_time - time`, displays `-goal_time + time`.