### PR TITLE
Fixed mission 'Dvaered Sabotage'

### DIFF
--- a/dat/missions/dvaered/frontier_war/fw01_sabotage.lua
+++ b/dat/missions/dvaered/frontier_war/fw01_sabotage.lua
@@ -330,8 +330,8 @@ function spawn_phalanx()
    mem.pattacked = hook.pilot( p, "attacked", "phalanx_attacked" )
    mem.pboarded = hook.pilot( p, "board", "phalanx_boarded" )
    hook.pilot( p, "death", "phalanx_died" )
-   hook.pilot( p, "jump", "phalanx_safe" )
-   hook.pilot( p, "land", "phalanx_safe" )
+   mem.pjump = hook.pilot( p, "jump", "phalanx_safe" )
+   mem.pland = hook.pilot( p, "land", "phalanx_safe" )
 
    mem.stage = 4
    misn.osdActive(2)
@@ -353,6 +353,8 @@ end
 
 function phalanx_boarded()
    hook.rm(mem.pboarded)
+   hook.rm(mem.pjump)
+   hook.rm(mem.pland)
    tk.msg( _("Boarding"), fmt.f(_([[All the members of the commando unit have put on their battle suits. Hamfresser gives the final orders. "Nikolov, Tronk, and I will enter first and clear the area. Remember, we don't have our usual Dudley combat androids. We're stuck with the two useless plumber bots and the few security droids of {player}'s ship so we'll have to get our hands dirty. Corvettes are typically protected by a few 629 Spitfires and an occasional 711 Grillmeister. That's not very much, but still enough to send the inattentive soldier ad patres."
    When the corvette's airlock falls under Nikolov's circular saw, the captain waves and the small team enters the ship. You hear shots and explosions coming from further and further into the enemy ship. Finally, you hear a laconic message coming from the disabled corvette: "Strafer here, everything went well. We'll now transfer the cargo into the Phalanx... Now that the maneuver is finished, you may leave." Happy to have survived the operation so far, you start your engines and respond "Good luck, folks!" The lieutenant answers "Thanks, citizen, I'm glad to have met you."]]), {player=player.name()}) )
    mem.stage = 5


### PR DESCRIPTION
Now it won't fail if Gorgon phalanx escapes after being boarded.

**Bug Fix**

## Summary
Fixes erroneous mission behavior at the last stage of 'Dvaered Sabotage' where player is ordered to board a phalanx ship Gorgon.
If the ship lands or jumps out the mission fails as it should.
After Gorgon gets boarded a message is displayed saying the ship is intercepted by allied Lt. Strafer.
If the player lingers in the system long enough, the Gorgon ship will get back to operational and jump out to nearby Maus system. This used to render a message "Mission Failed: target escaped" and fail the mission. Not good.
Now if Gorgon jumps out after being boarded the mission continues normally.

## Testing Done
I have playtested the relevant section of 'Dvaered Sabotage'.
The mission fails if Gorgon lands back on Timu or jumps out to Maus prior to boarding.
The mission does not fail if Gorgon jumps out after being intercepted.