### PR TITLE
Fix dead code in ship enthusiast event allowing 50k reward.

### DIFF
--- a/dat/events/neutral/shiplover.lua
+++ b/dat/events/neutral/shiplover.lua
@@ -218,7 +218,7 @@ function create ()
    -- Increase the difficulty as progresses
    local difficulty = 1
    local cash_reward = 10e3
-   if nwon >= 5 then
+   if nwon >= 5 and nwon <= 10 then
       difficulty = 2
       cash_reward = 25e3
    elseif nwon > 10 then


### PR DESCRIPTION
**Bug Fix**

## Summary
On the first glance it appears that after achieving 10 wins against the Ship Enthusiast's quiz, the cash reward was intended to be increased to 50e3. The difficulty rating was also to be increased to 3 although that currently doesn't affect anything AFAICT.
In current implementation those values are unreachable because the condition to do that was true only when the previous condition was true as well, rendering the code dead.

## Testing Done
I have playtested the event with 50+ wins and got a 50k reward on success.
