### PR TITLE
Gauntlet Intrinsics (again)

### DIFF
--- a/dat/events/dvaered/totoran.lua
+++ b/dat/events/dvaered/totoran.lua
@@ -204,7 +204,8 @@ function approach_guide ()
       if t.type == "var" then
          tradein_item.description = t.description
       elseif t.type == "intrinsic" then
-         tradein_item.description = t.outfit:summary().."\n"..t.outfit:description()
+         --tradein_item.description = t.outfit:summary().."\n"..t.outfit:description()
+         tradein_item.description = t.outfit:summary()
       else
          error(_("unknown tradein type"))
       end

--- a/dat/events/dvaered/totoran.lua
+++ b/dat/events/dvaered/totoran.lua
@@ -204,7 +204,6 @@ function approach_guide ()
       if t.type == "var" then
          tradein_item.description = t.description
       elseif t.type == "intrinsic" then
-         --tradein_item.description = t.outfit:summary().."\n"..t.outfit:description()
          tradein_item.description = t.outfit:summary()
       else
          error(_("unknown tradein type"))
@@ -238,15 +237,15 @@ Is there anything else you would like to purchase?"]]), {
 
    vn.label("trade_confirm")
    guide( function ()
-      local out="Are you sure you want to trade in for the '#w{name}#0'?"
+      local out=fmt.f(_("Are you sure you want to trade in for the '#w{name}#0'?"),tradein_item)
       for k,v in ipairs(trades) do
          if v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ) then
-            out=out.."\n"..fmt.f("This will remove #w{other}#0.",{other=v.outfit:name()})
+            out=out.."\n\n"..fmt.f(_([[This will #rremove#0:"
+#w{desc}#0"]]),{desc=v.outfit:summary()}).."\n"
          end
       end
-      return fmt.f(_(out.."\n"..[[The description is as follows:
-"#w{description}#0"]]),
-         tradein_item)
+      return out.."\n"..fmt.f(_([[You will #rget#0:"
+#w{description}#0"]]),tradein_item)
    end )
    vn.menu{
       {_("Trade"), "trade_consumate"},

--- a/dat/events/dvaered/totoran.lua
+++ b/dat/events/dvaered/totoran.lua
@@ -262,7 +262,7 @@ Is there anything else you would like to purchase?"]]), {
       elseif t.type == "intrinsic" then
          for k,v in ipairs(trades) do
             if v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ) then
-               player.pilot():outfitRmIntrinsic( v )
+               player.pilot():outfitRmIntrinsic( v.outfit )
             end
          end
          player.pilot():outfitAddIntrinsic( t.outfit )

--- a/dat/events/dvaered/totoran.lua
+++ b/dat/events/dvaered/totoran.lua
@@ -215,17 +215,11 @@ function approach_guide ()
    vn.menu( function ()
       local opts = {}
       for k,v in ipairs(trades) do
-         local toadd = true
-         if v.test and not v.test() then
-            toadd = false
-         end
-         if v.type=="var" and var.peek(v.var) then
-            toadd = false
-         end
-         if v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ) then
-            toadd = false
-         end
-         if toadd then
+         if not(
+            (v.test and not v.test()) 
+            or (v.type=="var" and var.peek(v.var))
+            or (v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ))
+         ) then
             table.insert( opts, {string.format(_("%s (%s)"), v.name, gauntlet.emblems_str(v.cost)), k} )
          end
       end
@@ -243,10 +237,16 @@ Is there anything else you would like to purchase?"]]), {
    vn.jump("trade_menu_raw")
 
    vn.label("trade_confirm")
-   guide( function () return fmt.f(
-      _([["Are you sure you want to trade in for the '#w{name}#0'? The description is as follows:"
-#w{description}#0"]]),
-      tradein_item)
+   guide( function ()
+      local out="Are you sure you want to trade in for the '#w{name}#0'?"
+      for k,v in ipairs(trades) do
+         if v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ) then
+            out=out.."\n"..fmt.f("This will remove #w{other}#0.",{other=v.outfit:name()})
+         end
+      end
+      return fmt.f(_(out.."\n"..[[The description is as follows:
+"#w{description}#0"]]),
+         tradein_item)
    end )
    vn.menu{
       {_("Trade"), "trade_consumate"},

--- a/dat/events/dvaered/totoran.lua
+++ b/dat/events/dvaered/totoran.lua
@@ -216,11 +216,11 @@ function approach_guide ()
       local opts = {}
       for k,v in ipairs(trades) do
          if not(
-            (v.test and not v.test()) 
+            (v.test and not v.test())
             or (v.type=="var" and var.peek(v.var))
-            or (v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ))
+            or (v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit))
          ) then
-            table.insert( opts, {string.format(_("%s (%s)"), v.name, gauntlet.emblems_str(v.cost)), k} )
+            table.insert( opts, {string.format(_("%s (%s)"), v.name, gauntlet.emblems_str(v.cost)), k})
          end
       end
       table.insert( opts, {_("Back"), "menu_main"} )
@@ -260,6 +260,11 @@ Is there anything else you would like to purchase?"]]), {
       if t.type == "var" then
          var.push( t.var, true )
       elseif t.type == "intrinsic" then
+         for k,v in ipairs(trades) do
+            if v.type=="intrinsic" and hasIntrinsic( player.pilot(), v.outfit ) then
+               player.pilot():outfitRmIntrinsic( v )
+            end
+         end
          player.pilot():outfitAddIntrinsic( t.outfit )
       else
          error(_("unknown tradein type"))

--- a/dat/events/updater.lua
+++ b/dat/events/updater.lua
@@ -13,6 +13,7 @@ local tut = require 'common.tutorial'
 local vn  = require 'vn'
 local fmt = require 'format'
 local luatk = require "luatk"
+local gauntlet = require 'common.gauntlet'
 
 -- Runs on saves older than 0.13.0
 local function updater0130( _did0120, _did0110, _did0100, _did090 )
@@ -21,9 +22,35 @@ local function updater0130( _did0120, _did0110, _did0100, _did090 )
       diff.apply( "melendez_dome_xy37" )
    end
 
+   local function update_gauntlet(plt)
+      local GauntletIntrinsics={outfit.get("Gauntlet Deluxe"),outfit.get("Gauntlet Supreme")}
+      local count=0
+      for _i,o in pairs(GauntletIntrinsics) do
+         for _k,v in ipairs( plt:outfitsList("intrinsic") ) do
+            if v==o then
+               count=count+1
+               break
+            end
+         end
+      end
+      if count>1 then
+         for _i,o in ipairs(GauntletIntrinsics) do
+            if not plt:outfitRmIntrinsic( o ) then
+               print(fmt.f("\t{ship} '{shipname}': {name} refunded for 2500 Crimson Emblems.",{
+                  ship=plt:ship():name(),
+                  shipname=plt:name(),
+                  name=o:name(),
+               }))
+               gauntlet.emblems_pay(2500)
+            end
+         end
+      end
+   end
+
    local cores_cache = naev.cache().save_updater
    if cores_cache.split_cores then
       local function update_ship( plt )
+         update_gauntlet( plt )
          for oname,i in pairs(cores_cache.split_list) do
             local o = outfit.get(oname)
             local _oname, _osize, oslot = o:slot()

--- a/dat/outfits/intrinsic/gauntlet_deluxe.xml
+++ b/dat/outfits/intrinsic/gauntlet_deluxe.xml
@@ -9,7 +9,7 @@
   <rarity>6</rarity>
  </general>
  <specific type="modification">
-  <fwd_damage>5</fwd_damage>
-  <tur_damage>5</tur_damage>
+  <fwd_damage>7</fwd_damage>
+  <tur_damage>3</tur_damage>
  </specific>
 </outfit>

--- a/dat/outfits/intrinsic/gauntlet_supreme.lua
+++ b/dat/outfits/intrinsic/gauntlet_supreme.lua
@@ -12,9 +12,9 @@ function init( p, po )
       end
    end
 
-   -- Doubles effect
+   -- effect goes from 3 to 7
    if hasunguided then
-      po:set( "launch_damage", 5 )
+      po:set( "launch_damage", 4 )
    else
       po:clear()
    end

--- a/dat/outfits/intrinsic/gauntlet_supreme.xml
+++ b/dat/outfits/intrinsic/gauntlet_supreme.xml
@@ -5,12 +5,12 @@
   <mass>0</mass>
   <price>1000000</price>
   <description>This service focuses on refining and polishing the launcher systems to maximize the missile fire power of the ship. It is a comprehensive and in-depth optimization that has to be done on a per-ship basis, with specialized technicians tuning everything for maximum efficiency. Due to the nature of the service, only one can be applied to each ship.</description>
-  <desc_extra>#oDoubles effect when using unguided launchers.#0</desc_extra>
+  <desc_extra>#oAdditional +4% damage (for a total of 7%) when using unguided launchers.#0</desc_extra>
   <gfx_store>/gfx/misc/crimson_gauntlet.webp</gfx_store>
   <rarity>6</rarity>
  </general>
  <specific type="modification">
   <lua>outfits/intrinsic/gauntlet_supreme.lua</lua>
-  <launch_damage>5</launch_damage>
+  <launch_damage>3</launch_damage>
  </specific>
 </outfit>


### PR DESCRIPTION
**Balance**

This PR addresses the feature described in #2799.

## Notes

This PR is a rebased version of #2804.

Before the bugfix commit, replacing an intrinsic caused a **CRASH**. That is why I left these as two different commits, to allow testing this.

Is the Lua API documentation on `outfitRmIntrinsic` correct ? It says it returns true iff successful.
My lua code works since I have been assuming the opposite, so either my code works by accident, or the documentation is wrong.

## Summary
- [x] Change values
- [x] The extra desc of Gauntlet Supreme is displayed twice in the dialog.
- [x] Warn user about losing one of them if choosing the other.
- [x] Remove the other when getting Gauntlet Supreme or Gauntlet Deluxe.
- [x] Also display the removed intrinsic properties.
- [x] Manage savegames updating.

## Testing
It works.