### PR TITLE
autonav - reset if non-pdef weapon fired

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
          * Can automatically land when following a ship
          * Improved autonav behaviour when losing a followed ship
          * Disables afterburner when getting ready to land or jump
+         * Shooting *non-point defense* weapons resets autonav speed up
    * Content
       * 2 new missions
       * 6 new ship variants

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -1265,7 +1265,7 @@ int pilot_shootWeapon( Pilot *p, PilotOutfitSlot *w, const Target *target,
    w->timer += rate_mod * outfit_delay( w->outfit );
 
    /* Reset autonav if is player. */
-   if ( pilot_isPlayer( p ) && !outfit_isProp( w->outfit, OUTFIT_PROP_WEAP_POINTDEFENSE )
+   if ( pilot_isPlayer( p ) && !outfit_isProp( w->outfit, OUTFIT_PROP_WEAP_POINTDEFENSE ) )
       player_autonavReset( 1. );
 
    return 1;

--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -23,6 +23,7 @@
 #include "pilot.h"
 #include "pilot_ship.h"
 #include "player.h"
+#include "player_autonav.h"
 #include "sound.h"
 #include "spfx.h"
 #include "weapon.h"
@@ -1264,8 +1265,8 @@ int pilot_shootWeapon( Pilot *p, PilotOutfitSlot *w, const Target *target,
    w->timer += rate_mod * outfit_delay( w->outfit );
 
    /* Reset autonav if is player. */
-   // if ( pilot_isPlayer( p ) )
-   //    player_autonavReset( 1. );
+   if ( pilot_isPlayer( p ) && !outfit_isProp( w->outfit, OUTFIT_PROP_WEAP_POINTDEFENSE )
+      player_autonavReset( 1. );
 
    return 1;
 }


### PR DESCRIPTION
**Bug Fix**/**New Feature**

This PR addresses the bug/feature described in #2696.

## Summary
See #2696. This patch relates to commit :
```git
commit d3f8d4179b4c8a6c043f52d5db35fef1f039e7a4 (HEAD)
Author: Edgar Simo-Serra <bobbens@gmail.com>
Date:   Thu Nov 21 23:56:57 2024 +0900

    Shooting weapons no longer resets autonav speed up.
```
I reverted it and added a check for point defense flag.

## Testing Done
I can't. Sorry !
