### PR TITLE
sort c2luadoc output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,12 @@ repos:
       types: [png]
 - repo: local
   hooks:
+    - id: check_luadoc_func
+      name: check @lua.. not used outside @luafunc
+      entry: utils/check_luadoc_func.sh
+      files: '^src/nlua_*.c'
+      types: [c]
+      language: script
     - id: luafunc_dup
       name: duplicate @luafunc entry detector
       entry: utils/luafunc_dup.sh

--- a/docs/lua/c2luadoc.sh
+++ b/docs/lua/c2luadoc.sh
@@ -61,4 +61,9 @@ sed -n                                                                         \
    }
    /@/ {
       print $0, "\n"
-   }' > "$2"
+   }' |                                                                        \
+# Sort it
+sed ':a;N;$!ba;s/\n--/\\n--/g' | grep -v "^$" |                                \
+sed 's/^\(.*\)\(@function .*\)$/z\2\1\2/' | sort --stable -d |                 \
+sed 's/\\n--/\n--/g' | sed 's/^z@function .*$//'                               \
+> "$2"

--- a/docs/lua/c2luadoc.sh
+++ b/docs/lua/c2luadoc.sh
@@ -61,10 +61,4 @@ sed -n                                                                        \
    }
    /@/ {
       print $0, "\n"
-   }' |                                                                       \
-# Sort it
-sed ':a;N;$!ba;s/\n--/\\n--/g' | grep -v "^$" |                               \
-sed 's/^\(.*\)\(@function .*\)$/z\2\1\2/' |                                   \
-sed '/\(@module\)\|\(@function\)/! s/^\(.*\)$/zzz\1/' | sort --stable -d |    \
-sed 's/\\n--/\n--/g' | sed 's/^z@function .*$//' | sed 's/^zzz$//g'           \
-> "$2"
+   }' > "$2"

--- a/docs/lua/c2luadoc.sh
+++ b/docs/lua/c2luadoc.sh
@@ -3,57 +3,57 @@
 # Convert Doxygen comments to Luadoc comments
 # CAUTION: We need to support BSD/macOS sed in addition to GNU sed.
 #          If you aren't suffering, you've probably introduced a bug. :P
-sed -n                                                                         \
+sed -n                                                                        \
  -e '1i\
--- This file was generated automatically from C sources to feed LDoc.'         \
-`# Convert Doxygen /** to Luadoc ---`                                          \
- -e 's|^ */\*\* *$|---|p'                                                      \
-`# Convert special tags to Lua expressions.`                                   \
-`# Lines after @luafunc & @luamod will be ignored by Luadoc`                   \
-`# Doxygen comments that do not contain any of these tags have no impact on`   \
-`# the Luadoc output.`                                                         \
-`# Rename some tags:`                                                          \
- -e 's|^ *\* *@luafunc|-- @function|p'                                         \
- -e 's|^ *\* *@brief|--|p'                                                     \
- -e 's|^ *\* *@luasee|-- @see|p'                                               \
- -e 's|^ *\* *@luaparam|-- @param|p'                                           \
- -e 's|^ *\* *@luatparam|-- @tparam|p'                                         \
- -e 's|^ *\* *@luareturn|-- @return|p' `#we accept both @luareturn & @return`  \
- -e 's|^ *\* *@luatreturn|-- @treturn|p'                                       \
- -e 's|^ *\* *@luamod|-- @module|p'                                            \
- -e 's|^ *\* *@luatype|-- @type|p'                                             \
- -e 's|^ *\* *@luaset|-- @set|p'                                               \
-`# Keep tags Luadoc understands:`                                              \
-`#   s|^ *\* *@param|-- @param|p # use luaparam; param is for C arguments`     \
-`#   s|^ *\* *@see|-- @see|p # use luasee`                                     \
-`#   s|^ *\* *@return|-- @return|p # use luareturn`                            \
- -e 's|^ *\* *@usage|-- @usage|p'                                              \
- -e 's|^ *\* *@description|-- @description|p'                                  \
- -e 's|^ *\* *@name|-- @name|p'                                                \
- -e 's|^ *\* *@class|-- @class|p'                                              \
- -e 's|^ *\* *@field|-- @field|p'                                              \
- -e 's|^ *\* *@release|-- @release|p'                                          \
-`# HACK: ldoc supports annotations: fixme, todo, warning.`                     \
-`# They eat your message. Let's do our own thing here.`                        \
- -e 's|^ *\* *@fixme|-- <em>FIXME</em>|p'                                      \
- -e 's|^ *\* *@todo|-- <em>TODO</em>|p'                                        \
- -e 's|^ *\* *@TODO|-- <em>TODO</em>|p'                                        \
- -e 's|^ *\* *@warning|-- <em>Warning</em>|p'                                  \
- -e 's|^ *\* *@note|-- <em>Note</em>|p'                                        \
-`# Custom tags:`                                                               \
- -e 's|^ *\* *@code|-- <pre>|p'                                                \
- -e 's|^ *\* *@endcode|-- </pre>|p'                                            \
-`# Remove other tags:`                                                         \
- -e '\|^ *\* *@.*|d'                                                           \
-`# Insert newline between comments, replace */ with \n:`                       \
+-- This file was generated automatically from C sources to feed LDoc.'        \
+`# Convert Doxygen /** to Luadoc ---`                                         \
+ -e 's|^ */\*\* *$|---|p'                                                     \
+`# Convert special tags to Lua expressions.`                                  \
+`# Lines after @luafunc & @luamod will be ignored by Luadoc`                  \
+`# Doxygen comments that do not contain any of these tags have no impact on`  \
+`# the Luadoc output.`                                                        \
+`# Rename some tags:`                                                         \
+ -e 's|^ *\* *@luafunc|-- @function|p'                                        \
+ -e 's|^ *\* *@brief|--|p'                                                    \
+ -e 's|^ *\* *@luasee|-- @see|p'                                              \
+ -e 's|^ *\* *@luaparam|-- @param|p'                                          \
+ -e 's|^ *\* *@luatparam|-- @tparam|p'                                        \
+ -e 's|^ *\* *@luareturn|-- @return|p' `#we accept both @luareturn & @return` \
+ -e 's|^ *\* *@luatreturn|-- @treturn|p'                                      \
+ -e 's|^ *\* *@luamod|-- @module|p'                                           \
+ -e 's|^ *\* *@luatype|-- @type|p'                                            \
+ -e 's|^ *\* *@luaset|-- @set|p'                                              \
+`# Keep tags Luadoc understands:`                                             \
+`#   s|^ *\* *@param|-- @param|p # use luaparam; param is for C arguments`    \
+`#   s|^ *\* *@see|-- @see|p # use luasee`                                    \
+`#   s|^ *\* *@return|-- @return|p # use luareturn`                           \
+ -e 's|^ *\* *@usage|-- @usage|p'                                             \
+ -e 's|^ *\* *@description|-- @description|p'                                 \
+ -e 's|^ *\* *@name|-- @name|p'                                               \
+ -e 's|^ *\* *@class|-- @class|p'                                             \
+ -e 's|^ *\* *@field|-- @field|p'                                             \
+ -e 's|^ *\* *@release|-- @release|p'                                         \
+`# HACK: ldoc supports annotations: fixme, todo, warning.`                    \
+`# They eat your message. Let's do our own thing here.`                       \
+ -e 's|^ *\* *@fixme|-- <em>FIXME</em>|p'                                     \
+ -e 's|^ *\* *@todo|-- <em>TODO</em>|p'                                       \
+ -e 's|^ *\* *@TODO|-- <em>TODO</em>|p'                                       \
+ -e 's|^ *\* *@warning|-- <em>Warning</em>|p'                                 \
+ -e 's|^ *\* *@note|-- <em>Note</em>|p'                                       \
+`# Custom tags:`                                                              \
+ -e 's|^ *\* *@code|-- <pre>|p'                                               \
+ -e 's|^ *\* *@endcode|-- </pre>|p'                                           \
+`# Remove other tags:`                                                        \
+ -e '\|^ *\* *@.*|d'                                                          \
+`# Insert newline between comments, replace */ with \n:`                      \
  -e '\|^ *\*/|c\
-'                                                                              \
-`# Keep other comments, replace * with --`                                     \
- -e 's|^ *\*|--|p'                                                             \
-`# Keep blank lines`                                                           \
- -e 's|^\s*$||p'                                                               \
-`# Delete everything else, just in case:`                                      \
- -e 'd'                                                                        \
+'                                                                             \
+`# Keep other comments, replace * with --`                                    \
+ -e 's|^ *\*|--|p'                                                            \
+`# Keep blank lines`                                                          \
+ -e 's|^\s*$||p'                                                              \
+`# Delete everything else, just in case:`                                     \
+ -e 'd'                                                                       \
    "$1" | awk '
 # Skips all comment blocks without an @ tag
    BEGIN {
@@ -61,9 +61,10 @@ sed -n                                                                         \
    }
    /@/ {
       print $0, "\n"
-   }' |                                                                        \
+   }' |                                                                       \
 # Sort it
-sed ':a;N;$!ba;s/\n--/\\n--/g' | grep -v "^$" |                                \
-sed 's/^\(.*\)\(@function .*\)$/z\2\1\2/' | sort --stable -d |                 \
-sed 's/\\n--/\n--/g' | sed 's/^z@function .*$//'                               \
+sed ':a;N;$!ba;s/\n--/\\n--/g' | grep -v "^$" |                               \
+sed 's/^\(.*\)\(@function .*\)$/z\2\1\2/' |                                   \
+sed '/\(@module\)\|\(@function\)/! s/^\(.*\)$/zzz\1/' | sort --stable -d |    \
+sed 's/\\n--/\n--/g' | sed 's/^z@function .*$//' | sed 's/^zzz$//g'           \
 > "$2"

--- a/docs/lua/config.ld
+++ b/docs/lua/config.ld
@@ -1,4 +1,5 @@
 not_luadoc = true
+sort = true
 title = "Naev Lua API"
 project = "Naev Lua API"
 description = "Naev Lua API"

--- a/src/nlua_colour.c
+++ b/src/nlua_colour.c
@@ -455,6 +455,7 @@ static int colL_setalpha( lua_State *L )
  *
  *    @luatparam Colour col Colour to change from linear to gamma.
  *    @luatreturn Colour Modified colour.
+ * @luafunc linearToGamma
  */
 static int colL_linearToGamma( lua_State *L )
 {
@@ -473,6 +474,7 @@ static int colL_linearToGamma( lua_State *L )
  *
  *    @luatparam Colour col Colour to change from gamma corrected to linear.
  *    @luatreturn Colour Modified colour.
+ * @luafunc gammaToLinear
  */
 static int colL_gammaToLinear( lua_State *L )
 {

--- a/src/nlua_spfx.c
+++ b/src/nlua_spfx.c
@@ -656,7 +656,7 @@ void spfxL_exit( void )
 /**
  * @brief Updates the spfx.
  *
- *    @luatparam dt Delta tick to use for the update.
+ *    @param dt Delta tick to use for the update.
  */
 void spfxL_update( double dt )
 {

--- a/utils/check_luadoc_funcs.sh
+++ b/utils/check_luadoc_funcs.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/bash
 
-TMP=$(mktemp)
+TMP=$(mktemp -u)
+mkfifo "$TMP"
 TMP2=$(mktemp)
+
 res=0
 trap 'rm -f "$TMP" "$TMP2" ; exit $res' EXIT
 
 for arg in "$@" ; do
-   docs/lua/c2luadoc.sh "$arg" "$TMP"
+   docs/lua/c2luadoc.sh "$arg" "$TMP" &
    sed ':a;N;$!ba;s/\n--/\\n--/g' < "$TMP" | grep -v '\(^$\)\|\(@module\)\|\(@function\)' > "$TMP2"
    if [ -s "$TMP2" ] ; then
       echo "$arg:"

--- a/utils/check_luadoc_funcs.sh
+++ b/utils/check_luadoc_funcs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+TMP=$(mktemp)
+TMP2=$(mktemp)
+res=0
+trap 'rm -f "$TMP" "$TMP2" ; exit $res' EXIT
+
+for arg in "$@" ; do
+   docs/lua/c2luadoc.sh "$arg" "$TMP"
+   sed ':a;N;$!ba;s/\n--/\\n--/g' < "$TMP" | grep -v '\(^$\)\|\(@module\)\|\(@function\)' > "$TMP2"
+   if [ -s "$TMP2" ] ; then
+      echo "$arg:"
+      cat "$TMP2"
+      res=1
+   fi
+done
+


### PR DESCRIPTION
**New Feature**

## Why

The lua API doc is somewhat hard to navigate, as functions appear in no particular order.
Each time I look for a function, I have to scan the whole list. Sometimes, subsequences are sorted, giving the false impression that the function I am looking for is not in the list.

The alphabetical order is not perfect, but at least will regroup (or keep them grouped) related functions as they tend to share common prefixes.

A possible improvement of that would maybe be to first have `name()` funcs then `nameVerb()` funcs, as `name()` are most often read-accessors and would maybe be better presented first.

## Initial Summary (outdated)
<details><summary>details</summary>
Lexicographical sort of `c2luadoc.sh` output.

This output is consisting of blocks defined by their ending `@keyword`.

The blocks with `@function` are sorted by dictionary order (`sort -d`) of the function name and put after any other block. The other blocks keep their position (`sort --stable`).

Currently, as far as I could see, there is only one other block type that is module, and it keeps its leading position.
</details>

## True Summary
See discussions below.

## Testing Done (Updated!)
Tested on `*.c`.

Could not check whether adding `sort = true` to `docs/lua/config.ld` was the correct way to have luadoc sort it. You will have to check that !

## TODO
- [x] Make it work
- [x] Wait to see if optimization patch works.