### PR TITLE
Fix errors in missions

### DIFF
--- a/dat/events/wildspace/intro_npc.lua
+++ b/dat/events/wildspace/intro_npc.lua
@@ -4,7 +4,7 @@
  <location>land</location>
  <unique />
  <chance>10</chance>
- <chapter>^0</chapter><!-- TODO bump to 2 when finished. -->
+ <chapter>[^0]</chapter><!-- TODO bump to 2 when finished. -->
  <cond>
    local s = spob.cur()
    if not s:services()["bar"] then

--- a/dat/missions/dvaered/frontier_war/fw04_meeting.lua
+++ b/dat/missions/dvaered/frontier_war/fw04_meeting.lua
@@ -467,7 +467,7 @@ end
 
 -- Spawn Hamelsen in a hyena
 function spawnHam()
-   hamelsen = pilot.add( "Hyena", "Independent", system.get("Beeklo"), {naked=true} )
+   hamelsen = pilot.add( "Hyena", "Independent", system.get("Beeklo"), nil, {naked=true} )
    equipHyena( hamelsen )
    hamelsen:control()
    hamelsen:land(targpla)
@@ -476,7 +476,7 @@ function spawnHam()
    hook.timer(0.5, "proximity", {location = targpos, radius = 10000, funcname = "incomingHamelsen", focus = hamelsen})
 
    -- Hamelsen's partner, whose purpose is to make a fight occur
-   jules = pilot.add( "Hyena", "Independent", system.get("Beeklo"), {naked=true} )
+   jules = pilot.add( "Hyena", "Independent", system.get("Beeklo"), nil, {naked=true} )
    equipHyena( jules )
    jules:control()
    jules:follow( hamelsen )

--- a/dat/missions/dvaered/frontier_war/fw05_triathlon.lua
+++ b/dat/missions/dvaered/frontier_war/fw05_triathlon.lua
@@ -325,11 +325,11 @@ end
 function tamCommon()
    local c = tk.choice("", _("What do you want to ask Major Tam?"), _("Explain next stage"), _("Display the scores"))
    if c == 1 then
-      if mem.stage == 1 then
+      if mem.stage <= 2 then
          tamStage1()
-      elseif mem.stage == 3 then
+      elseif mem.stage <= 4 then
          tamStage2()
-      else --if mem.stage == 5 then
+      else --if mem.stage <= 6 then
          tamStage3()
       end
    else -- Display the scores

--- a/dat/missions/dvaered/recruitment/dv_bikers.lua
+++ b/dat/missions/dvaered/recruitment/dv_bikers.lua
@@ -50,10 +50,10 @@ local portrait = require "portrait"
 local agentPort = "dvaered/dv_military_m2.webp"
 local BBB1Port = "pirate/pirate4.webp"
 local BBB2Port = "pirate/pirate6.webp"
-local npc1img, npc1por = vni.get()
-local npc2img, npc2por = vni.get()
-local npc3img, npc3por = vni.get()
-local npc4img, npc4por = vni.get()
+local npc1img, npc1por = vni.generic()
+local npc2img, npc2por = vni.generic()
+local npc3img, npc3por = vni.generic()
+local npc4img, npc4por = vni.generic()
 
 local gangs = { _("Big Bang Band"), -- gang of Blue Belly Billy
                 _("Cringe Crew"),

--- a/dat/missions/minerva/pirate4.lua
+++ b/dat/missions/minerva/pirate4.lua
@@ -27,7 +27,7 @@ local reward_amount = minerva.rewards.pirate4
 
 local mainsys     = system.get("Fried")
 local dvaeredsys  = system.get("Limbo")
-local piratesys   = system.get("Effetey")
+local piratesys   = system.get("Gold")
 local shippos     = vec2.new( 4000, 0 ) -- asteroid field center
 -- Mission states:
 --  nil: mission not accepted yet

--- a/dat/missions/neutral/runaway/runaway_search.lua
+++ b/dat/missions/neutral/runaway/runaway_search.lua
@@ -207,8 +207,8 @@ function land ()
 
       if mem.hascynthia then
          --Talk to the father and get the reward
-         local _cynthia = vn.newCharacter( npc_name, {image=npc_image, pos="left"} )
-         local _father = vn.newCharacter( npc_name, {image=npc_image, pos="righ"} )
+         local _cynthia = vn.newCharacter( npc2_name, {image=npc2_image, pos="left"} )
+         local _father = vn.newCharacter( npc_name, {image=npc_image, pos="right"} )
          vn.transition()
 
          vn.na(_("As Cynthia sees her father, she begins her crying anew. You overhear the father talking about how her abusive mother died. Cynthia becomes visibly happier, so you pick up your payment and depart."))

--- a/dat/missions/shadow/shadowrun.lua
+++ b/dat/missions/shadow/shadowrun.lua
@@ -212,7 +212,7 @@ end
 function soldier2()
    vn.clear()
    vn.scene()
-   vn.newCharacter( "Soldier", {image=sol2img, pos="lef:"} )
+   vn.newCharacter( "Soldier", {image=sol2img, pos="left"} )
    vn.newCharacter( "Soldier", {image=sol3img, pos="right"} )
    vn.transition()
    vn.na(_([[They don't seem to appreciate your company. You decide to leave them to their game.]]))

--- a/dat/missions/wildspace/intro.lua
+++ b/dat/missions/wildspace/intro.lua
@@ -200,7 +200,7 @@ When you receive this message, there is no need to come look for me. I will no l
       -- TODO log
       local msg = _([[You recovered a package for Claude from {spb} ({sys} system), who, sacrificed himself before turning Lost. The package contained a blueprint to make your ship resistant to the Wild Space local effects making people Lost, allowing you to safely survive.]])
       if not jump.get("Scholz's Star", "Haered"):known() then
-         msg = fmt.f(_([[{msg} Furthermore, your Ship AI indicated that it is likely that there is a second exit from Wild Space, which may warrant more exploration.]], {msg=msg}))
+         msg = fmt.f(_([[{msg} Furthermore, your Ship AI indicated that it is likely that there is a second exit from Wild Space, which may warrant more exploration.]]), {msg=msg})
       end
       ws.log(fmt.f(msg, {spb=target, sys=targetsys}))
 

--- a/dat/missions/zalek/sciencegonewrong/00_sciwrong.lua
+++ b/dat/missions/zalek/sciencegonewrong/00_sciwrong.lua
@@ -210,6 +210,7 @@ function third_trd()
 
    misn.npcRm(mem.bar1pir1)
    misn.cargoRm(mem.carg_id)
+   mem.carg_id = nil
    player.msg(mem.t_sys[3]:name())
    misn.osdCreate(_("The one with the Shopping"), {
       fmt.f(_("Return to the {sys} system and deliver to Dr. Geller on {pnt}"), {sys=mem.t_sys[3], pnt=mem.t_pla[3]}),
@@ -245,7 +246,7 @@ function fnl_ld ()
 end
 -- when the player takes off the authorities will want them
 function sys_enter ()
-   if system.cur() == mem.t_sys[2] then
+   if system.cur() == mem.t_sys[2] and mem.carg_id then
       hook.timer(7.0, "call_the_police")
    end
 end
@@ -266,7 +267,7 @@ function call_the_police ()
 end
 
 function spwn_police () -- Get called to Waterhole
-   local spwnsys = system.get("Holly")
+   local spwnsys = system.get("Majesteka")
    lance1 = pilot.add( "Empire Lancelot", "Empire", spwnsys, nil, {naked=true} )
    lance2 = pilot.add( "Empire Lancelot", "Empire", spwnsys, nil, {naked=true} )
    adm1 = pilot.add( "Empire Admonisher", "Empire", spwnsys, nil, {naked=true} )
@@ -339,6 +340,7 @@ function fine_vanish ()
    end
 
    misn.cargoRm(mem.carg_id)
+   mem.carg_id = nil
    if adm1:exists() then
       adm1:hyperspace()
    end

--- a/dat/naevpedia/mechanics/shipstats.md
+++ b/dat/naevpedia/mechanics/shipstats.md
@@ -8,7 +8,7 @@ title: "Ship Stats"
 There are many different important stats for ships that define their behaviour when flying in space. These are all visible from the [equipment](mechanics/equipment) panel.
 
 * [Model](ships): The name of the ship model.
-* [Class](mechanics/class): The ship class.
+* [Class](ships/classes): The ship class.
 * [Value](mechanics/credits): The value of the ship including all the [outfits](outfits) equipped on it.
 <% if naev.player.fleetCapacity() > 0 then %>
 * [Fleet Capacity](mechanics/playerfleet): Determine how much fleet capacity a ship uses when deployed in a [fleet](mechanics/playerfleet).

--- a/dat/naevpedia/ships/classes.lua
+++ b/dat/naevpedia/ships/classes.lua
@@ -15,7 +15,7 @@ function classes.list( c )
       return a:name() < b:name()
    end )
    for k,s in ipairs(ships) do
-      local desc = fmt.f(_("{fct} {class}"), {fct=s:faction(), class=s:classDisplay()})
+      local desc = fmt.f(_("{fct} {class}"), {fct=s:faction(), class=_(s:classDisplay())})
       out = out.."* **["..s:name().."]("..naevpedia.get(s:nameRaw())..")**: "..desc.."\n"
    end
    return out

--- a/dat/scripts/minigames/chuckaluck.lua
+++ b/dat/scripts/minigames/chuckaluck.lua
@@ -62,7 +62,7 @@ local function _chatter( chat_type )
    local text
    cl.chatter_colour = nil
    -- Special secretcode being input chat
-   if var.peek("minerva_caninputcode") then
+   if not cl.secretcode and var.peek("minerva_caninputcode") then
       if secretcode_status == 4 then
          cl.chatter = _("The dealer hands you a note saying to meet him after his shift.")
          naev.trigger( "minerva_secretcode" )

--- a/dat/spob/hs224.xml
+++ b/dat/spob/hs224.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spob name="HS-224">
+ <lua>thurion.lua</lua>
  <pos x="-843.838336" y="-1820.509003"/>
  <GFX>
   <space>000.webp</space>

--- a/dat/spob/hs232.xml
+++ b/dat/spob/hs232.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spob name="HS-232">
+ <lua>thurion.lua</lua>
  <pos x="6432.707086" y="3748.710360"/>
  <GFX>
   <space>000.webp</space>

--- a/dat/spob/hs24.xml
+++ b/dat/spob/hs24.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spob name="HS-24">
+ <lua>thurion.lua</lua>
  <pos x="-5194.434413" y="7375.522896"/>
  <GFX>
   <space>000.webp</space>

--- a/dat/spob/hs37.xml
+++ b/dat/spob/hs37.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spob name="HS-37">
+ <lua>thurion.lua</lua>
  <pos x="-6851.664918" y="-5971.606224"/>
  <GFX>
   <space>000.webp</space>

--- a/dat/spob/hs54.xml
+++ b/dat/spob/hs54.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spob name="HS-54">
+ <lua>thurion.lua</lua>
  <pos x="1844.468963" y="-3806.397829"/>
  <GFX>
   <space>000.webp</space>

--- a/dat/spob/lua/thurion.lua
+++ b/dat/spob/lua/thurion.lua
@@ -5,7 +5,7 @@ luaspob.setup{
    std_land = 0,
    std_bribe = 101,
    msg_granted = {
-      function () fmt.f(_([["Welcome, {player}. You may dock when ready."]]), {player=player.name()}) end,
+      function () return player.name() and fmt.f(_([["Welcome, {player}. You may dock when ready."]]), {player=player.name()}) or "" end,
       _([["Dock at the life-support enabled ports when ready."]]),
    },
    msg_denied = {
@@ -22,10 +22,14 @@ luaspob.setup{
 local _can_land = can_land
 function can_land ()
    local ret, msg = _can_land()
+   if type(msg) == "function" then
+      msg = msg()
+   end
    if not ret then
       return ret, msg
    end
    if not faction.get("Thurion"):known() then
       return false, _([["You are not yet authorized to land here."]])
    end
+   return ret, msg
 end

--- a/dat/spob/lua/thurion_mil_restricted.lua
+++ b/dat/spob/lua/thurion_mil_restricted.lua
@@ -5,7 +5,7 @@ luaspob.setup{
    std_land = 50,
    std_bribe = 100,
    msg_granted = {
-      function () fmt.f(_([["Welcome, friend {player}. You may dock when ready."]]), {player=player.name()}) end,
+      function () return player.name() and fmt.f(_([["Welcome, friend {player}. You may dock when ready."]]), {player=player.name()}) or "" end,
    },
    msg_notyet = {
       _([["We can't trust you to land here just yet."]]),
@@ -18,10 +18,14 @@ luaspob.setup{
 local _can_land = can_land
 function can_land ()
    local ret, msg = _can_land()
+   if type(msg) == "function" then
+      msg = msg()
+   end
    if not ret then
       return ret, msg
    end
    if not faction.get("Thurion"):known() then
       return false, _([["You are not yet authorized to land here."]])
    end
+   return ret, msg
 end


### PR DESCRIPTION
**Bug Fix**
## Summary
This PR fixes some errors that I have found in the last playthrough.

Fixed:
- Trivial errors
  - Overwrapping some portraits in "The Search for Cynthia"
  - Overwrapping a portrait in "Shadowrun"
  - No violation happened in "Dvaered Meeting"
  - No common bikers in "Dvaered Negotiation 2"
  - Never occurred the event "Way to Wild Space"
  - A log wasn't recorded in "Old Friends at Protera Husk"
- Errors by some unwanted input
  - Skipped some stages by asking Major Tam twice in "Dvaered Ballet"
  - Duplicate events occurred if you don't stop playing the chuckaluck after you received the note
- There is no nearby system "Effetey" in "Minerva Pirates 4"
  Dvaered and pirates' reinforcements might come from the same jump point and Dvaered could defeat the pirates easily. The pirates should come from the other side.
- Two errors in "The one with the Shopping"
  - There was no nearby system "Holly"
  - Patrol warned you when returning to the originating system through the system "Waterhole" without phosphine
- Landing permissions in Thurion
  - The Habitation Stations didn't have their permission, so you may land before you were known.
  - Shipyard and military restricted areas would never give you the landing permission even if you could increased the reputation. (Simply speaking, there was no return statement in the function can_land())
  - Some granted messages were nil.
- Naevpedia
  - A link error in shipstats.md
  - Not specified translation in classes.lua

## Testing Done
I played the fixed missions.