### PR TITLE
Outfit generation scripts simplified

### DIFF
--- a/dat/outfits/generated/corsair_engine.py
+++ b/dat/outfits/generated/corsair_engine.py
@@ -25,4 +25,5 @@ specific['jump_distance'] = { 'pri': 25 }
 #specific['lua_inline'] = 'local set = require("outfits.lib.set")'
 specific['lua_inline_post'] = 'require("outfits.core_sets.corsair_engine").init()'
 
+data.prisec_only(sec= False)
 data.save()

--- a/dat/outfits/generated/corsair_engine.py
+++ b/dat/outfits/generated/corsair_engine.py
@@ -20,13 +20,9 @@ before they quickly took to the air""")
 del general['slot']['@prop_extra']
 
 specific = o['specific']
-ref = h.get_outfit_dict( h.INPUT, True )
-del ref['time_mod']
-ref['jump_distance'] = (25,)
-specific['lua_inline'] = '\n'.join([
-   'local set = require("outfits.lib.set")',
-   h.to_multicore_lua( ref, True, 'set.set' ),
-   'require("outfits.core_sets.corsair_engine").init()'
-])
+del specific['time_mod']
+specific['jump_distance'] = { 'pri': 25 }
+#specific['lua_inline'] = 'local set = require("outfits.lib.set")'
+specific['lua_inline_post'] = 'require("outfits.core_sets.corsair_engine").init()'
 
 data.save()

--- a/dat/outfits/generated/corsair_hull.py
+++ b/dat/outfits/generated/corsair_hull.py
@@ -25,4 +25,5 @@ specific['ew_stealth_timer'] = { 'pri': -10 }
 #specific['lua_inline'] = 'local set = require("outfits.lib.set")'
 specific['lua_inline_post'] = 'require("outfits.core_sets.corsair_hull").init()'
 
+data.prisec_only(sec= False)
 data.save()

--- a/dat/outfits/generated/corsair_hull.py
+++ b/dat/outfits/generated/corsair_hull.py
@@ -20,13 +20,9 @@ irresistible buccaneer stare""")
 del general['slot']['@prop_extra']
 
 specific = o['specific']
-ref = h.get_outfit_dict( h.INPUT, True )
-ref['absorb'] = (ref['absorb'][0]-5.0,)
-ref['ew_stealth_timer'] = (-10,)
-specific['lua_inline'] = '\n'.join([
-   "local set = require('outfits.lib.set')",
-   h.to_multicore_lua( ref, True, 'set.set' ),
-   "require('outfits.core_sets.corsair_hull').init()"
-])
+specific['absorb']['$pri'] -= 5.0
+specific['ew_stealth_timer'] = { 'pri': -10 }
+#specific['lua_inline'] = 'local set = require("outfits.lib.set")'
+specific['lua_inline_post'] = 'require("outfits.core_sets.corsair_hull").init()'
 
 data.save()

--- a/dat/outfits/generated/corsair_systems.py
+++ b/dat/outfits/generated/corsair_systems.py
@@ -26,4 +26,5 @@ specific['ew_detect']['$pri'] += 5
 #specific['lua_inline'] = "local set = require('outfits.lib.set')"
 specific['lua_inline_post'] = "require('outfits.core_sets.corsair_systems').init()"
 
+data.prisec_only(sec= False)
 data.save()

--- a/dat/outfits/generated/corsair_systems.py
+++ b/dat/outfits/generated/corsair_systems.py
@@ -21,13 +21,9 @@ in space is it also mal de mer?""")
 del general['slot']['@prop_extra']
 
 specific = o['specific']
-ref = h.get_outfit_dict( h.INPUT, True )
-del ref['cooldown_time']
-ref['ew_detect'] = (ref['ew_detect'][0]+5.0,)
-specific['lua_inline'] = '\n'.join([
-   "local set = require('outfits.lib.set')",
-   h.to_multicore_lua( ref, True, 'set.set' ),
-   "require('outfits.core_sets.corsair_systems').init()"
-])
+del specific['cooldown_time']
+specific['ew_detect']['$pri'] += 5
+#specific['lua_inline'] = "local set = require('outfits.lib.set')"
+specific['lua_inline_post'] = "require('outfits.core_sets.corsair_systems').init()"
 
 data.save()

--- a/dat/outfits/generated/helper.py
+++ b/dat/outfits/generated/helper.py
@@ -3,31 +3,12 @@ from os import path
 script_dir = path.join(path.dirname(__file__), '..', '..', '..', 'utils')
 sys.path.append(path.realpath(script_dir))
 sys.path.append(path.realpath(path.join(script_dir, 'outfits')))
-from naev_xml import naev_xml
 from outfit import outfit, KEEP_IN_XML
 
 INPUT = sys.argv[1]
 OUTPUT = sys.argv[2]
 
 def read():
-   o = naev_xml(INPUT)
+   o = outfit(INPUT)
    o.save_as(OUTPUT)
    return o
-
-def get_outfit_dict( name, core = False ):
-   return outfit(name, is_multi = core).to_dict()
-
-def to_multicore_lua( ref, pri_only = True, setfunc = 'nil' ):
-   out = """local multicore = require('outfits.lib.multicore').init({"""
-   # We operate under the assumption that dictionaries are ordered in python now
-   for r in ref:
-      if r in KEEP_IN_XML:
-         continue
-      v = ref[r]
-      if type(v) in {int,  float}:
-         out += f'\n   {{"{r}", {v} }},'
-      elif not pri_only and len(v) > 1:
-         out += f'\n   {{"{r}", {v[0]}, {v[1]} }},'
-      else:
-         out += f'\n   {{"{r}", {v[0]} }},'
-   return out + f'\n}}, {setfunc})'

--- a/utils/naev_xml.py
+++ b/utils/naev_xml.py
@@ -1,5 +1,4 @@
-# for testing:
-#!/usr/bin/env python3
+# python3
 
 """
 An elementTree-based implementation of xmltodict. 10% slower than pure elementTree,
@@ -140,8 +139,7 @@ def _parse( node, par, key ):
    return d
 
 def _unparse_elt( v, k, indent):
-   out = ''
-   out += indent*' ' + '<' + k
+   out = indent*' ' + '<' + k
    if isinstance(v, dict):
       for ka, va in v.attr.items():
          out += ' ' + ka[1:] + '="' + va.replace('&', '&amp;') + '"'
@@ -229,12 +227,3 @@ class naev_xml( xml_node ):
    def __del__( self ):
       if not self._uptodate and self._filename != devnull:
          stderr.write('Warning: unsaved file "' + self._filename + '" at exit.\n')
-"""
-if __name__ == '__main__':
-   from sys import argv
-
-   for a in argv[1:]:
-      d = naev_xml(a)
-      d.touch()
-      d.save()
-"""

--- a/utils/outfits/outfit.py
+++ b/utils/outfits/outfit.py
@@ -66,7 +66,7 @@ def un_multicore( o ):
    except:
       return False
 
-   e['lua_inline'] = bef
+   e['lua_inline'] = bef.strip()
    if aft:
       e['lua_inline_post'] = aft
 
@@ -208,9 +208,9 @@ class outfit(naev_xml):
             lua_inline += ind + '{ ' + ', '.join(['"'+k+'"'] + [str(u) for u in v]) + '},\n'
             del oout['specific'][k]
          lua_inline += '}'
-         oout['specific']['lua_inline'] += lua_inline
+         oout['specific']['lua_inline'] = (oout['specific']['lua_inline'] + '\n' + lua_inline).strip()
          if 'lua_inline_post' in oout['specific']:
-            oout['specific']['lua_inline'] += oout['specific']['lua_inline_post']
+            oout['specific']['lua_inline'] += '\n' + oout['specific']['lua_inline_post']
             del oout['specific']['lua_inline_post']
       else:
          out = self

--- a/utils/outfits/outfit.py
+++ b/utils/outfits/outfit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+# python3
 
 
 import sys
@@ -191,6 +191,10 @@ class outfit(naev_xml):
          self.short = res
       return self.short
 
+   def prisec_only(self, sec = False):
+      for d, k, v in list(self.equipped(sec)):
+         d[k] = v
+
    def save( self ):
       if self.is_multi:
          # make a deep copy
@@ -205,7 +209,7 @@ class outfit(naev_xml):
                continue
             if not isinstance(v, tuple):
                v = (v,)
-            lua_inline += ind + '{ ' + ', '.join(['"'+k+'"'] + [str(u) for u in v]) + '},\n'
+            lua_inline += ind + '{' + ', '.join(["'"+k+"'"] + [str(u) for u in v]) + ' },\n'
             del oout['specific'][k]
          lua_inline += '}'
          oout['specific']['lua_inline'] = (oout['specific']['lua_inline'] + '\n' + lua_inline).strip()
@@ -216,9 +220,3 @@ class outfit(naev_xml):
          out = self
       naev_xml.save(out)
       self._uptodate = True
-
-if __name__ == '__main__':
-   from sys import argv
-   for i in argv[1:]:
-      o = outfit(i)
-      o.save()


### PR DESCRIPTION

**Cleanup**

This PR continues what was started in #2926.

## Summary
Using the new `outfit.py`, we can simplify `dat/outfits/generated/*.py`.
The last redundancies and inconsistencies of these are corrected.
Now these files look like what they are: a list of modifications applied to an outfit in order to get another one.
With these examples, building new outfits by derivation of old ones becomes a child's play!