### PR TITLE
add the viewport frame in the radar and overlay.

### DIFF
--- a/dat/glsl/viewport_frame.frag
+++ b/dat/glsl/viewport_frame.frag
@@ -1,0 +1,12 @@
+#include "lib/sdf.glsl"
+
+uniform vec4 colour;
+
+in vec2 pos;
+out vec4 colour_out;
+
+void main(void) {
+   colour_out   = colour;
+   colour_out.a *= smoothstep(0.5, 0.8, abs(pos.x));
+   colour_out.a *= smoothstep(-1.0, 0.0, -abs(pos.y));
+}

--- a/src/colours_c_gen.py
+++ b/src/colours_c_gen.py
@@ -104,6 +104,7 @@ COLOURS = [
     Colour( "Radar_weap",       0.8, 0.2, 0.2 ),
     Colour( "Radar_hilight",    0.6, 1.0, 1.0 ),
     Colour( "Radar_scanning",   1.0, 1.0, 0.6 ),
+    Colour( "Radar_viewport",   1.0, 1.0, 1.0, 0.5 ),
     # Health
     Colour( "Shield",       0.2, 0.2, 0.8 ),
     Colour( "Armour",       0.5, 0.5, 0.5 ),

--- a/src/conf.c
+++ b/src/conf.c
@@ -129,6 +129,7 @@ void conf_setDefaults( void )
    conf.map_overlay_opacity = MAP_OVERLAY_OPACITY_DEFAULT;
    conf.big_icons           = BIG_ICONS_DEFAULT;
    conf.always_radar        = 0;
+   conf.show_viewport       = 0;
 
    /* Repeat. */
    conf.repeat_delay = 500;
@@ -408,6 +409,7 @@ int conf_loadConfig( const char *file )
       conf.map_overlay_opacity = CLAMP( 0, 1, conf.map_overlay_opacity );
       conf_loadBool( lEnv, "big_icons", conf.big_icons );
       conf_loadBool( lEnv, "always_radar", conf.always_radar );
+      conf_loadBool( lEnv, "show_viewport", conf.show_viewport );
 
       /* Key repeat. */
       conf_loadInt( lEnv, "repeat_delay", conf.repeat_delay );
@@ -1092,6 +1094,8 @@ int conf_saveConfig( const char *file )
    conf_saveComment( _(
       "Always show the radar and don't hide it when the overlay is active." ) );
    conf_saveBool( "always_radar", conf.always_radar );
+   conf_saveComment( _( "Show the viewport in the radar/overlay." ) );
+   conf_saveBool( "show_viewport", conf.show_viewport );
    conf_saveEmptyLine();
 
    /* Key repeat. */

--- a/src/conf.h
+++ b/src/conf.h
@@ -162,6 +162,7 @@ typedef struct PlayerConf_s {
    double map_overlay_opacity; /**< Map overlay opacity. */
    int    big_icons;           /**< Use big icons or not. */
    int    always_radar;        /**< Radar is always visible. */
+   int    show_viewport;       /**< Show viewport in the radar/overlay map. */
 
    /* Keyrepeat. */
    unsigned int repeat_delay; /**< Time in ms before start repeating. */

--- a/src/gui.h
+++ b/src/gui.h
@@ -77,6 +77,7 @@ void gui_renderPilot( const Pilot *p, RadarShape shape, double w, double h,
                       double res, int overlay );
 void gui_renderAsteroid( const Asteroid *a, double w, double h, double res,
                          double render_radius, int overlay );
+void gui_renderViewportFrame( double res, double render_radius, int overlay );
 void gui_renderPlayer( double res, int overlay );
 
 /*

--- a/src/map_overlay.c
+++ b/src/map_overlay.c
@@ -980,6 +980,9 @@ void ovr_render( double dt )
       glDisableVertexAttribArray( shaders.stealthoverlay.vertex );
    }
 
+   /* Render the viewport frame */
+   gui_renderViewportFrame( res, INFINITY, 1 );
+
    /* Render markers foreground. */
    ovr_mrkRenderAll( res, 1 );
 

--- a/src/options.c
+++ b/src/options.c
@@ -108,6 +108,7 @@ static void opt_setScalefactor( unsigned int wid, const char *str );
 static void opt_setZoomFar( unsigned int wid, const char *str );
 static void opt_setZoomNear( unsigned int wid, const char *str );
 static void opt_checkHealth( unsigned int wid, const char *str );
+static void opt_checkViewport( unsigned int wid, const char *str );
 static void opt_checkRestart( unsigned int wid, const char *str );
 /* Audio. */
 static void opt_audio( unsigned int wid );
@@ -1476,6 +1477,10 @@ static void opt_video( unsigned int wid )
    window_addFader( wid, x + 20, y, cw - 60, 20, "fadMapOverlayOpacity", 0., 1.,
                     conf.map_overlay_opacity, opt_setMapOverlayOpacity );
    opt_setMapOverlayOpacity( wid, "fadMapOverlayOpacity" );
+   y -= 25;
+   window_addCheckbox( wid, x, y, cw, 20, "chkViewport",
+                       _( "Show viewport in radar/overlay" ), opt_checkViewport,
+                       conf.show_viewport );
    y -= 40;
 
    /* GUI */
@@ -1620,6 +1625,15 @@ static void opt_checkHealth( unsigned int wid, const char *str )
 {
    int f           = window_checkboxState( wid, str );
    conf.healthbars = f;
+}
+
+/**
+ * @brief Handles the viewport checkbox.
+ */
+static void opt_checkViewport( unsigned int wid, const char *str )
+{
+   int f              = window_checkboxState( wid, str );
+   conf.show_viewport = f;
 }
 
 /**

--- a/src/shaders_c_gen.py
+++ b/src/shaders_c_gen.py
@@ -410,6 +410,10 @@ SHADERS = [
       name = "shop_bg",
       fs_path = "shop_bg.frag",
    ),
+   SimpleShader(
+      name = "viewport_frame",
+      fs_path = "viewport_frame.frag",
+   ),
 ]
 SHADERS.sort()
 


### PR DESCRIPTION
**New Feature**

## Summary
This PR introduces the frame of the viewport in the overlay map and the radar. It reduces the confusion of the ship positions in the overlay map with the center of the viewport, hopefully.

![2025-06-12-20:27:19 FTM](https://github.com/user-attachments/assets/23f32df9-3c00-4514-81a6-66fecb697a3e)

## Testing Done
- scale factor: 1.0, 1.5 and 2.0
- overlay and radar in silm and legacy.