### PR TITLE
Fix a bug that causes a buffer overflow when scrolling up the message.

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -241,7 +241,7 @@ void gui_messageScrollUp( int lines )
       lines = o;
 
    /* Move viewpoint. */
-   const int new_point = ( mesg_viewpoint - lines ) % mesg_max;
+   const int new_point = ( mesg_max + mesg_viewpoint - lines ) % mesg_max;
    if ( mesg_stack && mesg_stack[new_point].str )
       mesg_viewpoint = new_point;
 }


### PR DESCRIPTION
**Bug Fix**

## Summary
mesg_stack[new_point] might be out of the range because the modulo operator may result in a negative value.

mesg_viewpoint could also happen to be -1, so the message area was rewound the last line.

This PR fixes it.

## Testing Done
I scrolled up the messages after the lines of the message is more than 128.