### PR TITLE
Fix running from dev environment

### DIFF
--- a/utils/build/naev.py
+++ b/utils/build/naev.py
@@ -69,7 +69,7 @@ def wrapper(*args):
     else:
         command = list(args)
 
-    command = ["meson", "devenv"] + command
+    command = [sys.executable, os.path.join(source_root, "meson.py"), "devenv"] + command
 
     try:
         # Run the command

--- a/utils/build/naev.py
+++ b/utils/build/naev.py
@@ -69,6 +69,8 @@ def wrapper(*args):
     else:
         command = list(args)
 
+    command = ["meson", "devenv"] + command
+
     try:
         # Run the command
         debugger_process = subprocess.Popen(command)


### PR DESCRIPTION
Using `meson devenv` in the run helper fixes cases of missing shared libs from subprojects
