### PR TITLE
xml/lua redundancy bugfix

### DIFF
--- a/dat/outfits/core_hull/large/nexus_phantasm_weave.mvx
+++ b/dat/outfits/core_hull/large/nexus_phantasm_weave.mvx
@@ -1,6 +1,6 @@
-<outfit name="Nexus Phantasm Plating">
+<outfit name="Nexus Phantasm Weave">
  <general>
-  <shortname>N. Phantasm Plating</shortname>
+  <shortname>N. Phantasm Weave</shortname>
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>large</size>

--- a/dat/outfits/core_hull/large/patchwork_heavy_plating.xml
+++ b/dat/outfits/core_hull/large/patchwork_heavy_plating.xml
@@ -4,7 +4,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>large</size>
   <priority>3</priority>
-  <mass>600</mass>
   <price>0</price>
   <description>On the plus side, it keeps air from venting into space. But that's about it. This kind of hull maintenance is simply unacceptable.</description>
   <gfx_store>plating_patchwork.webp</gfx_store>

--- a/dat/outfits/core_hull/large/rs_large_cargo_hull.xml
+++ b/dat/outfits/core_hull/large/rs_large_cargo_hull.xml
@@ -5,7 +5,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>large</size>
   <priority>7</priority>
-  <mass>550</mass>
   <price>1200000</price>
   <description>The Imperial Red Star is dedicated to relief efforts in areas stricken by war, piracy and disease. Recently developed by the organization is a series of specialized cargo hulls meant to maximize the odds of their supplies and personnel safely arriving where they are needed most. The integrated scrambler systems allow even the largest ships a chance to turn away missiles.</description>
   <gfx_store>rs_hull_l.webp</gfx_store>

--- a/dat/outfits/core_hull/large/sk_large_cargo_hull.xml
+++ b/dat/outfits/core_hull/large/sk_large_cargo_hull.xml
@@ -4,7 +4,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>large</size>
   <priority>7</priority>
-  <mass>550</mass>
   <price>1100000</price>
   <description>This cargo hull from Schafer &amp; Kane Industries makes use of state-of-the-art defensive alloys, which allows it to free up even more space for cargo without sacrificing too much durability.</description>
   <gfx_store>cargo_hull_l.webp</gfx_store>

--- a/dat/outfits/core_hull/medium/nexus_ghost_weave.mvx
+++ b/dat/outfits/core_hull/medium/nexus_ghost_weave.mvx
@@ -1,6 +1,6 @@
-<outfit name="Nexus Ghost Plating">
+<outfit name="Nexus Ghost Weave">
  <general>
-  <shortname>N. Ghost Plating</shortname>
+  <shortname>N. Ghost Weave</shortname>
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>medium</size>

--- a/dat/outfits/core_hull/medium/patchwork_medium_plating.xml
+++ b/dat/outfits/core_hull/medium/patchwork_medium_plating.xml
@@ -4,7 +4,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>medium</size>
   <priority>3</priority>
-  <mass>130</mass>
   <price>0</price>
   <description>On the plus side, it keeps air from venting into space. But that's about it. This kind of hull maintenance is simply unacceptable.</description>
   <gfx_store>plating_patchwork.webp</gfx_store>

--- a/dat/outfits/core_hull/small/nexus_shadow_weave.mvx
+++ b/dat/outfits/core_hull/small/nexus_shadow_weave.mvx
@@ -1,6 +1,6 @@
-<outfit name="Nexus Shadow Plating">
+<outfit name="Nexus Shadow Weave">
  <general>
-  <shortname>N. Shadow Plating</shortname>
+  <shortname>N. Shadow Weave</shortname>
   <typename>Core Systems (Hull)</typename>
   <slot prop="hull">structure</slot>
   <size>small</size>

--- a/dat/outfits/core_hull/small/nexus_shadow_weave.xml
+++ b/dat/outfits/core_hull/small/nexus_shadow_weave.xml
@@ -5,7 +5,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>small</size>
   <priority>7</priority>
-  <mass>25</mass>
   <price>90000</price>
   <description>Designed for military scouting and patrol vessels, Nexus' Light Stealth Plating configuration features the latest in sensor-absorbing materials and geometry.</description>
   <gfx_store>stealth_hull_t.webp</gfx_store>

--- a/dat/outfits/core_hull/small/patchwork_light_plating.xml
+++ b/dat/outfits/core_hull/small/patchwork_light_plating.xml
@@ -4,13 +4,11 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>small</size>
   <priority>3</priority>
-  <mass>30</mass>
   <price>0</price>
   <description>On the plus side, it keeps air from venting into space. But that's about it. This kind of hull maintenance is simply unacceptable.</description>
   <gfx_store>plating_patchwork.webp</gfx_store>
  </general>
  <specific type="modification">
-  <absorb>0</absorb>
   <lua_inline>
 require("outfits.lib.multicore").init{
    { "mass", 30, 30},

--- a/dat/outfits/core_hull/small/rs_small_cargo_hull.xml
+++ b/dat/outfits/core_hull/small/rs_small_cargo_hull.xml
@@ -5,7 +5,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>small</size>
   <priority>7</priority>
-  <mass>28</mass>
   <price>140000</price>
   <description>The Imperial Red Star is dedicated to relief efforts in areas stricken by war, piracy and disease. Recently developed by the organization is a series of specialized cargo hulls meant to maximize the odds of their supplies and personnel safely arriving where they are needed most. This hull integrates scramblers to help blunt the effects of homing missiles and turret tracking, allowing small ships to more effectively run blockades by pirates and privateers.</description>
   <gfx_store>rs_hull_s.webp</gfx_store>

--- a/dat/outfits/core_hull/small/sk_skirmish_plating.mvx
+++ b/dat/outfits/core_hull/small/sk_skirmish_plating.mvx
@@ -5,7 +5,7 @@
   <size>small</size>
   <mass>30</mass>
   <price>120000</price>
-  <description>Schafer &amp; Kane Industries mostly develop for larger ships, but the Ultralight Combat Plating configuration is a product made for light fighters and in-system patrol craft, providing optimum protection.</description>
+  <description>Schafer &amp; Kane Industries mostly develop for larger ships, but the Skirmish Plating configuration is a product made for light fighters and in-system patrol craft, providing optimum protection.</description>
   <gfx_store>combat_hull_t.webp</gfx_store>
   <priority>3</priority>
  </general>

--- a/dat/outfits/core_hull/small/sk_skirmish_plating.xml
+++ b/dat/outfits/core_hull/small/sk_skirmish_plating.xml
@@ -3,14 +3,12 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>small</size>
-  <mass>30</mass>
   <price>120000</price>
   <description>Schafer &amp; Kane Industries mostly develop for larger ships, but the Skirmish Plating configuration is a product made for light fighters and in-system patrol craft, providing optimum protection.</description>
   <gfx_store>combat_hull_t.webp</gfx_store>
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <cargo>2</cargo>
   <lua_inline>
 require("outfits.lib.multicore").init{
    { "mass", 30, 30},

--- a/dat/outfits/core_hull/small/sk_small_cargo_hull.xml
+++ b/dat/outfits/core_hull/small/sk_small_cargo_hull.xml
@@ -4,7 +4,6 @@
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>small</size>
   <priority>7</priority>
-  <mass>30</mass>
   <price>120000</price>
   <description>Though a pricey investment for small couriers, this hull modification from Schafer &amp; Kane Industries provides an impressive amount of cargo space without compromising the hull's integrity.</description>
   <gfx_store>cargo_hull_s.webp</gfx_store>

--- a/dat/outfits/core_hull/small/unicorp_d2_light_plating.xml
+++ b/dat/outfits/core_hull/small/unicorp_d2_light_plating.xml
@@ -4,7 +4,6 @@
   <typename>Core Systems (Hull)</typename>
   <slot prop_extra="hull_secondary" prop="hull">structure</slot>
   <size>small</size>
-  <mass>24</mass>
   <price>14500</price>
   <description>Commonly found on civilian vessels, the D-2 plating is popular with ship manufacturers due to its low cost and adequate, if uninspiring performance.</description>
   <gfx_store>base_hull_t.webp</gfx_store>

--- a/dat/outfits/core_system/large/milspec_orion_8601_core_system.xml
+++ b/dat/outfits/core_system/large/milspec_orion_8601_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 540, 760},
    { "cpu_max", 540, 1660},
    { "energy", 2460, 1380},

--- a/dat/outfits/core_system/large/milspec_thalos_8502_core_system.xml
+++ b/dat/outfits/core_system/large/milspec_thalos_8502_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 500, 700},
    { "cpu_max", 680, 2120},
    { "energy", 2300, 1060},

--- a/dat/outfits/core_system/large/previous_generation_large_systems.xml
+++ b/dat/outfits/core_system/large/previous_generation_large_systems.xml
@@ -4,13 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop_extra="systems_secondary" prop="systems">utility</slot>
   <size>large</size>
-  <mass>640</mass>
   <price>0</price>
   <description>A jury-rigged mess of processors and generators that most captains wouldn't be seen dead having installed on their ship.</description>
   <gfx_store>misc02.webp</gfx_store>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 640, 640},
    { "cpu_max", 380, 0},
    { "energy", 1760, 0},

--- a/dat/outfits/core_system/large/unicorp_pt440_core_system.xml
+++ b/dat/outfits/core_system/large/unicorp_pt440_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 420, 580},
    { "cpu_max", 440, 1310},
    { "energy", 1860, 940},

--- a/dat/outfits/core_system/medium/milspec_orion_4801_core_system.xml
+++ b/dat/outfits/core_system/medium/milspec_orion_4801_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 90, 180},
    { "cpu_max", 260, 100},
    { "energy", 750, 850},

--- a/dat/outfits/core_system/medium/milspec_thalos_4702_core_system.xml
+++ b/dat/outfits/core_system/medium/milspec_thalos_4702_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 80, 170},
    { "cpu_max", 300, 120},
    { "energy", 675, 725},

--- a/dat/outfits/core_system/medium/previous_generation_medium_systems.xml
+++ b/dat/outfits/core_system/medium/previous_generation_medium_systems.xml
@@ -4,13 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop_extra="systems_secondary" prop="systems">utility</slot>
   <size>medium</size>
-  <mass>100</mass>
   <price>0</price>
   <description>A jury-rigged mess of processors and generators that most captains wouldn't be seen dead having installed on their ship.</description>
   <gfx_store>reactor01.webp</gfx_store>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 100, 100},
    { "cpu_max", 180, 0},
    { "energy", 580, 0},

--- a/dat/outfits/core_system/medium/unicorp_pt200_core_system.xml
+++ b/dat/outfits/core_system/medium/unicorp_pt200_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 70, 140},
    { "cpu_max", 200, 110},
    { "energy", 525, 575},

--- a/dat/outfits/core_system/small/milspec_orion_2301_core_system.xml
+++ b/dat/outfits/core_system/small/milspec_orion_2301_core_system.xml
@@ -10,8 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <energy>200</energy>
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 14, 61},
    { "cpu_max", 18, 52},
    { "energy", 200, 200},

--- a/dat/outfits/core_system/small/milspec_thalos_2202_core_system.xml
+++ b/dat/outfits/core_system/small/milspec_thalos_2202_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 12, 58},
    { "cpu_max", 24, 66},
    { "energy", 150, 200},

--- a/dat/outfits/core_system/small/previous_generation_small_systems.xml
+++ b/dat/outfits/core_system/small/previous_generation_small_systems.xml
@@ -4,13 +4,13 @@
   <typename>Core Systems (System)</typename>
   <slot prop_extra="systems_secondary" prop="systems">utility</slot>
   <size>small</size>
-  <mass>18</mass>
   <price>0</price>
   <description>A jury-rigged mess of processors and generators that most captains wouldn't be seen dead having installed on their ship.</description>
   <gfx_store>apu.webp</gfx_store>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 18, 18},
    { "cpu_max", 10, 0},
    { "energy", 100, 0},

--- a/dat/outfits/core_system/small/unicorp_pt16_core_system.xml
+++ b/dat/outfits/core_system/small/unicorp_pt16_core_system.xml
@@ -10,7 +10,8 @@
   <priority>3</priority>
  </general>
  <specific type="modification">
-  <lua_inline>require("outfits.lib.multicore").init{
+  <lua_inline>
+require("outfits.lib.multicore").init{
    { "mass", 8, 57},
    { "cpu_max", 16, 52},
    { "energy", 150, 75},

--- a/dat/outfits/unique/homebrew_processing_unit.xml
+++ b/dat/outfits/unique/homebrew_processing_unit.xml
@@ -1,11 +1,9 @@
 <outfit name="Homebrew Processing Unit">
  <general>
-  <rarity>6</rarity>
   <unique />
   <typename>Core Systems (System)</typename>
-  <slot prop="systems" prop_extra="systems_secondary">utility</slot>
+  <slot prop_extra="systems_secondary" prop="systems">utility</slot>
   <size>small</size>
-  <mass>10</mass>
   <price>50000</price>
   <description>This core system is easily recognizable as the work of some amateurs, with sloppy wiring and dangerously exposed internals. However, unlike mass manufactured cores, you can tell that a lot of love and care has gone into developing the unit. While the shield and computation power are less than most similar cores, it has significantly better developed functionality in other areas.</description>
   <gfx_store>core_system_power_s1.webp</gfx_store>
@@ -26,7 +24,6 @@ require("outfits.lib.multicore").init{
    { "land_delay", -25, 0},
    { "jump_delay", -25, 0},
    { "ew_hide", -20, 0},
-}
-  </lua_inline>
+}</lua_inline>
  </specific>
 </outfit>

--- a/utils/outfits/mvx2xmllua.py
+++ b/utils/outfits/mvx2xmllua.py
@@ -58,19 +58,17 @@ def process_group(r,field):
 
          if t == 'price':
             e.text=fmt(round((a+b)/2,-2))
-         elif a==b:
-            e.text=fmt(a)
-            acc.append((t,(a,a)))
+         elif t=='priority' and a==b:
+            continue
          else:
-            needs_lua=True
+            if a==b:
+               e.text=fmt(a)
+            else:
+               needs_lua=True
             acc.append((t,(a,b)))
-            torem.append(e)
+            torem.append((r,e))
 
-   for e in torem:
-      r.remove(e)
-
-   return needs_lua,acc
-
+   return needs_lua,acc,torem
 
 def mklua(L):
    output='\n'
@@ -102,10 +100,13 @@ def main():
 
    nam=nam2fil(R.attrib['name'])
 
-   f1,acc1=process_group(R,'./general')
-   f2,acc2=process_group(R,'./specific')
+   f1,acc1,tr1=process_group(R,'./general')
+   f2,acc2,tr2=process_group(R,'./specific')
 
    if f1 or f2:
+      for (r,e) in tr1+tr2:
+         r.remove(e)
+
       acc=acc1+acc2
 
       for e in R.findall('./specific'):


### PR DESCRIPTION

**Bug Fix**

This PR addresses the bug described in #2766.
The xml/lua redundancy is fixed by removing redundant modifiers from xml.
Notice, however, that `priority` stays in xml. 
(that's a choice: we specifically asked for that in the script, as we did for price.)
