### PR TITLE
fix(input): default to Meta+V paste keybind on macOS

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -364,7 +364,12 @@ void input_setDefault( int wasd )
    input_setKeybind( KST_MENU_SMALL, KEYBIND_KEYBOARD, SDLK_ESCAPE, NMOD_ANY );
    input_setKeybind( KST_MENU_INFO, KEYBIND_KEYBOARD, SDLK_i, NMOD_NONE );
    input_setKeybind( KST_CONSOLE, KEYBIND_KEYBOARD, SDLK_F2, NMOD_ANY );
+
+   #if __MACOSX__
+   input_setKeybind( KST_PASTE, KEYBIND_KEYBOARD, SDLK_v, NMOD_META );
+   #else
    input_setKeybind( KST_PASTE, KEYBIND_KEYBOARD, SDLK_v, NMOD_CTRL );
+   #endif
 }
 
 /**


### PR DESCRIPTION
**Bug Fix**

## Summary

Changes the default paste keybind on macOS to `Meta+V` instead of `Ctrl+V`, since that is [the standard keybind](https://support.apple.com/en-us/102553) to use on macOS.

## Testing Done

Compiles, unsure if it works since I haven't been able to get the compiled binary to run.
