### PR TITLE
Fix Lua errors in Japanese language.

### DIFF
--- a/dat/events/sirius/test_of_devotion.lua
+++ b/dat/events/sirius/test_of_devotion.lua
@@ -123,7 +123,7 @@ function spawn ()
 
    -- Spawn an enemy
    local pos = player.pos() + vec2.newP( 800+400*rnd.rnd(), rnd.angle() )
-   local e = pilot.add( "Astral Projection Lesser", _("Independent"), pos, nil, {ai="baddie_norun"})
+   local e = pilot.add( "Astral Projection Lesser", "Independent", pos, nil, {ai="baddie_norun"})
    e:effectAdd("Astral Projection")
    e:setHostile(true)
    e:setVisible(true)

--- a/dat/events/sirius/test_of_renewal.lua
+++ b/dat/events/sirius/test_of_renewal.lua
@@ -99,7 +99,7 @@ function puzzle01_addship ()
    if noadd then return end
    -- Spawn an enemy
    local pos = player.pos() + vec2.newP( 800+400*rnd.rnd(), rnd.angle() )
-   local e = pilot.add( "Astral Projection Lesser", _("Independent"), pos, nil, {ai="baddie_norun"})
+   local e = pilot.add( "Astral Projection Lesser", "Independent", pos, nil, {ai="baddie_norun"})
    e:effectAdd("Astral Projection")
    e:setHostile(true)
    e:setVisible(true)


### PR DESCRIPTION
**Bug Fix**
This PR addresses the bug that no enemies appeared in Test of Devotion and Renewal when you played it in Japanese language.

## Summary
Remove unnecessary translation functions.

## Testing Done
I played Test of Devotion and Renewal in Japanese environment.