### PR TITLE
Mission improvement - update moving cargo objective location in 'Dvaered Negotiation 1'

### DIFF
--- a/dat/missions/dvaered/recruitment/dv_goddard.lua
+++ b/dat/missions/dvaered/recruitment/dv_goddard.lua
@@ -392,12 +392,25 @@ function spreadCommando()
    local vel = mem.koala:vel()
    local poC = mem.koala:pos() - vel/vel:mod() * 10
    mem.mrk = system.markerAdd( poC, _("Commandos") )
-   system.addGatherable( _cargo(), 1, poC, vel*0.5, 3600, true ) -- Spawn the commando (player-only gatherable) just behind the Koala
+   mem.commandosVelocity = vel*0.5
+   mem.commandosInitialPosition = poC
+   mem.commandosTimer = 0
+   system.addGatherable( _cargo(), 1, mem.commandosInitialPosition, mem.commandosVelocity, 3600, true ) -- Spawn the commando (player-only gatherable) just behind the Koala
+   hook.timer( 3, "updateMarkerPosition" )
    audio.soundPlay( "target" )
    player.msg("#o".._("Spacewalking commandos in sight.").."#0")
    player.autonavReset(5)
    mem.koala:setHilight(false)
    mem.gathHook = hook.gather("gather")
+end
+
+function updateMarkerPosition()
+   if mem.misn_state < 3 then
+      system.markerRm( mem.mrk )
+      mem.commandosTimer = mem.commandosTimer + 3
+      mem.mrk = system.markerAdd( mem.commandosInitialPosition + mem.commandosVelocity * mem.commandosTimer, _("Commandos") )
+      hook.timer( 3, "updateMarkerPosition" )
+   end
 end
 
 -- Player gathers the commandos


### PR DESCRIPTION
**Bug Fix**

This PR addresses the bug/feature described in #2882

## Summary
In mission 'Dvaered Negotiation 1' the system map marker (point of interest) "Commandos" will now have it's location updated every 3 seconds to follow the actual location of the cargo.
I did not change behavior of the cargo or it's spawning parameters.
This is my crude attempt to remedy gatherable commandos fading away into space. (Bullet 2 in aforementioned #2882)

## Testing Done
I only playtested the relevant mission 'Dvaered Negotiation 1'.
Prior to the change the system map marker stayed at it's initial spawn point while the cargo run away. After the change the marker location got periodically updated and properly reflected actual location of the cargo.
I added troubleshooting log messages (absent in final commit) to make sure the new hook stops executing when the cargo is collected or when the mission is failed.