### PR TITLE
Fix a bug that conf.max_3d_tex_size was saved as a boolean.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1013,7 +1013,7 @@ int conf_saveConfig( const char *file )
    conf_saveComment(
       _( "Maximum texture size to use for 3D models when in low memory mode. A "
          "value of less than or equal to 0 disables texture resizing." ) );
-   conf_saveBool( "max_3d_tex_size", conf.max_3d_tex_size );
+   conf_saveInt( "max_3d_tex_size", conf.max_3d_tex_size );
    conf_saveEmptyLine();
 
    /* FPS */


### PR DESCRIPTION
**Bug Fix**

## Summary
conf.max_3d_tex_size is saved as an integer number, same as the type when loading.


## Testing Done
I checked 'max_3d_tex_size = 256' in the config file after exiting Naev.
