### PR TITLE
autonav - disable afterburner when approaching

### DIFF
--- a/dat/autonav.lua
+++ b/dat/autonav.lua
@@ -412,7 +412,7 @@ local function turnoff_afterburner()
       -- Proposition:
       --   activate: boolean Whether to activate or deactivate
       if n["type"]=="Afterburner" and n["state"]=="on" then
-         player.pilot():outfitToggle(i)
+         player.pilot():outfitToggle( n['slot'] )
       end
    end
    for _i,n in ipairs(player.pilot():actives()) do

--- a/dat/autonav.lua
+++ b/dat/autonav.lua
@@ -404,20 +404,12 @@ local function autonav_rampdown( count_brake )
 end
 
 local function turnoff_afterburner()
-   for i,n in ipairs(player.pilot():actives()) do
+   local pp=player.pilot()
+   for _i,n in ipairs(pp:actives()) do
       -- Why does n:type() not work ?
       -- Why *A*fterburner and not afterburner ?
-      -- The documentation is not clear : (too much or.s)
-      --   activate: boolean Whether or not to activate or deactivate
-      -- Proposition:
-      --   activate: boolean Whether to activate or deactivate
       if n["type"]=="Afterburner" and n["state"]=="on" then
-         player.pilot():outfitToggle( n['slot'] )
-      end
-   end
-   for _i,n in ipairs(player.pilot():actives()) do
-      if n["type"]=="Afterburner" and n["state"]=="on" then
-         print("Toggle failed!")
+         pp:outfitToggle( n['slot'] )
       end
    end
 end

--- a/dat/autonav.lua
+++ b/dat/autonav.lua
@@ -10,6 +10,7 @@ local autonav_timer, tc_base, tc_mod, tc_max, tc_rampdown, tc_down
 local last_shield, last_armour, map_npath, reset_shield, reset_dist, reset_lockon, fleet_speed, game_speed, escort_health
 local path, uselanes_jump, uselanes_spob, uselanes_thr, match_fleet, follow_land_jump, brake_pos, include_escorts
 local follow_pilot_fleet
+local already_aboff
 
 -- Some defaults
 autonav_timer = 0
@@ -42,6 +43,7 @@ local function autonav_setup ()
    tc_rampdown = false
    tc_down     = 0
    path        = nil
+   already_aboff= false
    follow_pilot_fleet = {}
    local stealth = pp:flags("stealth")
    uselanes_jump = var.peek("autonav_uselanes_jump") and not stealth
@@ -409,9 +411,14 @@ local function turnoff_afterburner()
       -- Why does n:type() not work ?
       -- Why *A*fterburner and not afterburner ?
       if n["type"]=="Afterburner" and n["state"]=="on" then
-         pp:outfitToggle( n['slot'] )
+         if already_aboff then
+            return autonav_abort(_("Manual commands at approach."))
+         else
+            pp:outfitToggle( n['slot'] )
+         end
       end
    end
+   already_aboff=true
 end
 
 --[[
@@ -446,6 +453,7 @@ local function autonav_approach( pos, count_brakedist )
          end
       end
    end
+
 
    -- Distance left to start breaking
    local dist = d - brakedist

--- a/dat/autonav.lua
+++ b/dat/autonav.lua
@@ -403,9 +403,27 @@ local function autonav_rampdown( count_brake )
    end
 end
 
+local function turnoff_afterburner()
+   for i,n in ipairs(player.pilot():actives()) do
+      -- Why does n:type() not work ?
+      -- Why *A*fterburner and not afterburner ?
+      -- The documentation is not clear : (too much or.s)
+      --   activate: boolean Whether or not to activate or deactivate
+      -- Proposition:
+      --   activate: boolean Whether to activate or deactivate
+      if n["type"]=="Afterburner" and n["state"]=="on" then
+         player.pilot():outfitToggle(i)
+      end
+   end
+   for _i,n in ipairs(player.pilot():actives()) do
+      if n["type"]=="Afterburner" and n["state"]=="on" then
+         print("Toggle failed!")
+      end
+   end
+end
+
 --[[
    For approaching a static target.
-
 --]]
 local function autonav_approach( pos, count_brakedist )
    local pp = player.pilot()
@@ -447,6 +465,7 @@ local function autonav_approach( pos, count_brakedist )
    end
 
    if dist < 0 then
+      turnoff_afterburner()
       ai.accel(0)
       return true, retd
    end

--- a/dat/autonav.lua
+++ b/dat/autonav.lua
@@ -412,7 +412,7 @@ local function turnoff_afterburner()
       -- Why *A*fterburner and not afterburner ?
       if n["type"]=="Afterburner" and n["state"]=="on" then
          if already_aboff then
-            return autonav_abort(_("Manual commands at approach."))
+            return autonav_abort(_("manual commands at approach"))
          else
             pp:outfitToggle( n['slot'] )
          end
@@ -453,7 +453,6 @@ local function autonav_approach( pos, count_brakedist )
          end
       end
    end
-
 
    -- Distance left to start breaking
    local dist = d - brakedist

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -2647,7 +2647,7 @@ static int outfitToggle( lua_State *L, Pilot *p, int id, int activate )
  *    @luatparam Pilot p Pilot to toggle outfit of.
  *    @luatparam table|integer id ID of the pilot outfit, or table of pilot
  * outfit ids.
- *    @luatparam[opt=false] boolean activate Whether or not to activate or
+ *    @luatparam[opt=false] boolean activate Whether to activate or
  * deactivate the outfit.
  * @luafunc outfitToggle
  */


### PR DESCRIPTION
**Bug Fix**/**New Feature**

This PR addresses the bug/feature described in #2774.

## Summary
 - Turn off afterburner before:
      - [x]  a jump, except if the ship has _instant jump_;
      - [x]  landing.
 - [x] Hitting the afterburner while doing final approach should abort autonav.
 - The comments in the sources raise issues.
 