### PR TITLE
Bugfix : all_outfits also depends on biooutfits

### DIFF
--- a/dat/naevpedia/outfits/meson.build
+++ b/dat/naevpedia/outfits/meson.build
@@ -28,7 +28,7 @@ endforeach
 foreach ns: genlist
   naevpedia_outfits += custom_target( ns.full_path().replace('/','_'),
       command: outfits_gen,
-      depends: [gen_outfits, gen_bio_outfits] # a bit brute force to depend on gen_outfit stage, but works
+      depends: [gen_outfits, gen_bio_outfits], # a bit brute force to depend on gen_outfit stage, but works
       input: ns,
       output: '@BASENAME@.md',
       install: true,

--- a/dat/naevpedia/outfits/meson.build
+++ b/dat/naevpedia/outfits/meson.build
@@ -28,7 +28,7 @@ endforeach
 foreach ns: genlist
   naevpedia_outfits += custom_target( ns.full_path().replace('/','_'),
       command: outfits_gen,
-      depends: gen_outfits, # a bit brute force to depend on gen_outfit stage, but works
+      depends: [gen_outfits, gen_bio_outfits] # a bit brute force to depend on gen_outfit stage, but works
       input: ns,
       output: '@BASENAME@.md',
       install: true,

--- a/dat/outfits/bioship/meson.build
+++ b/dat/outfits/bioship/meson.build
@@ -234,6 +234,7 @@ gen_bioship = find_program('generate.py')
 bio_cmd = [gen_bioship, '@INPUT@', '-o', '@OUTPUT@']
 bio_dir = ndata_path / 'dat/outfits/bioship'
 
+gen_bio_outfits = []
 foreach name, data : biooutfits
    depend_files = []
    if 'depend_files' in data
@@ -242,7 +243,7 @@ foreach name, data : biooutfits
       endforeach
    endif
 
-   gen_outfits += [custom_target( name,
+   gen_bio_outfits += [custom_target( name,
       command: bio_cmd,
       install: true,
       install_dir: bio_dir,

--- a/dat/outfits/generated/meson.build
+++ b/dat/outfits/generated/meson.build
@@ -32,6 +32,7 @@ py_outfits_extra_deps = files('helper.py')
 py_outfits_extra_deps += meson.project_source_root() / 'utils/outfits/outfit.py'
 py_outfits_extra_deps += meson.project_source_root() / 'utils/naev_xml.py'
 
+gen_outfits = []
 foreach name, data : customoutfits
   gen_outfits += [custom_target( name,
     command: [find_program( data['command'] ), '@INPUT@', '@OUTPUT@', ],

--- a/dat/outfits/meson.build
+++ b/dat/outfits/meson.build
@@ -1,6 +1,5 @@
 # All generated outfits should be tossed in here so that the
 # other scripts can be happy with it
-gen_outfits = []
 
 subdir('bioship')
 subdir('generated')

--- a/dat/tech/meson.build
+++ b/dat/tech/meson.build
@@ -10,8 +10,8 @@ custom_target( 'all_ships',
 )
 
 
-com_outifts = run_command([find_program('all_outfits_dep.sh'), meson.project_source_root() / 'dat/outfits/' ], check: true)
-outfits_sources = com_outifts.stdout().strip().split('\n')
+com_outfits = run_command([find_program('all_outfits_dep.sh'), meson.project_source_root() / 'dat/outfits/' ], check: true)
+outfits_sources = com_outfits.stdout().strip().split('\n')
 
 custom_target( 'all_outfits',
    command: [find_program( 'gen_all_outfits_tech.sh' ), '@OUTPUT@', '@INPUT@'],


### PR DESCRIPTION
... which should not be the case.

This was caused by using `gen_outfits` while it included bio-outfits.
Now we have a separate `gen_bio_outfits`.

Naevpedia `meson.build` have been updated accordingly.