### PR TITLE
two little bugfixes

### DIFF
--- a/dat/outfits/lib/multicore.lua
+++ b/dat/outfits/lib/multicore.lua
@@ -172,7 +172,7 @@ function multicore.init( params )
 
       for k,s in ipairs(stats) do
          local off = multicore_off and (nosec or nomain) and s.name ~= "mass"
-         desc = desc .. "\n" .. add_desc(s, nomain or off, nosec or off, averaged and is_mobility[s.name])
+         desc = desc .. "\n" .. add_desc(s, nomain or off, nosec or off, averaged and is_mobility[s.name] and s.name ~= "engine_limit")
       end
 
       if multicore_off ~= nil then

--- a/src/economy.c
+++ b/src/economy.c
@@ -175,7 +175,7 @@ int economy_getAverageSpobPrice( const Commodity *com, const Spob *p,
    CommodityPrice *commPrice;
 
    double      price_mod = 1.;
-   double     *prices;
+   double     *prices = NULL;
    Commodity **tech = tech_getCommodity( p->tech, &prices );
    for ( int j = 0; j < array_size( tech ); j++ ) {
       if ( tech[j] == com ) {

--- a/src/tech.c
+++ b/src/tech.c
@@ -970,6 +970,7 @@ Commodity **tech_getCommodity( const tech_group_t *tech, double **price )
    if ( tech == NULL )
       return NULL;
 
+   *tech = NULL;
    double *pricelist = ( price == NULL ) ? NULL : array_create( double );
 
    /* Get the commodities. */

--- a/src/tech.c
+++ b/src/tech.c
@@ -967,10 +967,11 @@ Ship **tech_getShipArray( tech_group_t **tech, int num )
  */
 Commodity **tech_getCommodity( const tech_group_t *tech, double **price )
 {
+   if( price!= NULL )
+      *price = NULL;
    if ( tech == NULL )
       return NULL;
 
-   *tech = NULL;
    double *pricelist = ( price == NULL ) ? NULL : array_create( double );
 
    /* Get the commodities. */


### PR DESCRIPTION
**Bug Fixes**

This PR addresses some bugs described respectively in #2766 and #2850.

## Summary
 - [x] Fix the eml-in-blue bug, should be green, (giving the false impression eml was _affected by_ the load factor)
 - Fix the commodity crash
    - [x] `economy_getAverageSpobPrice` was not cautious enough.
    - [x] `tech_getCommodity` behavior was misleading: it did not initialize the ptr when failing.

## Testing Done
Only the first.
