### PR TITLE
Fix some bugs for the viewport frame in the radar.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -417,6 +417,7 @@ int conf_loadConfig( const char *file )
    conf.map_overlay_opacity = CLAMP( 0, 1, conf.map_overlay_opacity );
    conf_loadBool( L, "big_icons", conf.big_icons );
    conf_loadBool( L, "always_radar", conf.always_radar );
+   conf_loadBool( L, "show_viewport", conf.show_viewport );
 
    /* Key repeat. */
    conf_loadInt( L, "repeat_delay", conf.repeat_delay );

--- a/src/gui.c
+++ b/src/gui.c
@@ -1204,8 +1204,7 @@ void gui_renderViewportFrame( double res, double render_radius, int overlay )
       return;
    }
 
-   const double z =
-      cam_getZoom() * res * ( overlay ? 1.0 : 1.0 / gl_screen.scale );
+   const double z           = cam_getZoom() * res;
    const double vp_corner_x = SCREEN_W / 2.0 / z;
    const double vp_corner_y = SCREEN_H / 2.0 / z;
    if ( isfinite( render_radius ) &&


### PR DESCRIPTION

**Bug Fix**
## Summary
- Revert loading the config.
- Remove the scale factor for the radar. I'm not sure but seems to work fine.

## Testing Done
- Reappearance the viewport frame in the radar.
- It's right the size of the viewport frame in the radar.