### PR TITLE
bugfix - duplicate luadoc entries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: luafunc_dup
       name: duplicate @luafunc entry detector
       entry: utils/luafunc_dup.sh
-      files: '^src/nlua_'
+      files: '^src/nlua_*.c'
       types: [c]
       language: script
     - id: nluacheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,12 @@ repos:
         - tomli
 - repo: local
   hooks:
+    - id: luafunc_dup
+      name: duplicate @luafunc entry detector
+      entry: utils/luafunc_dup.sh
+      files: '^src/nlua_'
+      types: [c]
+      language: script
     - id: nluacheck
       name: wrapper for luacheck that understands Naev hooks
       entry: utils/nluacheck.py

--- a/src/nlua_asteroid.c
+++ b/src/nlua_asteroid.c
@@ -432,7 +432,7 @@ static int asteroidL_state( lua_State *L )
  *    @luatparam Asteroid a Asteroid to set state of.
  *    @luatparam string s State to set. Has to be one of "FG", "XB", "BX",
  * "XX_TO_BG", "FG_TO_BG", "BG_TO_FG", "BG_TO_XX", or "XX".
- * @luafunc state
+ * @luafunc setState
  */
 static int asteroidL_setState( lua_State *L )
 {
@@ -597,7 +597,7 @@ static int asteroidL_armour( lua_State *L )
  *    @luatparam Asteroid a Asteroid to set armour of.
  *    @luatparam number Amount to set the armour to (negative values will
  * explode it).
- * @luafunc setTimer
+ * @luafunc setArmour
  */
 static int asteroidL_setArmour( lua_State *L )
 {

--- a/src/nlua_faction.c
+++ b/src/nlua_faction.c
@@ -480,7 +480,7 @@ static int factionL_hit( lua_State *L )
  * "distress" sources. For missions the default is "script".
  *    @luatreturn How much the reputation was actually changed after Lua script
  * was run.
- * @luafunc hit
+ * @luafunc hitTest
  */
 static int factionL_hitTest( lua_State *L )
 {

--- a/src/nlua_jump.c
+++ b/src/nlua_jump.c
@@ -437,7 +437,7 @@ static int jumpL_dest( lua_State *L )
  *    @luatparam Jump j Jump to get the jump distance of.
  *    @luatparam Pilot p Pilot to get information for.
  *    @luatreturn number The distance from the jump at which the pilot can jump.
- * @luafunc dest
+ * @luafunc jumpDist
  */
 static int jumpL_jumpDist( lua_State *L )
 {

--- a/src/nlua_naev.c
+++ b/src/nlua_naev.c
@@ -885,7 +885,7 @@ static int naevL_menuSmall( lua_State *L )
  * @brief Checks to see if the game is paused.
  *
  *    @luatreturn boolean Whether or not the game is currently paused.
- * @luafunc pause
+ * @luafunc isPaused
  */
 static int naevL_isPaused( lua_State *L )
 {

--- a/src/nlua_outfit.c
+++ b/src/nlua_outfit.c
@@ -254,7 +254,7 @@ static int outfitL_get( lua_State *L )
  *
  *    @luatparam string s Raw (untranslated) name of the outfit to get.
  *    @luatreturn Outfit|nil The outfit matching name or nil if not found
- * @luafunc get
+ * @luafunc exists
  */
 static int outfitL_exists( lua_State *L )
 {
@@ -454,7 +454,7 @@ static int outfitL_slot( lua_State *L )
  *    @luatparam Outfit o Outfit to get information of.
  *    @luatreturn string|nil Human readable property (in English) or nil if
  * none.
- * @luafunc slot
+ * @luafunc slotExtra
  */
 static int outfitL_slotExtra( lua_State *L )
 {

--- a/src/nlua_pilot.c
+++ b/src/nlua_pilot.c
@@ -2149,7 +2149,7 @@ static int pilotL_weapsetAdd( lua_State *L )
  *    @luatparam integer id ID of the weapon set as shown in game (from 0 to 9).
  *    @luatparam string|integer slot Slot to add to weapon set. Can be passed by
  * either id or name.
- * @luafunc weapsetAdd
+ * @luafunc weapsetAddType
  */
 static int pilotL_weapsetAddType( lua_State *L )
 {
@@ -3355,7 +3355,7 @@ static int pilotL_setInvisible( lua_State *L )
  *
  *    @luatparam Pilot p Pilot to set norender status of.
  *    @luatparam boolean state State to set norender.
- * @luafunc setInvisible
+ * @luafunc setNoRender
  */
 static int pilotL_setNoRender( lua_State *L )
 {
@@ -3419,7 +3419,7 @@ static int pilotL_setHilight( lua_State *L )
  *
  *    @luatparam Pilot p Pilot to set bribed status of.
  *    @luatparam[opt=true] boolean state State to set bribed.
- * @luafunc setHilight
+ * @luafunc setBribed
  */
 static int pilotL_setBribed( lua_State *L )
 {
@@ -4533,7 +4533,7 @@ static int pilotL_setHealth( lua_State *L )
  * absolute value
  *    @luatparam[opt=current stress] number stress Value to set stress (disable
  * damage) to, in absolute value.
- * @luafunc setHealth
+ * @luafunc setHealthAbs
  */
 static int pilotL_setHealthAbs( lua_State *L )
 {
@@ -5262,7 +5262,7 @@ static int pilotL_getColour( lua_State *L )
  *    @luatparam Pilot p Pilot to get the colour of.
  *    @luatreturn string Character representing the pilot's colour for use with
  * specila printing characters.
- * @luafunc colour
+ * @luafunc colourChar
  */
 static int pilotL_colourChar( lua_State *L )
 {

--- a/src/nlua_player.c
+++ b/src/nlua_player.c
@@ -1113,7 +1113,7 @@ static int playerL_takeoff( lua_State *L )
  *    @luatparam boolean noisy Whether or not to do player messages.
  *    @luatreturn string Status of the boarding attempt. Can be "impossible",
  * "retry", "ok", or "error".
- * @luafunc tryBoard
+ * @luafunc tryLand
  */
 static int playerL_tryLand( lua_State *L )
 {
@@ -2333,7 +2333,7 @@ static int playerL_inventoryAdd( lua_State *L )
  *    @luatparam string name The name of the item to remove.
  *    @luatparam integer quantity The amount of the item to remove.
  *    @luatreturn integer The amount of the item removed.
- * @luafunc inventoryAdd
+ * @luafunc inventoryRm
  */
 static int playerL_inventoryRm( lua_State *L )
 {
@@ -2351,7 +2351,7 @@ static int playerL_inventoryRm( lua_State *L )
  *
  *    @luatparam string name The name of the item to check.
  *    @luatreturn integer The amount of the item the player has (0 if none).
- * @luafunc inventoryAdd
+ * @luafunc inventoryOwned
  */
 static int playerL_inventoryOwned( lua_State *L )
 {

--- a/src/nlua_shader.c
+++ b/src/nlua_shader.c
@@ -321,7 +321,7 @@ static int shaderL_send( lua_State *L )
  *
  *    @luatparam Shader shader Shader to send uniform to.
  *    @luatparam string name Name of the uniform.
- * @luafunc send
+ * @luafunc sendRaw
  */
 static int shaderL_sendRaw( lua_State *L )
 {

--- a/src/nlua_spfx.c
+++ b/src/nlua_spfx.c
@@ -529,7 +529,7 @@ static int spfxL_setVel( lua_State *L )
  *
  *    @luatparam spfx s Spfx to get sound effect of.
  *    @luatreturn audio Sound effect of the spfx.
- * @luafunc vel
+ * @luafunc sfx
  */
 static int spfxL_sfx( lua_State *L )
 {

--- a/src/nlua_spob.c
+++ b/src/nlua_spob.c
@@ -720,7 +720,7 @@ static int spobL_services( lua_State *L )
  * @usage if p:flags()["nomissionspawn"] then -- Spob doesn't spawn missions
  *    @luatparam Spob p Spob to get the services of.
  *    @luatreturn table Table containing all the services.
- * @luafunc services
+ * @luafunc flags
  */
 static int spobL_flags( lua_State *L )
 {

--- a/src/nlua_system.c
+++ b/src/nlua_system.c
@@ -929,7 +929,7 @@ static int systemL_hidden( lua_State *L )
  *
  *    @luatparam System s System to check if the player knows.
  *    @luatparam boolean hide Whether or not to hide the system.
- * @luafunc hidden
+ * @luafunc setHidden
  */
 static int systemL_setHidden( lua_State *L )
 {

--- a/src/nlua_transform.c
+++ b/src/nlua_transform.c
@@ -316,7 +316,7 @@ static int transformL_rotate2d( lua_State *L )
  *    @luatparam number nearVal value.
  *    @luatparam number farVal value.
  *    @luatreturn Transform A new transformation.
- * @luafunc translate
+ * @luafunc ortho
  */
 static int transformL_ortho( lua_State *L )
 {

--- a/utils/luafunc_dup.sh
+++ b/utils/luafunc_dup.sh
@@ -5,7 +5,7 @@ res=0
 trap 'rm -f $LST ; exit $res' EXIT
 
 for arg in $@ ; do
-   grep '^ \* @luafunc' $arg | sort | uniq -c | grep -v "^ *1" > $LST
+   grep '^ \* @luafunc' $arg | sort | uniq -c | grep -v "^ *1 " > $LST
 
    if [ -s "$LST" ] ; then
       echo "$arg:"

--- a/utils/luafunc_dup.sh
+++ b/utils/luafunc_dup.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/bash
 
-LST=`tempfile`
+LST=$(mktemp)
 res=0
 trap 'rm -f $LST ; exit $res' EXIT
 
-for arg in $@ ; do
-   grep '^ \* @luafunc' $arg | sort | uniq -c | grep -v "^ *1 " > $LST
+for arg in "$@" ; do
+   grep '^ \* @luafunc' "$arg" | sort | uniq -c | grep -v "^ *1 " > "$LST"
 
    if [ -s "$LST" ] ; then
       echo "$arg:"
-      cat $LST
+      cat "$LST"
       res=1
    fi
 done

--- a/utils/luafunc_dup.sh
+++ b/utils/luafunc_dup.sh
@@ -2,13 +2,17 @@
 
 TMP=`tempfile`
 LST=`tempfile`
-trap 'rm -f $TMP $LST' EXIT
+res=0
+trap 'rm -f $TMP $LST ; exit $res' EXIT
 
-grep '^ \* @luafunc' $1 | sort > $TMP
-sort -u $TMP | diff $TMP - | sort -u - | grep '<' | cut '-d<' -f2- > $LST
+for arg in $@ ; do
+   grep '^ \* @luafunc' $arg | sort > $TMP
+   sort -u $TMP | diff $TMP - | sort -u - | grep '<' | cut '-d<' -f2- > $LST
 
-if [ -s "$LST" ] ; then
-   echo "$1:"
-   cat $LST
-   exit 1
-fi
+   if [ -s "$LST" ] ; then
+      echo "$arg:"
+      cat $LST
+      res=1
+   fi
+done
+

--- a/utils/luafunc_dup.sh
+++ b/utils/luafunc_dup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+TMP=`tempfile`
+LST=`tempfile`
+trap 'rm -f $TMP $LST' EXIT
+
+grep '^ \* @luafunc' $1 | sort > $TMP
+sort -u $TMP | diff $TMP - | sort -u - | grep '<' | cut '-d<' -f2- > $LST
+
+if [ -s "$LST" ] ; then
+   echo "Duplicates in $1:"
+   cat $LST
+   exit 1
+fi

--- a/utils/luafunc_dup.sh
+++ b/utils/luafunc_dup.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/bash
 
-TMP=`tempfile`
 LST=`tempfile`
 res=0
-trap 'rm -f $TMP $LST ; exit $res' EXIT
+trap 'rm -f $LST ; exit $res' EXIT
 
 for arg in $@ ; do
-   grep '^ \* @luafunc' $arg | sort > $TMP
-   sort -u $TMP | diff $TMP - | sort -u - | grep '<' | cut '-d<' -f2- > $LST
+   grep '^ \* @luafunc' $arg | sort | uniq -c | grep -v "^ *1" > $LST
 
    if [ -s "$LST" ] ; then
       echo "$arg:"

--- a/utils/luafunc_dup.sh
+++ b/utils/luafunc_dup.sh
@@ -8,7 +8,7 @@ grep '^ \* @luafunc' $1 | sort > $TMP
 sort -u $TMP | diff $TMP - | sort -u - | grep '<' | cut '-d<' -f2- > $LST
 
 if [ -s "$LST" ] ; then
-   echo "Duplicates in $1:"
+   echo "$1:"
    cat $LST
    exit 1
 fi


### PR DESCRIPTION
**Bug Fix** / **New Feature**

This PR addresses the bug/feature described in #2829.

Baware that sorting takes time, even sorting the list of `@luafunc` occurences. Might take up to a second on your machine, or maybe even more.

## Summary
 - [x] luafunc_dup.sh
 - [x] nlua_pilot.c
 - [x] other nlua_*.c files
 - [x] add it to precommit
 - [x] handle multiple files
 - [x] simplify and improve the script with uniq

```shell
src/nlua_asteroid.c:
      2  * @luafunc setTimer
      2  * @luafunc state
src/nlua_faction.c:
      2  * @luafunc hit
src/nlua_jump.c:
      2  * @luafunc dest
src/nlua_naev.c:
      2  * @luafunc pause
src/nlua_outfit.c:
      2  * @luafunc get
      2  * @luafunc slot
src/nlua_pilot.c:
      2  * @luafunc colour
      2  * @luafunc setHealth
      2  * @luafunc setHilight
      2  * @luafunc setInvisible
      2  * @luafunc weapsetAdd
src/nlua_player.c:
      3  * @luafunc inventoryAdd
      2  * @luafunc tryBoard
src/nlua_shader.c:
      2  * @luafunc send
src/nlua_spfx.c:
      2  * @luafunc vel
src/nlua_spob.c:
      2  * @luafunc services
src/nlua_system.c:
      2  * @luafunc hidden
src/nlua_transform.c:
      2  * @luafunc translate
```
