### PR TITLE
Preliminary drone nerf

### DIFF
--- a/dat/outfits/launchers/electron_burst_cannon.xml
+++ b/dat/outfits/launchers/electron_burst_cannon.xml
@@ -33,7 +33,7 @@
   <damage>
    <type>ion</type>
    <penetrate>24</penetrate>
-   <physical>12</physical>
+   <physical>14</physical>
   </damage>
   <ai>unguided</ai>
  </specific>

--- a/dat/outfits/launchers/electron_burst_cannon.xml
+++ b/dat/outfits/launchers/electron_burst_cannon.xml
@@ -10,12 +10,12 @@
   <rarity>3</rarity>
   <mass>12</mass>
   <price>40000</price>
-  <description>This powerful energy weapon is built to bombard a target from great range with EMP bursts, causing debilitating damage to a target's shields and electrical systems, which can leave a ship effectively defenceless. It was developed by the Za'lek to be used by their heavier droness to supplement the short range and high damage of their beams.</description>
+  <description>This powerful energy weapon is built to bombard a target from great range with ion bursts, causing debilitating damage to a target's shields and electrical systems, which can leave a ship effectively defenceless. It was developed by the Za'lek to be used by their heavier droness to supplement the short range and high damage of their beams.</description>
   <gfx_store>weapon01.webp</gfx_store>
   <cpu>-10</cpu>
  </general>
  <specific type="launcher">
-  <delay>0.3</delay>
+  <delay>0.4</delay>
   <reload_time>6</reload_time>
   <amount>50</amount>
   <swivel>22</swivel>
@@ -31,10 +31,9 @@
   <accel>0</accel>
   <speed>1500</speed>
   <damage>
-   <type>emp</type>
+   <type>ion</type>
    <penetrate>24</penetrate>
-   <physical>13</physical>
-   <disable>3</disable>
+   <physical>12</physical>
   </damage>
   <ai>unguided</ai>
  </specific>

--- a/dat/ships/zalek/zalek_drone_heavy.xml
+++ b/dat/ships/zalek/zalek_drone_heavy.xml
@@ -32,11 +32,10 @@
   <fuel>100</fuel>
   <cargo>0</cargo>
   <fuel_consumption>1</fuel_consumption>
-  <cpu>80</cpu>
+  <cpu>68</cpu>
  </characteristics>
  <slots>
   <weapon size="small" x="15" y="-5" h="2">Orion Lance</weapon>
-  <weapon size="small" x="15" y="-4" h="2">Orion Lance</weapon>
   <weapon size="small" x="-12" y="6" h="0">Electron Burst Cannon</weapon>
   <utility size="small" />
   <utility size="small" />
@@ -44,7 +43,6 @@
   <structure size="small" />
  </slots>
  <stats>
-  <fwd_damage>-20</fwd_damage>
   <tur_damage>-20</tur_damage>
   <launch_damage>-20</launch_damage>
  </stats>


### PR DESCRIPTION
Heavy Drones now only have one Orion beam that does full damage. EBCs are a little better at damaging armor, but no longer do any disable damage.