### PR TITLE
med core inconsistencies + bugfix

### DIFF
--- a/dat/outfits/core_system/medium/previous_generation_medium_systems.xml
+++ b/dat/outfits/core_system/medium/previous_generation_medium_systems.xml
@@ -14,7 +14,7 @@ require("outfits.lib.multicore").init{
    { "mass", 100, 200},
    { "cpu_max", 180, 90},
    { "energy", 480, 510},
-   { "energy_regen", 23, 12},
+   { "energy_regen", 17, 12},
    { "shield", 310, 100},
    { "shield_regen", 6, 0},
 }</lua_inline>

--- a/dat/outfits/core_system/medium/unicorp_pt200_core_system.xml
+++ b/dat/outfits/core_system/medium/unicorp_pt200_core_system.xml
@@ -15,7 +15,7 @@ require("outfits.lib.multicore").init{
    { "mass", 70, 140},
    { "cpu_max", 200, 110},
    { "energy", 525, 575},
-   { "energy_regen", 17, 19},
+   { "energy_regen", 23, 19},
    { "shield", 330, 70},
    { "shield_regen", 7, 1},
    { "ew_detect", 10, 0},

--- a/utils/outfits/outfits2md.py
+++ b/utils/outfits/outfits2md.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
    parser.add_argument('-c', '--color', action = 'store_true', help = 'colored terminal output. You can pipe to "less -RS" if it is too wide.')
    parser.add_argument('-t', '--term', action = 'store_true', help = 'colored terminal output (TODO: with extended table characters).')
    parser.add_argument('-n', '--nomax', action = 'store_true', help = 'Do not emphasize min/max values.' )
-   parser.add_argument('-s', '--sort', action = 'store_true', help = 'inputs are sorted by their SORT key.')
+   parser.add_argument('-s', '--sort', help = 'inputs are sorted by their SORT key.')
    parser.add_argument('-S', '--sortbymass', action = 'store_true', help = 'Like -s mass.' )
    parser.add_argument('-A', '--autostack', action = 'store_true', help = 'Outfits are presented both alone and auto-stacked.')
    parser.add_argument('-C', '--combinations', action = 'store_true', help = 'Does all the combinations.' )


### PR DESCRIPTION

**Bug Fix**

## Summary
 - [x] inconsistencies in med. core systems energy regen. See diff for the actual change. See below for core systems overview.
 - [x] -s management in outfits2md.

<details><summary>Before:</summary>

|      | Prev. Gen. Small Systems | U. PT-16 System | M. Orion 2301 System | Prev. Gen. Medium Systems | U. PT-200 System | M. Orion 4801 System | Prev. Gen. Large Systems | U. PT-440 System | M. Orion 8601 System |
| ---- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| price | **0** | 17500 | 105000 | **0** | 50000 | 300000 | **0** | 325000 | _2000000_ |
| priority |    _ |    3 |    3 |    _ |    3 |    3 |    _ |    3 |    3 |
| mass | 18/45 | **8/42** | 14/46 | 100/200 | 70/140 | 90/180 | _640/800_ | 420/580 | 540/760 |
| cpu max | _10/20_ | 16/52 | 18/52 | 180/90 | 200/110 | 260/100 | 380/1100 | 440/1310 | **540/1660** |
| energy | _100/50_ | 150/75 |  200 | 480/510 | 525/575 | 750/850 | 1760/800 | 1860/940 | **2460/1380** |
| energy regen | _5/1_ |  7/3 |    9 | 23/12 | 17/19 | 33/20 | 35/40 | 46/51 | **66/74** |
| shield | _110/20_ | 150/30 | 200/50 | 310/100 | 330/70 | 450/130 | 500/150 | 650/100 | **850/250** |
| shield regen | _4/0_ | 4.5/1 |  7/1 |  6/0 |  7/1 | 10/2 |  9/1 | 11/2 | **15/3** |
| ew detect |    _ | 10/0 |    _ |    _ | 10/0 |    _ |    _ | 10/0 |    _ |
| cooldown time |    _ | -25/0 |    _ |    _ | -25/0 |    _ |    _ | -25/0 |    _ |
</details>

<details><summary>After:</summary>

|      | Prev. Gen. Small Systems | U. PT-16 System | M. Orion 2301 System | Prev. Gen. Medium Systems | U. PT-200 System | M. Orion 4801 System | Prev. Gen. Large Systems | U. PT-440 System | M. Orion 8601 System |
| ---- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| price | **0** | 17500 | 105000 | **0** | 50000 | 300000 | **0** | 325000 | _2000000_ |
| priority |    _ |    3 |    3 |    _ |    3 |    3 |    _ |    3 |    3 |
| mass | 18/45 | **8/42** | 14/46 | 100/200 | 70/140 | 90/180 | _640/800_ | 420/580 | 540/760 |
| cpu max | _10/20_ | 16/52 | 18/52 | 180/90 | 200/110 | 260/100 | 380/1100 | 440/1310 | **540/1660** |
| energy | _100/50_ | 150/75 |  200 | 480/510 | 525/575 | 750/850 | 1760/800 | 1860/940 | **2460/1380** |
| energy regen | _5/1_ |  7/3 |    9 | 17/12 | 23/19 | 33/20 | 35/40 | 46/51 | **66/74** |
| shield | _110/20_ | 150/30 | 200/50 | 310/100 | 330/70 | 450/130 | 500/150 | 650/100 | **850/250** |
| shield regen | _4/0_ | 4.5/1 |  7/1 |  6/0 |  7/1 | 10/2 |  9/1 | 11/2 | **15/3** |
| ew detect |    _ | 10/0 |    _ |    _ | 10/0 |    _ |    _ | 10/0 |    _ |
| cooldown time |    _ | -25/0 |    _ |    _ | -25/0 |    _ |    _ | -25/0 |    _ |
</details>

## Testing Done
`outfits2md -s` now works, see above.