### PR TITLE
Colored CLI/term output

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -121,12 +121,12 @@ static char *fontcol_toTermEscapeString(const char*s){
    char*buf;
    int i, wi=0, count=0;
 
-   for(i=0; s[i++]; i++)
+   for(i=0; s[i]; i++)
       if(s[i] == FONT_COLOUR_CODE)
          count++;
 
    buf=calloc(i+count*7+1,sizeof(char));
-   for(i=0; i<len; i++){
+   for(i=0; s[i]; i++){
       if(s[i] == FONT_COLOUR_CODE){
          const char*es=seq[(s[i+1]>='0' && s[i+1]<='z')? _CID(s[i+1]):0];
 
@@ -195,7 +195,7 @@ static int cli_printCore( lua_State *L, int cli_only, int escape )
    const char *s = lua_tostring( L, -1 );
 
    if ( !cli_only ){
-      char*tolog=fontcol_toTermEscapeString(s)
+      char*tolog=fontcol_toTermEscapeString(s);
       LOG( "%s", s );
       free(tolog);
    }

--- a/src/console.c
+++ b/src/console.c
@@ -196,7 +196,7 @@ static int cli_printCore( lua_State *L, int cli_only, int escape )
 
    if ( !cli_only ){
       char*tolog=fontcol_toTermEscapeString(s);
-      LOG( "%s", s );
+      LOG( "%s", tolog );
       free(tolog);
    }
    cli_printCoreString( s, escape );

--- a/src/console.c
+++ b/src/console.c
@@ -125,7 +125,7 @@ static char *fontcol_toTermEscapeString(const char*s){
       if(s[i] == FONT_COLOUR_CODE)
          count++;
 
-   buf=calloc(i+count*7+1,sizeof(char));
+   buf=calloc(i+count*7+4+1,sizeof(char));
    for(i=0; s[i]; i++){
       if(s[i] == FONT_COLOUR_CODE){
          const char*es=seq[(s[i+1]>='0' && s[i+1]<='z')? _CID(s[i+1]):0];
@@ -138,6 +138,9 @@ static char *fontcol_toTermEscapeString(const char*s){
       }
       buf[wi++]=s[i];
    }
+   if(wi<i)
+      sprintf(buf+wi,"%s",seq[_CID('0')]);
+
    return buf;
 }
 #undef _CID

--- a/src/console.c
+++ b/src/console.c
@@ -119,6 +119,7 @@ static char *fontcol_toTermEscapeString(const char*s){
       [_CID('y')] = "\e[1;33m"  // yellow
    };
    char*buf;
+   const char*es=seq[_CID('0')];
    int i, wi=0, count=0;
 
    for(i=0; s[i]; i++)
@@ -126,19 +127,17 @@ static char *fontcol_toTermEscapeString(const char*s){
          count++;
 
    buf=calloc(i+count*7+4+1,sizeof(char));
-   for(i=0; s[i]; i++){
-      if(s[i] == FONT_COLOUR_CODE){
-         const char*es=seq[(s[i+1]>='0' && s[i+1]<='z')? _CID(s[i+1]):0];
 
-         if(es){
-            wi+=sprintf(buf+wi,"%s",es);
-            i++;
-            continue;
-         }
-      }
-      buf[wi++]=s[i];
-   }
-   if(wi<i)
+   for(i=0; s[i]; i++)
+      if(s[i] == FONT_COLOUR_CODE &&
+         ((es=seq[(s[i+1]>='0' && s[i+1]<='z')? _CID(s[i+1]):0]))
+      ){
+         wi+=sprintf(buf+wi,"%s",es);
+         i++;
+      }else
+         buf[wi++]=s[i];
+
+   if(es!=seq[_CID('0')])
       sprintf(buf+wi,"%s",seq[_CID('0')]);
 
    return buf;

--- a/src/console.c
+++ b/src/console.c
@@ -105,6 +105,43 @@ static char *cli_escapeString( int *len_out, const char *s, int len )
    return buf;
 }
 
+#define _CID(c)   (((int)c)-(int)'0'+1)
+static char *fontcol_toTermEscapeString(const char*s){
+   static const char*const seq[_CID('z')+1] = {
+      [_CID('0')] = "\e[0m",    // default
+      [_CID('b')] = "\e[0;34m", // blue
+      [_CID('g')] = "\e[0;32m", // green
+      [_CID('n')] = "\e[1;30m", // grey
+      [_CID('o')] = "\e[0;33m", // orange -> brown
+      [_CID('p')] = "\e[0;35m", // purple or pink? -> magenta
+      [_CID('r')] = "\e[0;31m", // red
+      [_CID('w')] = "\e[0;37m", // white
+      [_CID('y')] = "\e[1;33m"  // yellow
+   };
+   char*buf;
+   int i, wi=0, count=0;
+
+   for(i=0; s[i++]; i++)
+      if(s[i] == FONT_COLOUR_CODE)
+         count++;
+
+   buf=calloc(i+count*7+1,sizeof(char));
+   for(i=0; i<len; i++){
+      if(s[i] == FONT_COLOUR_CODE){
+         const char*es=seq[(s[i+1]>='0' && s[i+1]<='z')? _CID(s[i+1]):0];
+
+         if(es){
+            wi+=sprintf(buf+wi,"%s",es);
+            i++;
+            continue;
+         }
+      }
+      buf[wi++]=s[i];
+   }
+   return buf;
+}
+#undef _CID
+
 /**
  * @brief Prints a string.
  */
@@ -156,8 +193,12 @@ static int cli_printCore( lua_State *L, int cli_only, int escape )
    }
 
    const char *s = lua_tostring( L, -1 );
-   if ( !cli_only )
+
+   if ( !cli_only ){
+      char*tolog=fontcol_toTermEscapeString(s)
       LOG( "%s", s );
+      free(tolog);
+   }
    cli_printCoreString( s, escape );
 
    lua_pop( L, 2 ); /* */
@@ -181,7 +222,7 @@ int cli_warn( lua_State *L )
  */
 int cli_print( lua_State *L )
 {
-   return cli_printCore( L, 0, 1 );
+   return cli_printCore( L, 0, 0 );
 }
 
 /**
@@ -191,7 +232,7 @@ int cli_print( lua_State *L )
  */
 int cli_printRaw( lua_State *L )
 {
-   return cli_printCore( L, 1, 0 );
+   return cli_printCore( L, 0, 0 );
 }
 
 /**

--- a/src/log.c
+++ b/src/log.c
@@ -53,23 +53,45 @@ static void log_cleanStream( PHYSFS_File **file, const char *fname,
                              const char *filedouble );
 static void log_purge( void );
 
+
+static char*_noesc(const char*s,int*ne){
+   char*buf=calloc(strlen(s)+1,sizeof(char));
+   int wi=0,inesc=0;
+   for(int i=0;s[i];i++)
+      if(inesc){
+         if ((s[i]>='a' && s[i]<='z') || (s[i]>='A' && s[i]<='Z'))
+            inesc=0;
+      }else if(s[i]=='\e'){
+         inesc=1;
+      }else
+         buf[wi++]=s[i];
+
+   buf[wi]= '\0';
+   *ne=wi;
+   return buf;
+}
+
+static char
 /**
  * @brief va_list version of logprintf and backend.
  */
 static int slogprintf( FILE *stream, int newline, const char *str, size_t n )
 {
+   int ne;
+   char*strne=_noesc(str,&ne);
+
    /* Append to strfer. */
    if ( copying )
       log_append( stream, str );
 
    if ( stream == stdout && logout_file != NULL ) {
-      PHYSFS_writeBytes( logout_file, str, newline ? n + 1 : n );
+      PHYSFS_writeBytes( logout_file, strne, newline ? ne + 1 : ne );
       if ( newline )
          PHYSFS_flush( logout_file );
    }
 
    if ( stream == stderr && logerr_file != NULL ) {
-      PHYSFS_writeBytes( logerr_file, str, newline ? n + 1 : n );
+      PHYSFS_writeBytes( logerr_file, strne, newline ? ne + 1 : ne );
       if ( newline )
          PHYSFS_flush( logerr_file );
    }
@@ -78,6 +100,7 @@ static int slogprintf( FILE *stream, int newline, const char *str, size_t n )
    n = fprintf( stream, "%s", str );
    if ( newline )
       fflush( stream );
+   free(strne);
    return n;
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -71,7 +71,6 @@ static char*_noesc(const char*s,int*ne){
    return buf;
 }
 
-static char
 /**
  * @brief va_list version of logprintf and backend.
  */


### PR DESCRIPTION
**New Feature**

This PR addresses the feature described in #2833.

## Summary
1. Restored CLI color output.
2. Translated this `#.`-colored output into ANSI escape sequences in order to pass it to LOG.
3. LOG now outputs its input string to stdout/stderr as usual but removes ansi esc. seq. when it comes to writing to a file.

## Testing Done
Tested the introduced funcs separately, but **did not test into the project**.

