### PR TITLE
A small typo fix

### DIFF
--- a/dat/events/news/soromid.lua
+++ b/dat/events/news/soromid.lua
@@ -4,7 +4,7 @@ local head = {
 local greeting = {
    _("Genetically tailoured for you."),
    _("Naturally selected news."),
-   _("In memory of Sorom"),
+   _("In memory of Sorom."),
 }
 local articles = {
 


### PR DESCRIPTION
Fixes a typo on line 7 of `dat/events/news/soromid.lua`.
I have no idea how this news system works, but based on the two lines above it there should be a period.
Sorry if I'm wrong.

EDIT: this was added in #2569.