### PR TITLE
Allow mods to adjust POI NPC priority

### DIFF
--- a/dat/events/poi_generator.lua
+++ b/dat/events/poi_generator.lua
@@ -58,7 +58,10 @@ function land ()
    npc_image, npc_prt = vni.generic()
    npc_name = _("Tipsy Patron")
    npc_desc = _("You see a tipsy individual who seems like they have something to say.")
-   evt.npcAdd( "approach_npc", npc_name, npc_prt, npc_desc, 9 )
+
+   -- Allow plugins to modify the NPC priority of the POI generator NPC
+   local poi_generator_npc_priority = var.peek("poi_generator_npc_priority") or 9
+   evt.npcAdd( "approach_npc", npc_name, npc_prt, npc_desc, poi_generator_npc_priority )
 end
 
 function approach_npc( npcid )


### PR DESCRIPTION
**New Feature**

## Summary
Gets the POI NPC priority from a variable, defaulting to the current default of 9. This allows for mods to adjust this (I have a mod in the works that adjusts this value to 5 so it shows up as an important NPC that gives an alert). 

## Testing Done
Made sure when landing there weren't a bunch of Lua errors. 
