### PR TITLE
Fix some bugs where SIGSEGV at finding an outfit by the map panel in Japanese language.

### DIFF
--- a/src/map_find.c
+++ b/src/map_find.c
@@ -539,16 +539,16 @@ static char **map_fuzzyOutfits( Outfit **o, const char *name )
    /* Do fuzzy search. */
    for ( int i = 0; i < array_size( o ); i++ ) {
       if ( SDL_strcasestr( outfit_name( o[i] ), name ) != NULL )
-         array_push_back( &names, (char *)outfit_name( o[i] ) );
+         array_push_back( &names, (char *)outfit_rawname( o[i] ) );
       else if ( SDL_strcasestr( outfit_getType( o[i] ), name ) != NULL )
-         array_push_back( &names, (char *)outfit_name( o[i] ) );
+         array_push_back( &names, (char *)outfit_rawname( o[i] ) );
       else if ( ( outfit_condstr( o[i] ) != NULL ) &&
                 SDL_strcasestr( outfit_condstr( o[i] ), name ) != NULL )
-         array_push_back( &names, (char *)outfit_name( o[i] ) );
+         array_push_back( &names, (char *)outfit_rawname( o[i] ) );
       else if ( SDL_strcasestr( outfit_description( o[i] ), name ) != NULL )
-         array_push_back( &names, (char *)outfit_name( o[i] ) );
+         array_push_back( &names, (char *)outfit_rawname( o[i] ) );
       else if ( SDL_strcasestr( outfit_summary( o[i], 0 ), name ) != NULL )
-         array_push_back( &names, (char *)outfit_name( o[i] ) );
+         array_push_back( &names, (char *)outfit_rawname( o[i] ) );
    }
 
    return names;

--- a/src/msgcat.c
+++ b/src/msgcat.c
@@ -98,6 +98,7 @@ void msgcat_init( msgcat_t* p, const void* map, size_t map_size )
  */
 const char* msgcat_ngettext( const msgcat_t* p, const char* msgid1, const char* msgid2, uint64_t n )
 {
+   if (!msgid1) return NULL;
    const char *trans = msgcat_mo_lookup(p->map, p->map_size, msgid1);
    if (!trans) return NULL;
 


### PR DESCRIPTION
**Bug Fix**
## Summary
Fix some bugs where SIGSEGV at finding an outfit by the map panel in Japanese language.

1. The cause is the parameter `s` = NULL for `msgcat_mo_lookup()` since an outfit, such as "Nexus Drill Lance", has NULL for the field `condstr`. GNU gettext accepts NULL for `msgid` and returns NULL, so I would change `msgcat_ngettext()` to the same behavior.
2. `map_foundOutfitNames[]` should have the raw name of the outfits.

## Testing Done
I found an outfit in Japanese environment.