### PR TITLE
ambush hunter bugfix

### DIFF
--- a/dat/outfits/bioship/generate.py
+++ b/dat/outfits/bioship/generate.py
@@ -11,7 +11,7 @@ N_ = lambda text: text
 class Build:
     ''' By default, build everything in-tree. '''
 
-    def read_tempate(self, name):
+    def read_template(self, name):
         return open(f'templates/{name}').read()
 
     def file_names(self, names):

--- a/dat/outfits/bioship/skills/ambush_hunter.lua
+++ b/dat/outfits/bioship/skills/ambush_hunter.lua
@@ -1,20 +1,19 @@
 notactive = true
 
-local function _update( p, stealthed )
+function onstealth( p, _po, stealthed )
    if mem.stealthed and not stealthed then
       p:effectAdd( "Ambush Hunter" )
    end
    mem.stealthed = stealthed
 end
 
-function init( p, _po )
+function init( p, po )
    mem.stealthed = p:flags("stealth")
 end
 
-function onstealth( p, _po, stealthed )
-   _update( p, stealthed )
+function land(p,po)
+   -- At least, ship properties lose the effect bonus.
+   -- Still, the icon remains.
+   p:effectRm( "Ambush Hunter" )
 end
 
-function update( p, _po, _dt )
-   _update( p, p:flags("stealth") )
-end

--- a/dat/outfits/bioship/skills/ambush_hunter.xml
+++ b/dat/outfits/bioship/skills/ambush_hunter.xml
@@ -11,6 +11,5 @@
  </general>
  <specific type="modification">
   <lua>outfits/bioship/skills/ambush_hunter.lua</lua>
-  <weapon_damage>50</weapon_damage>
  </specific>
 </outfit>


### PR DESCRIPTION
**Bug Fix**

This PR addresses the bugs described in #2753

## Summary
Bug 1 was fixed by removing outfit mods, as it is the effect that is supposed to add modifiers, not the outfit.

Bug 2 was fixed by always removing the effect when landing.
I couldn't think of another event that would interrupt the effect.

Notice that removing the effect does not removes the icon, 
and here I assume it is another bug.

Actually, it is possible to "fix" that by adding a new effect at take off (init) that adds a new effect that overwrites this one with a duration of 0. But I think it is better to fix the bug than to hide it in a dirty way.

## Testing Done
Yes, I did.
