### PR TITLE
A new module for managing xml outfits in scripts

### DIFF
--- a/dat/outfits/py/corsair_engine.py
+++ b/dat/outfits/py/corsair_engine.py
@@ -24,4 +24,4 @@ specific['lua_inline'] = '\n'.join([
    'require("outfits.core_sets.corsair_engine").init()'
 ])
 
-h.write( data )
+data.save()

--- a/dat/outfits/py/corsair_engine.py
+++ b/dat/outfits/py/corsair_engine.py
@@ -11,18 +11,17 @@ del general['shortname']
 general['unique'] = None
 general['rarity'] = 6
 general['price'] = 1e6
-general['description'] = "TODO"
+general['description'] = 'TODO'
 del general['slot']['@prop_extra']
 
 specific = o['specific']
 ref = h.get_outfit_dict( h.INPUT, True )
 del ref['time_mod']
 ref['jump_distance'] = (25,)
-lua = f"""
-local set = require("outfits.lib.set")
-{h.to_multicore_lua( ref, True, "set.set" )}
-require("outfits.core_sets.corsair_engine").init()
-"""
-specific['lua_inline'] = lua
+specific['lua_inline'] = '\n'.join([
+   'local set = require("outfits.lib.set")',
+   h.to_multicore_lua( ref, True, 'set.set' ),
+   'require("outfits.core_sets.corsair_engine").init()'
+])
 
 h.write( data )

--- a/dat/outfits/py/corsair_hull.py
+++ b/dat/outfits/py/corsair_hull.py
@@ -11,18 +11,17 @@ del general['shortname']
 general['unique'] = None
 general['rarity'] = 6
 general['price'] = 1e6
-general['description'] = "TODO"
+general['description'] = 'TODO'
 del general['slot']['@prop_extra']
 
 specific = o['specific']
 ref = h.get_outfit_dict( h.INPUT, True )
 ref['absorb'] = (ref['absorb'][0]-5.0,)
 ref['ew_stealth_timer'] = (-10,)
-lua = f"""
-local set = require("outfits.lib.set")
-{h.to_multicore_lua( ref, True, "set.set" )}
-require("outfits.core_sets.corsair_hull").init()
-"""
-specific['lua_inline'] = lua
+specific['lua_inline'] = '\n'.join([
+   "local set = require('outfits.lib.set')",
+   h.to_multicore_lua( ref, True, 'set.set' ),
+   "require('outfits.core_sets.corsair_hull').init()"
+])
 
 h.write( data )

--- a/dat/outfits/py/corsair_hull.py
+++ b/dat/outfits/py/corsair_hull.py
@@ -24,4 +24,4 @@ specific['lua_inline'] = '\n'.join([
    "require('outfits.core_sets.corsair_hull').init()"
 ])
 
-h.write( data )
+data.save()

--- a/dat/outfits/py/corsair_systems.py
+++ b/dat/outfits/py/corsair_systems.py
@@ -24,4 +24,4 @@ specific['lua_inline'] = '\n'.join([
    "require('outfits.core_sets.corsair_systems').init()"
 ])
 
-h.write( data )
+data.save()

--- a/dat/outfits/py/corsair_systems.py
+++ b/dat/outfits/py/corsair_systems.py
@@ -11,18 +11,17 @@ del general['shortname']
 general['unique'] = None
 general['rarity'] = 6
 general['price'] = 1e6
-general['description'] = "TODO"
+general['description'] = 'TODO'
 del general['slot']['@prop_extra']
 
 specific = o['specific']
 ref = h.get_outfit_dict( h.INPUT, True )
 del ref['cooldown_time']
 ref['ew_detect'] = (ref['ew_detect'][0]+5.0,)
-lua = f"""
-local set = require("outfits.lib.set")
-{h.to_multicore_lua( ref, True, "set.set" )}
-require("outfits.core_sets.corsair_systems").init()
-"""
-specific['lua_inline'] = lua
+specific['lua_inline'] = '\n'.join([
+   "local set = require('outfits.lib.set')",
+   h.to_multicore_lua( ref, True, 'set.set' ),
+   "require('outfits.core_sets.corsair_systems').init()"
+])
 
 h.write( data )

--- a/dat/outfits/py/helper.py
+++ b/dat/outfits/py/helper.py
@@ -1,5 +1,5 @@
 import sys
-import xmltodict
+from xml_outfit import xml_outfit
 from os import path
 script_dir = path.join(path.dirname(__file__), '..', '..', '..', 'utils', 'outfits')
 sys.path.append(path.realpath(script_dir))
@@ -10,24 +10,21 @@ INPUT = sys.argv[1]
 OUTPUT = sys.argv[2]
 
 def read():
-    with open(INPUT,'r') as f:
-        return xmltodict.parse( f.read() )
+   o = xml_outfit(INPUT)
+   o.save_as(OUTPUT)
+   return o
 
 def write( data ):
-    with open(OUTPUT,'w') as f:
-        f.write( tostring(data) )
-
-def tostring( data ):
-    return xmltodict.unparse( data, pretty=True )
+   data.save()
 
 def mul_i( d, f, v ):
-    d[f] = str(round(float(d[f])*v))
+    d['$' + f] = round( d['$' + f] * v )
 
 def add_i( d, f, v ):
-    d[f] = str(int(d[f])+int(v))
+    d['$' + f] += v
 
 def mul_f( d, f, v ):
-    d[f] = str(float(d[f])*v)
+    d['$' + f] *= v
 
 def get_outfit_dict( name, core = False ):
    try:
@@ -39,8 +36,8 @@ def get_outfit_dict( name, core = False ):
       raise Exception('Could not read "' + path.basename(name) + '"')
    return o.to_dict()
 
-def to_multicore_lua( ref, pri_only = True, setfunc = "nil" ):
-    out = """local multicore = require("outfits.lib.multicore").init({"""
+def to_multicore_lua( ref, pri_only = True, setfunc = 'nil' ):
+    out = """local multicore = require('outfits.lib.multicore').init({"""
     # We operate under the assumption that dictionaries are ordered in python now
     specific = False
     for r in ref:

--- a/dat/outfits/py/helper.py
+++ b/dat/outfits/py/helper.py
@@ -14,18 +14,6 @@ def read():
    o.save_as(OUTPUT)
    return o
 
-def write( data ):
-   data.save()
-
-def mul_i( d, f, v ):
-    d['$' + f] = round( d['$' + f] * v )
-
-def add_i( d, f, v ):
-    d['$' + f] += v
-
-def mul_f( d, f, v ):
-    d['$' + f] *= v
-
 def get_outfit_dict( name, core = False ):
    try:
       if core:

--- a/dat/outfits/py/neutralizer.py
+++ b/dat/outfits/py/neutralizer.py
@@ -8,22 +8,22 @@ data['outfit']['@name'] = N_('Neutralizer')
 general = data['outfit']['general']
 general['rarity'] = 2
 general['description'] = N_("Based on the Heavy Ion Cannon, the Neutralizer is proof to the importance of specialized engineering. With most of the hardware and software significantly modified or replaced, the Neutralizer shows significant improvements in nearly all facets. Due to the fact that few were made, it is a fairly rare find, but an import asset in a pilot's arsenal.")
-h.add_i(general, 'price', 150e3 )
-h.add_i(general, 'mass', -2 )
-h.mul_i(general, 'cpu', 0.92 )
+general['$price'] += 150e3
+general['$mass'] += -2
+general['$cpu'] = round(general['$cpu'] * 0.92)
 
 specific = data['outfit']['specific']
-h.mul_f(specific, 'range', 1.1 )
-h.mul_f(specific, 'falloff', 1.2 )
-h.mul_f(specific, 'delay', 1.05 )
-h.mul_f(specific, 'energy', 1.05 )
-h.mul_f(specific, 'swivel', 1.5 )
-h.mul_i(specific, 'trackmax', 0.8333333333 )
+specific['$range'] *= 1.1
+specific['$falloff'] *= 1.2
+specific['$delay'] *= 1.05
+specific['$energy'] *= 1.05
+specific['$swivel'] *= 1.5
+specific['$trackmax'] = round(specific['$trackmax'] * 0.8333333333)
 specific['lua'] = 'outfits/lib/matrix_sell.lua'
 
 damage = specific['damage']
-h.mul_f(damage, 'disable', 1.2 )
-h.mul_f(damage, 'physical', 1.25 )
-h.mul_i(damage, 'penetrate', 1.15 )
+damage['$disable'] *= 1.2
+damage['$physical'] *= 1.25
+damage['$penetrate'] = round(damage['$penetrate'] * 1.15)
 
-h.write( data )
+data.save()

--- a/dat/outfits/py/neutralizer.py
+++ b/dat/outfits/py/neutralizer.py
@@ -6,7 +6,7 @@ data = h.read()
 data['outfit']['@name'] = N_('Neutralizer')
 
 general = data['outfit']['general']
-general['rarity'] = '2'
+general['rarity'] = 2
 general['description'] = N_("Based on the Heavy Ion Cannon, the Neutralizer is proof to the importance of specialized engineering. With most of the hardware and software significantly modified or replaced, the Neutralizer shows significant improvements in nearly all facets. Due to the fact that few were made, it is a fairly rare find, but an import asset in a pilot's arsenal.")
 h.add_i(general, 'price', 150e3 )
 h.add_i(general, 'mass', -2 )
@@ -19,7 +19,7 @@ h.mul_f(specific, 'delay', 1.05 )
 h.mul_f(specific, 'energy', 1.05 )
 h.mul_f(specific, 'swivel', 1.5 )
 h.mul_i(specific, 'trackmax', 0.8333333333 )
-specific['lua'] = "outfits/lib/matrix_sell.lua"
+specific['lua'] = 'outfits/lib/matrix_sell.lua'
 
 damage = specific['damage']
 h.mul_f(damage, 'disable', 1.2 )

--- a/dat/outfits/py/reaver.py
+++ b/dat/outfits/py/reaver.py
@@ -8,17 +8,17 @@ data['outfit']['@name'] = N_('Reaver Cannon')
 general = data['outfit']['general']
 general['rarity'] = '2'
 general['description'] = N_('The complex engineering specifications and difficulty of mass production doomed the Reaver Cannon from the start. However, in the right hands, given the extreme long range and high penetration for a weapon of its size, it can be very deadly.')
-h.add_i(general, 'price', 130e3 )
-h.add_i(general, 'mass', 2 )
-h.mul_i(general, 'cpu', 1.1 )
+general['$price'] += 130e3
+general['$mass'] += 2
+general['$cpu'] = round(general['$cpu'] * 1.1)
 
 specific = data['outfit']['specific']
-h.mul_f(specific, 'range', 1.5 )
-h.mul_f(specific, 'falloff', 1.2 )
-h.mul_f(specific, 'delay', 2 )
-h.mul_f(specific, 'energy', 2.0 )
-h.mul_f(specific, 'swivel', 1.5 )
-h.mul_i(specific, 'trackmax', 0.8333333333 )
+specific['$range'] *= 1.5
+specific['$falloff'] *= 1.2
+specific['$delay'] *= 2
+specific['$energy'] *= 2.0
+specific['$swivel'] *= 1.5
+specific['$trackmax'] = round(specific['$trackmax'] * 0.8333333333)
 specific['lua'] = 'outfits/lib/matrix_sell.lua'
 specific['gfx'] = {
     '@type' : 'shader',
@@ -28,7 +28,7 @@ specific['gfx'] = {
 }
 
 damage = specific['damage']
-h.mul_f(damage, 'physical', 2.0 )
-h.mul_i(damage, 'penetrate', 1.3 )
+damage['$physical'] *= 2
+damage['$penetrate'] = round(damage['$penetrate'] * 1.3)
 
-h.write( data )
+data.save()

--- a/dat/outfits/py/reaver.py
+++ b/dat/outfits/py/reaver.py
@@ -7,7 +7,7 @@ data['outfit']['@name'] = N_('Reaver Cannon')
 
 general = data['outfit']['general']
 general['rarity'] = '2'
-general['description'] = N_("The complex engineering specifications and difficulty of mass production doomed the Reaver Cannon from the start. However, in the right hands, given the extreme long range and high penetration for a weapon of its size, it can be very deadly.")
+general['description'] = N_('The complex engineering specifications and difficulty of mass production doomed the Reaver Cannon from the start. However, in the right hands, given the extreme long range and high penetration for a weapon of its size, it can be very deadly.')
 h.add_i(general, 'price', 130e3 )
 h.add_i(general, 'mass', 2 )
 h.mul_i(general, 'cpu', 1.1 )
@@ -19,12 +19,12 @@ h.mul_f(specific, 'delay', 2 )
 h.mul_f(specific, 'energy', 2.0 )
 h.mul_f(specific, 'swivel', 1.5 )
 h.mul_i(specific, 'trackmax', 0.8333333333 )
-specific['lua'] = "outfits/lib/matrix_sell.lua"
+specific['lua'] = 'outfits/lib/matrix_sell.lua'
 specific['gfx'] = {
-    "@type" : "shader",
-    "@size" : "10",
-    "@col_size" : "8",
-    "#text" : "particles/reaver.frag",
+    '@type' : 'shader',
+    '@size' : '10',
+    '@col_size' : '8',
+    '#text' : 'particles/reaver.frag',
 }
 
 damage = specific['damage']

--- a/dat/outfits/py/xml_outfit.py
+++ b/dat/outfits/py/xml_outfit.py
@@ -60,10 +60,9 @@ class _outfit_node( dict ):
 
    def __getitem__ (self, key):
       if isinstance(key, str) and key[0]=='$':
-         val = intify(float(dict.__getitem__(self, key[1:])))
+         return intify(float(dict.__getitem__(self, key[1:])))
       else:
-         val = dict.__getitem__(self, key)
-      return val
+         return dict.__getitem__(self, key)
 
    def __setitem__(self, key, val):
       if isinstance(key, str) and key[0]=='$':

--- a/dat/outfits/py/xml_outfit.py
+++ b/dat/outfits/py/xml_outfit.py
@@ -36,7 +36,7 @@ class _outfit_node( dict ):
 class xml_outfit( _outfit_node ):
    def __init__( self, fnam ):
       self._uptodate = False
-      selfi_.filename = fnam
+      self._filename = fnam
       with open(fnam, 'r') as fp:
          _outfit_node.__init__(self, parse(fp.read()))
 
@@ -48,9 +48,9 @@ class xml_outfit( _outfit_node ):
       self._uptodate = True
 
    def save_as( self, filename ):
-      self._uptodate = self._uptodate and (filename == self.filename)
+      self._uptodate = self._uptodate and (filename == self._filename)
       self._filename = filename
 
    def __del__( self ):
-      if not self.uptodate:
-         stderr.write('Warning: unsaved file "' + self.filename + '" at exit.\n')
+      if not self._uptodate:
+         stderr.write('Warning: unsaved file "' + self._filename + '" at exit.\n')

--- a/dat/outfits/py/xml_outfit.py
+++ b/dat/outfits/py/xml_outfit.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from xmltodict import *
+from sys import stderr
+
+_headless = lambda s: s.replace('<?xml version="1.0" encoding="utf-8"?>\n', '', 1)
+intify = lambda x: int(x) if x == round(x) else x
+
+class _outfit_node( dict ):
+   def __init__ ( self, mapping, parent = None ):
+      mknode = lambda v: _outfit_node(v) if isinstance(v, dict) else v
+      dict.__init__(self, {k: mknode(v) for k, v in mapping.items()})
+      self._parent = parent
+
+   def _changed( self ):
+      if self._parent is None:
+         self._uptodate = False
+      else:
+         self._parent._changed()
+
+   def __getitem__ (self, key):
+      if isinstance(key, str) and key[0]=='$':
+         val = intify(float(dict.__getitem__(self, key[1:])))
+      else:
+         val = dict.__getitem__(self, key)
+      return val
+
+   def __setitem__(self, key, val):
+      if isinstance(key, str) and key[0]=='$':
+         key, val = key[1:], intify(val)
+      elif isinstance(val, dict) and not isinstance(val, _outfit_node):
+         val = _outfit_node(val, self)
+      dict.__setitem__(self, key, val)
+      self._changed()
+
+class xml_outfit( _outfit_node ):
+   def __init__( self, fnam ):
+      self._uptodate = False
+      selfi_.filename = fnam
+      with open(fnam, 'r') as fp:
+         _outfit_node.__init__(self, parse(fp.read()))
+
+   def save( self ):
+      if self._uptodate:
+         stderr.write('Warning: saving unchanged file "' + self.filename + '".\n')
+      with open(self._filename, 'w') as fp:
+         fp.write(_headless(unparse(self, pretty=True, indent=1)) + '\n')
+      self._uptodate = True
+
+   def save_as( self, filename ):
+      self._uptodate = self._uptodate and (filename == self.filename)
+      self._filename = filename
+
+   def __del__( self ):
+      if not self.uptodate:
+         stderr.write('Warning: unsaved file "' + self.filename + '" at exit.\n')

--- a/utils/outfits/gen_mvx_from_xml.sh
+++ b/utils/outfits/gen_mvx_from_xml.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DST=$(realpath --relative-to="$PWD" "${SCRIPT_DIR}/../../dat/outfits")
-
-echo Generate from "$DST" >&2
-grep -rl 'lua_inline' "${DST}" | grep '\.xml$' | while read -r i ; do
-   "${SCRIPT_DIR}/xmllua2mvx.py" "$i" > "$(dirname "$i")/.$(basename "$i" xml)mvx"
-done

--- a/utils/outfits/mvx2xmllua.py
+++ b/utils/outfits/mvx2xmllua.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+# python3
 
 keep_in_xml = set(['priority', 'rarity'])
 
@@ -93,21 +93,3 @@ def mvx2xmllua( argin, argout, quiet ):
          stderr.write('mvx2xmllua: ' + (nam if argout == '-' else argout) + '\n')
       o.write(argout)
    return o
-
-if __name__ == '__main__':
-   import argparse
-
-   parser = argparse.ArgumentParser(
-      description =
-   """Takes an extended outfit as input and outputs a xml (potentially with inlined lua) on output.
-The name the output should have is written on <stderr>.
-If the input is invalid, nothing is written on stdout and stderr and non-zero is returned.
-The special values "-" mean stdin/stdout.
-"""
-   )
-   parser.add_argument('input', nargs = '?', default = "-")
-   parser.add_argument('output', nargs = '?', default = "-")
-   parser.add_argument('-q', '--quiet', action = 'store_true')
-   args = parser.parse_args()
-   o = mvx2xmllua(args.input, args.output, args.quiet)
-   exit(1 if o is None else 0)

--- a/utils/outfits/xmllua2mvx.py
+++ b/utils/outfits/xmllua2mvx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+# python3
 
 # Tries to revert xml with inlined lua using multicore back to multi-valued xml.
 # exits 1 if anything turns wrong.
@@ -80,21 +80,3 @@ def xmllua2mvx( argin, argout, quiet = False, multicore_only = False ):
          stderr.write('xmllua2mvx: ' + o.name() + '\n')
       o.write(argout)
    return o
-
-if __name__ == '__main__':
-   import argparse
-
-   parser = argparse.ArgumentParser(
-      description =
-   """Takes a xml outfit as input (potentially with inlined lua) and produces a mvx on output.
-The name the output should have is written on <stderr>.
-If the input is invalid, nothing is written on stdout and stderr and non-zero is returned.
-The special values "-" mean stdin/stdout.
-"""
-   )
-   parser.add_argument('-q', '--quiet', action = 'store_true')
-   parser.add_argument('input', nargs = '?', default = '-')
-   parser.add_argument('output', nargs = '?', default = '-')
-   args = parser.parse_args()
-   o = xmllua2mvx(args.input, args.output, args.quiet)
-   exit(1 if o is None else 0)


### PR DESCRIPTION
**New Feature**

This PR addresses part of the feature described in #2910.

## Summary
 - a new `xml_outfit.py` wrapper around xmltodict:
    - works with the regular xmltodict object. 
    - in addition, manages save/save_as with warnings if unsaved at exit and up-to-date file overwrite.
    - cannot be mutated by indirect means. To change it, you need to explicitly `<some_subtree>[key] = value`. Allows natural cloning / modification of subtrees with no risk of mutating other parts of the tree unintentionally.
    - manages value casting. Allows `<subtree>[$key] += value` for ex.
    - output consistent with current setting (indent, no header, etc.). In particular, adds the empty tag folding feature that is missing in xmltodict.
    - total 60 lines: reasonably small.
 - simplified `dat/outfit/*.py` accordingly.
 - removed mvx term tools that were unused confusing remains of a previous setting.